### PR TITLE
Fix to prevent PDF scan when HTTP request contains GET parameters

### DIFF
--- a/crawlers/commonCrawlerFunc.js
+++ b/crawlers/commonCrawlerFunc.js
@@ -183,6 +183,5 @@ export const failedRequestHandler = async ({ request }) => {
 
 export const isUrlPdf = url => {
   const parsedUrl = new URL(url);
-  
   return /\.pdf($|\?|#)/i.test(parsedUrl.pathname);
 };

--- a/crawlers/crawlDomain.js
+++ b/crawlers/crawlDomain.js
@@ -269,7 +269,7 @@ const crawlDomain = async (
           return false;
         }
       }
-
+      if(!isScanPdfs){
       if (isExcluded(actualUrl) || isUrlPdf(actualUrl)) {
         guiInfoLog(guiInfoStatusTypes.SKIPPED, {
           numScanned: urlsCrawled.scanned.length,
@@ -283,6 +283,7 @@ const crawlDomain = async (
 
       let finalUrl = page.url(); // Initialize with the request URL
 
+
       if (isExcluded(actualUrl) || isUrlPdf(actualUrl)) {
         console.log(`Excluded URL (final/redirect): ${finalUrl}`);
         guiInfoLog(guiInfoStatusTypes.SKIPPED, {
@@ -291,6 +292,7 @@ const crawlDomain = async (
         });
         return; // Skip processing this URL
       }
+    }
 
       if (urlsCrawled.scanned.length >= maxRequestsPerCrawl) {
         crawler.autoscaledPool.abort();


### PR DESCRIPTION
- Implemented a fix to prevent PDF scans when the HTTPS request contains GET parameters.
- Updated the relevant logic to exclude PDF scans under such conditions.

- [x] I've kept this PR as small as possible (~500 lines) by splitting it into PRs with manageable chunks of code
- [x] I've requested reviews from 1 reviewer
- [x] I've tested existing features (website scan, sitemap, custom flow) in both node index and cli
- [x] I've synced this fork with GovTechSG repo
- [ ] I've added/updated unit tests
- [ ] I've added/updated any necessary dependencies in `package[-lock].json` `npm audit`, portable installation on GitHub Actions