### PR TITLE
Toggle to store JSON files scanItems.json and scanData.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,6 +346,24 @@ Options:
                                      ks
   [string] [choices: "default", "disable-oobee", "enable-wcag-aaa", "disable-oob
                                        ee,enable-wcag-aaa"] [default: "default"]
+  -g, --generateJsonFiles            Generate two JSON files containing the
+                                     results of the accessibility scan:
+                                     1. `scanData.json`: Provides an overview of
+                                        the scan, including:
+                                        - WCAG compliance score
+                                        - Violated WCAG clauses
+                                        - Metadata (e.g., scan start and end times)
+                                        - Pages scanned and skipped
+                                     2. `scanItems.json`: Contains detailed
+                                        information about detected accessibility
+                                        issues, including:
+                                        - Severity levels
+                                        - Issue descriptions
+                                        - Related WCAG guidelines
+                                        - URL of the pages violated the WCAG clauses
+                                     Useful for in-depth analysis or integration
+                                     with external reporting tools.
+                                     [string] [choices: "yes", "no"] [default: "no"]
 
 Examples:
   To scan sitemap of website:', 'npm run cli -- -c [ 1 | sitemap ] -u <url_lin

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@govtechsg/oobee",
-  "version": "0.10.20",
+  "version": "0.10.21",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@govtechsg/oobee",
-      "version": "0.10.20",
+      "version": "0.10.21",
       "license": "MIT",
       "dependencies": {
         "@json2csv/node": "^7.0.3",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@govtechsg/oobee",
   "main": "dist/npmIndex.js",
-  "version": "0.10.20",
+  "version": "0.10.21",
   "type": "module",
   "dependencies": {
     "@json2csv/node": "^7.0.3",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -393,7 +393,9 @@ const optionsAnswer: Answers = {
   blacklistedPatternsFilename: options.blacklistedPatternsFilename,
   playwrightDeviceDetailsObject: options.playwrightDeviceDetailsObject,
   ruleset: options.ruleset,
+  generateJsonFiles: options.generateJsonFiles,
 };
+
 await scanInit(optionsAnswer);
 process.exit(0);
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -184,11 +184,10 @@ Usage: npm run cli -- -c <crawler> -d <device> -w <viewport> -u <url> OPTIONS`,
     return option;
   })
   .check(argvs => {
-    if (
-      (argvs.scanner === ScannerTypes.CUSTOM) &&
-      argvs.maxpages
-    ) {
-      throw new Error('-p or --maxpages is only available in website, sitemap and local file scans.');
+    if (argvs.scanner === ScannerTypes.CUSTOM && argvs.maxpages) {
+      throw new Error(
+        '-p or --maxpages is only available in website, sitemap and local file scans.',
+      );
     }
     return true;
   })

--- a/src/combine.ts
+++ b/src/combine.ts
@@ -60,6 +60,7 @@ const combineRun = async (details: Data, deviceToScan: string) => {
     safeMode,
     zip,
     ruleset,
+    generateJsonFiles,
   } = envDetails;
 
   process.env.CRAWLEE_LOG_LEVEL = 'ERROR';
@@ -214,6 +215,7 @@ const combineRun = async (details: Data, deviceToScan: string) => {
         undefined,
         scanDetails,
         zip,
+        generateJsonFiles,
       );
       const [name, email] = nameEmail.split(':');
 

--- a/src/constants/cliFunctions.ts
+++ b/src/constants/cliFunctions.ts
@@ -296,6 +296,27 @@ export const cliOptions: { [key: string]: Options } = {
       return userChoices;
     },
   },
+  g: {
+    alias: 'generateJsonFiles',
+    describe:
+      'Generate JSON files in the results folder. Accepts "yes", "no", "y", or "n". Default is "no".',
+    type: 'string',
+    requiresArg: true,
+    default: 'no',
+    demandOption: false,
+    coerce: value => {
+      const validYes = ['yes', 'y'];
+      const validNo = ['no', 'n'];
+
+      if (validYes.includes(value.toLowerCase())) {
+        return true;
+      }
+      if (validNo.includes(value.toLowerCase())) {
+        return false;
+      }
+      throw new Error(`Invalid value "${value}" for --generate. Use "yes", "y", "no", or "n".`);
+    },
+  },
 };
 
 export const configureReportSetting = (isEnabled: boolean): void => {

--- a/src/constants/cliFunctions.ts
+++ b/src/constants/cliFunctions.ts
@@ -270,7 +270,9 @@ export const cliOptions: { [key: string]: Options } = {
     coerce: option => {
       const validChoices = Object.values(RuleFlags);
       const userChoices: string[] = option.split(',');
-      const invalidUserChoices = userChoices.filter(choice => !validChoices.includes(choice as RuleFlags));
+      const invalidUserChoices = userChoices.filter(
+        choice => !validChoices.includes(choice as RuleFlags),
+      );
       if (invalidUserChoices.length > 0) {
         printMessage(
           [

--- a/src/constants/common.ts
+++ b/src/constants/common.ts
@@ -579,6 +579,7 @@ export const prepareData = async (argv: Answers): Promise<Data> => {
     safeMode,
     zip,
     ruleset,
+    generateJsonFiles,
   } = argv;
 
   // construct filename for scan results
@@ -625,6 +626,7 @@ export const prepareData = async (argv: Answers): Promise<Data> => {
     safeMode,
     zip,
     ruleset,
+    generateJsonFiles,
   };
 };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,6 +51,7 @@ export type Answers = {
   exportDirectory: string;
   zip: string;
   ruleset: RuleFlags[];
+  generateJsonFiles: boolean;
 };
 
 export type Data = {
@@ -80,6 +81,7 @@ export type Data = {
   userDataDirectory?: string;
   zip?: string;
   ruleset: RuleFlags[];
+  generateJsonFiles: boolean;
 };
 
 const userData = getUserDataTxt();


### PR DESCRIPTION
This PR adds... <!-- A brief description of what your PR does -->
`-g  yes` to store raw scanItems.json and scanData.json

<!-- This checklist is just a guideline.-->
<!-- If any of the following does not apply to your PR, please leave them unchecked and explain in the PR -->

- [x] I've kept this PR as small as possible (~500 lines) by splitting it into PRs with manageable chunks of code
- [x] I've requested reviews from 1 reviewer
- [ ] I've tested existing features (website scan, sitemap, custom flow) in both node index and cli
- [ ] I've synced this fork with GovTechSG repo
- [ ] I've added/updated unit tests
- [ ] I've added/updated any necessary dependencies in `package[-lock].json` `npm audit`, portable installation on GitHub Actions
