### PR TITLE
Feat/advanced options metadata

### DIFF
--- a/src/combine.ts
+++ b/src/combine.ts
@@ -95,7 +95,7 @@ const combineRun = async (details: Data, deviceToScan: string) => {
     requestUrl: finalUrl,
     urlsCrawled: new UrlsCrawled(),
     isIncludeScreenshots: envDetails.includeScreenshots,
-    isAllowSubdomains: envDetails.includeScreenshots,
+    isAllowSubdomains: envDetails.strategy,
     isEnableCustomChecks: envDetails.ruleset,
     isEnableWcagAaa: envDetails.ruleset,
     isSlowScanMode: envDetails.specifiedMaxConcurrency,

--- a/src/combine.ts
+++ b/src/combine.ts
@@ -34,6 +34,8 @@ export class ViewportSettingsClass {
 }
 
 const combineRun = async (details: Data, deviceToScan: string) => {
+  // consoleLogger.info(`details is ${JSON.stringify(details, null, 2)}`);
+
   const envDetails = { ...details };
 
   const {
@@ -48,20 +50,21 @@ const combineRun = async (details: Data, deviceToScan: string) => {
     maxRequestsPerCrawl,
     browser,
     userDataDirectory,
-    strategy,
-    specifiedMaxConcurrency,
+    strategy, // Allow subdomains: if checked, = 'same-domain'
+    specifiedMaxConcurrency, // Slow scan mode: if checked, = '1'
     fileTypes,
     blacklistedPatternsFilename,
-    includeScreenshots,
-    followRobots,
+    includeScreenshots, // Include screenshots: if checked, = 'true'
+    followRobots, // Adhere to robots.txt: if checked, = 'true'
     metadata,
     customFlowLabel = 'Custom Flow',
     extraHTTPHeaders,
     safeMode,
     zip,
-    ruleset,
+    ruleset, // Enable custom checks, Enable WCAG AAA: if checked, = 'enable-wcag-aaa')
     generateJsonFiles,
   } = envDetails;
+  consoleLogger.info(`envDetails is ${JSON.stringify(envDetails, null, 2)}`);
 
   process.env.CRAWLEE_LOG_LEVEL = 'ERROR';
   process.env.CRAWLEE_STORAGE_DIR = randomToken;
@@ -91,6 +94,12 @@ const combineRun = async (details: Data, deviceToScan: string) => {
     crawlType: type,
     requestUrl: finalUrl,
     urlsCrawled: new UrlsCrawled(),
+    isIncludeScreenshots: envDetails.includeScreenshots,
+    isAllowSubdomains: envDetails.includeScreenshots,
+    isEnableCustomChecks: envDetails.ruleset,
+    isEnableWcagAaa: envDetails.ruleset,
+    isSlowScanMode: envDetails.specifiedMaxConcurrency,
+    isAdhereRobots: envDetails.followRobots,
   };
 
   const viewportSettings: ViewportSettingsClass = new ViewportSettingsClass(

--- a/src/static/ejs/partials/components/scanAbout.ejs
+++ b/src/static/ejs/partials/components/scanAbout.ejs
@@ -225,6 +225,71 @@
         </svg>
       </span>
     </li>
+
+    <li>
+      <svg aria-label="Advanced options scan summary" xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 18 18" fill="none">
+        <rect x="0.87" y="0.87" width="16.26" height="16.26" rx="3.13" stroke="#93928D" stroke-width="1.74"/>
+        <path d="M5 9L7.5 11.5L13 6" stroke="#93928D" stroke-width="1.74" stroke-linecap="square"/>
+      </svg>
+      <div>
+        <div class="d-flex flex-row justify-content-center align-items-center gap-3">
+          <button id="advancedScanOptionsSummaryTitle" onclick="toggleAdvanceScanSummary()">Advanced scan summary
+          </button>
+        </div>
+
+      </div>
+    </li>
+    <ul id="advancedScanOptionsSummary" class="d-none mb-3">
+      <li id="showIncludeScreenshots"class="d-flex flex-row">
+          <svg aria-label="Include screenshots was checked" xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 18 18" fill="none">
+            <rect x="0.87" y="0.87" width="16.26" height="16.26" rx="3.13" fill="#93928D" stroke="#93928D" stroke-width="1.74"/>
+            <path d="M5 9L7.5 11.5L13 6" fill="none" stroke="#ffffff" stroke-width="1.74" stroke-linecap="square"/>
+          </svg>
+        <div>Include screenshots
+        </div>
+      </li>
+      <li id="showAllowSubdomains"class="d-flex flex-row">
+          <svg aria-label="Allow subdomains was checked" xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 18 18" fill="none">
+            <rect x="0.87" y="0.87" width="16.26" height="16.26" rx="3.13" fill="#93928D" stroke="#93928D" stroke-width="1.74"/>
+            <path d="M5 9L7.5 11.5L13 6" fill="none" stroke="#ffffff" stroke-width="1.74" stroke-linecap="square"/>
+          </svg>
+        <div>Allow subdomains for scans
+        </div>
+      </li>
+      <li id="showEnableCustomChecks"class="d-flex flex-row">
+        <svg aria-label="Enable custom checks was checked" xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 18 18" fill="none">
+          <rect x="0.87" y="0.87" width="16.26" height="16.26" rx="3.13" fill="#93928D" stroke="#93928D" stroke-width="1.74"/>
+          <path d="M5 9L7.5 11.5L13 6" fill="none" stroke="#ffffff" stroke-width="1.74" stroke-linecap="square"/>
+        </svg>
+      <div>Enable custom checks
+      </div>
+    </li>
+    <li id="showEnableWcagAaa"class="d-flex flex-row">
+        <svg aria-label="Enable WCAG AAA checks was checked" xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 18 18" fill="none">
+          <rect x="0.87" y="0.87" width="16.26" height="16.26" rx="3.13" fill="#93928D" stroke="#93928D" stroke-width="1.74"/>
+          <path d="M5 9L7.5 11.5L13 6" fill="none" stroke="#ffffff" stroke-width="1.74" stroke-linecap="square"/>
+        </svg>
+      <div>Enable WCAG AAA checks
+      </div>
+    </li>
+      <li id="showSlowScanMode"class="d-flex flex-row">
+          <svg aria-label="Slow scan mode was checked" xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 18 18" fill="none">
+            <rect x="0.87" y="0.87" width="16.26" height="16.26" rx="3.13" fill="#93928D" stroke="#93928D" stroke-width="1.74"/>
+            <path d="M5 9L7.5 11.5L13 6" fill="none" stroke="#ffffff" stroke-width="1.74" stroke-linecap="square"/>
+          </svg>
+        <div>Slow scan mode
+        </div>
+      </li>
+
+      <li id="showAdhereRobots"class="d-flex flex-row">
+          <svg aria-label="Adhere to robots.txt was checked" xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 18 18" fill="none">
+            <rect x="0.87" y="0.87" width="16.26" height="16.26" rx="3.13" fill="#93928D" stroke="#93928D" stroke-width="1.74"/>
+            <path d="M5 9L7.5 11.5L13 6" fill="none" stroke="#ffffff" stroke-width="1.74" stroke-linecap="square"/>
+          </svg>
+        <div>Adhere to robots.txt
+        </div>
+      </li>
+    </ul>
     <li>
       <svg
         aria-label="Scan engine"

--- a/src/static/ejs/partials/scripts/scanAboutScript.ejs
+++ b/src/static/ejs/partials/scripts/scanAboutScript.ejs
@@ -1,0 +1,38 @@
+<%# functions to handle interaction and ui for advancedScanOptionsSummary in scanAbout.ejs.
+component %>
+
+<script>
+  let optionsToCheck = scanData.advancedScanOptionsSummaryItems;
+
+  document.querySelectorAll('#advancedScanOptionsSummary li').forEach(liElement => {
+    liElement.classList.add('d-none');
+  });
+
+  function toggleAdvanceScanSummary() {
+    const chevron = document.getElementById('advancedScanOptionsSummaryTitle');
+    const advancedScanOptionsSummary = document.getElementById('advancedScanOptionsSummary');
+
+    const isHidden = advancedScanOptionsSummary.classList.toggle('d-none');
+
+    chevron.classList.toggle('chevron-rotated', !isHidden);
+
+    if (!isHidden) {
+      showScanOptions(optionsToCheck);
+    }
+  }
+
+  function showScanOptions(options) {
+    document.querySelectorAll('#advancedScanOptionsSummary li').forEach(liElement => {
+      liElement.classList.add('d-none');
+    });
+
+    for (const key in options) {
+      if (options[key] === true) {
+        const liElement = document.getElementById(key);
+        if (liElement) {
+          liElement.classList.remove('d-none');
+        }
+      }
+    }
+  }
+</script>

--- a/src/static/ejs/partials/styles/styles.ejs
+++ b/src/static/ejs/partials/styles/styles.ejs
@@ -755,7 +755,8 @@
     margin: 1.5rem 0 1rem 0;
   }
 
-  button#wcagModalToggle {
+  button#wcagModalToggle,
+  button#advancedScanOptionsSummaryTitle {
     background: none;
     border: 0;
     padding: 0;
@@ -960,6 +961,26 @@
     margin-right: 1rem;
     height: 1.125rem;
     width: 1.125rem;
+  }
+
+  #advancedScanOptionsSummary li > svg {
+    margin-left: 2rem;
+  }
+
+  #advancedScanOptionsSummaryTitle::after {
+    content: '';
+    display: inline-block;
+    width: 12px;
+    height: 12px;
+    background: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 9 16" fill="none"><path d="M1.03847 16C0.833084 16 0.632306 15.9388 0.461529 15.8241C0.290753 15.7095 0.157649 15.5465 0.0790493 15.3558C0.000449621 15.1651 -0.0201154 14.9553 0.0199549 14.7529C0.0600251 14.5505 0.158931 14.3645 0.304165 14.2186L6.49293 7.99975L0.304165 1.78088C0.109639 1.58514 0.000422347 1.31979 0.000518839 1.04315C0.000615331 0.766523 0.110018 0.501248 0.30468 0.30564C0.499341 0.110032 0.763331 9.70251e-05 1.03862 6.41929e-08C1.31392 -9.68968e-05 1.57798 0.109652 1.77278 0.305123L8.69586 7.26187C8.8906 7.45757 9 7.72299 9 7.99975C9 8.2765 8.8906 8.54192 8.69586 8.73763L1.77278 15.6944C1.67646 15.7914 1.562 15.8684 1.43598 15.9208C1.30996 15.9733 1.17487 16.0002 1.03847 16Z" fill="%23006B8C" transform="rotate(90, 4.5, 8)"/></svg>');
+    background-size: contain;
+    background-repeat: no-repeat;
+    transform: scaleY(1);
+    margin-left: 0.5rem;
+  }
+
+  #advancedScanOptionsSummaryTitle.chevron-rotated::after {
+    transform: scaleY(-1);
   }
 
   #footer {

--- a/src/static/ejs/report.ejs
+++ b/src/static/ejs/report.ejs
@@ -25,6 +25,7 @@
     <%- include('partials/header') %> <%- include('partials/main') %> <%-
     include('partials/scripts/popper') %> <%- include('partials/scripts/bootstrap') %> <%-
     include('partials/scripts/highlightjs') %> <%- include('partials/scripts/utils') %> <%-
+    include('partials/scripts/scanAboutScript') %> <%-
     include('partials/scripts/categorySelectorDropdownScript') %> <%-
     include('partials/scripts/categorySummary') %> <%- include('partials/scripts/ruleOffcanvas') %>
     <%- include('partials/scripts/screenshotLightbox')%>


### PR DESCRIPTION
This PR adds...

- UI for the Advanced Scan Options Summary metadata for in `scanAbout.ejs` and css in `styles.ejs`
- Add `scandAboutScript.ejs `to handle toggle logic
- Add new` advancedScanOptionsSummaryItems` in `mergeAxeResults.ts`
- Add boolean values in `combine.ts` used in `advancedScanOptionSummaryItems`
- These changes ultimately **adds a new object** called `advancedScanOptionSummaryItems` in the `scanData` payload.

-------

- [x] I've kept this PR as small as possible (~500 lines) by splitting it into PRs with manageable chunks of code
- [x] I've requested reviews from 1 reviewer
- [x] I've tested existing features (website scan, sitemap, custom flow) in both node index and cli
- [ ] I've synced this fork with GovTechSG repo
- [ ] I've added/updated unit tests
- [ ] I've added/updated any necessary dependencies in `package[-lock].json` `npm audit`, portable installation on GitHub Actions
