### PR TITLE
fix: isAllowSubdomains boolean reference value

### DIFF
--- a/src/mergeAxeResults.ts
+++ b/src/mergeAxeResults.ts
@@ -850,7 +850,7 @@ const generateArtifacts = async (
     // Populate boolean values for id="advancedScanOptionsSummary"
     advancedScanOptionsSummaryItems: {
       showIncludeScreenshots: [true].includes(scanDetails.isIncludeScreenshots),
-      showAllowSubdomains: [true].includes(scanDetails.isAllowSubdomains),
+      showAllowSubdomains: ['same-domain'].includes(scanDetails.isAllowSubdomains),
       showEnableCustomChecks: ['default', 'enable-wcag-aaa'].includes(
         scanDetails.isEnableCustomChecks?.[0],
       ),


### PR DESCRIPTION
This PR adds... 

- Fix boolean reference value for `isAllowSubdomains` to string value `same-domain`

- [x] I've kept this PR as small as possible (~500 lines) by splitting it into PRs with manageable chunks of code
- [x] I've requested reviews from 1 reviewer
- [x] I've tested existing features (website scan, sitemap, custom flow) in both node index and cli
- [ ] I've synced this fork with GovTechSG repo
- [ ] I've added/updated unit tests
- [ ] I've added/updated any necessary dependencies in `package[-lock].json` `npm audit`, portable installation on GitHub Actions
