### PR TITLE
Fix Chrome browser failing to launch introduced in Chrome v132

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -208,6 +208,9 @@ const scanInit = async (argvs: Answers): Promise<string> => {
 
   const updatedArgvs = { ...argvs };
 
+  // Cannot use data.browser and data.isHeadless as the connectivity check comes first before prepareData
+  setHeadlessMode(updatedArgvs.browserToRun, updatedArgvs.headless);
+
   // let chromeDataDir = null;
   // let edgeDataDir = null;
   // Empty string for profile directory will use incognito mode in playwright
@@ -336,8 +339,6 @@ const scanInit = async (argvs: Answers): Promise<string> => {
       process.send(JSON.stringify(randomTokenMessage));
     }
   }
-
-  setHeadlessMode(data.browser, data.isHeadless);
 
   const screenToScan = getScreenToScan(
     updatedArgvs.deviceChosen,

--- a/src/constants/questions.ts
+++ b/src/constants/questions.ts
@@ -1,6 +1,6 @@
 import { Question } from 'inquirer';
 import { Answers } from '../index.js';
-import { getUserDataTxt } from '../utils.js';
+import { getUserDataTxt, setHeadlessMode } from '../utils.js';
 import {
   checkUrl,
   deleteClonedProfiles,
@@ -79,6 +79,9 @@ const startScanQuestions = [
 
       const statuses = constants.urlCheckStatuses;
       const { browserToRun, clonedBrowserDataDir } = getBrowserToRun(BrowserTypes.CHROME);
+
+      setHeadlessMode(browserToRun, answers.headless);
+
       const playwrightDeviceDetailsObject = getPlaywrightDeviceDetailsObject(
         answers.deviceChosen,
         answers.customDevice,

--- a/src/crawlers/crawlDomain.ts
+++ b/src/crawlers/crawlDomain.ts
@@ -568,31 +568,31 @@ const crawlDomain = async ({
     ],
     preNavigationHooks: isBasicAuth
       ? [
-          async ({ page, request }) => {
-            await page.setExtraHTTPHeaders({
-              Authorization: authHeader,
-              ...extraHTTPHeaders,
-            });
-            const processible = await isProcessibleUrl(request.url);
-            if (!processible) {
-              request.skipNavigation = true;
-              return null;
-            }
-          },
-        ]
+        async ({ page, request }) => {
+          await page.setExtraHTTPHeaders({
+            Authorization: authHeader,
+            ...extraHTTPHeaders,
+          });
+          const processible = await isProcessibleUrl(request.url);
+          if (!processible) {
+            request.skipNavigation = true;
+            return null;
+          }
+        },
+      ]
       : [
-          async ({ page, request }) => {
-            await page.setExtraHTTPHeaders({
-              ...extraHTTPHeaders,
-            });
+        async ({ page, request }) => {
+          await page.setExtraHTTPHeaders({
+            ...extraHTTPHeaders,
+          });
 
-            const processible = await isProcessibleUrl(request.url);
-            if (!processible) {
-              request.skipNavigation = true;
-              return null;
-            }
-          },
-        ],
+          const processible = await isProcessibleUrl(request.url);
+          if (!processible) {
+            request.skipNavigation = true;
+            return null;
+          }
+        },
+      ],
     requestHandlerTimeoutSecs: 90, // Allow each page to be processed by up from default 60 seconds
     requestHandler: async ({ page, request, response, crawler, sendRequest, enqueueLinks }) => {
       const browserContext: BrowserContext = page.context();

--- a/src/crawlers/crawlIntelligentSitemap.ts
+++ b/src/crawlers/crawlIntelligentSitemap.ts
@@ -50,7 +50,13 @@ const crawlIntelligentSitemap = async (
     const homeUrl = getHomeUrl(link);
     let sitemapLinkFound = false;
     let sitemapLink = '';
-    const chromiumBrowser = await chromium.launch({ headless: true, channel: 'chrome' });
+    const chromiumBrowser = await chromium.launch(
+      {
+        headless: false,
+        channel: 'chrome',
+        args: ['--headless=new', '--no-sandbox']
+      });
+
     const page = await chromiumBrowser.newPage();
     for (const path of sitemapPaths) {
       sitemapLink = homeUrl + path;

--- a/src/crawlers/crawlLocalFile.ts
+++ b/src/crawlers/crawlLocalFile.ts
@@ -143,7 +143,7 @@ const crawlLocalFile = async (
 
   if (!isUrlPdf(request.url)) {
     const browserContext = await constants.launcher.launchPersistentContext('', {
-      headless: process.env.CRAWLEE_HEADLESS === '1',
+      headless: false,
       ...getPlaywrightLaunchOptions(browser),
       ...playwrightDeviceDetailsObject,
     });

--- a/src/crawlers/crawlSitemap.ts
+++ b/src/crawlers/crawlSitemap.ts
@@ -163,19 +163,19 @@ const crawlSitemap = async (
     requestList,
     preNavigationHooks: isBasicAuth
       ? [
-          async ({ page }) => {
-            await page.setExtraHTTPHeaders({
-              Authorization: authHeader,
-              ...extraHTTPHeaders,
-            });
-          },
-        ]
+        async ({ page }) => {
+          await page.setExtraHTTPHeaders({
+            Authorization: authHeader,
+            ...extraHTTPHeaders,
+          });
+        },
+      ]
       : [
-          async () => {
-            preNavigationHooks(extraHTTPHeaders);
-            // insert other code here
-          },
-        ],
+        async () => {
+          preNavigationHooks(extraHTTPHeaders);
+          // insert other code here
+        },
+      ],
     requestHandlerTimeoutSecs: 90,
     requestHandler: async ({ page, request, response, sendRequest }) => {
       await waitForPageLoaded(page, 10000);

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,6 @@ import { EnqueueStrategy } from 'crawlee';
 import {
   getVersion,
   cleanUp,
-  setHeadlessMode,
   getUserDataTxt,
   writeToUserDataTxt,
 } from './utils.js';
@@ -111,7 +110,6 @@ const runScan = async (answers: Answers) => {
   const data: Data = await prepareData(answers);
   data.userDataDirectory = getClonedProfilesWithRandomToken(data.browser, data.randomToken);
 
-  setHeadlessMode(data.browser, data.isHeadless);
   printMessage(['Scanning website...'], messageOptions);
 
   await combineRun(data, screenToScan);

--- a/src/mergeAxeResults.ts
+++ b/src/mergeAxeResults.ts
@@ -623,8 +623,9 @@ const writeSummaryPdf = async (storagePath: string, pagesScanned: number, filena
   const htmlFilePath = `${storagePath}/${filename}.html`;
   const fileDestinationPath = `${storagePath}/${filename}.pdf`;
   const browser = await chromium.launch({
-    headless: true,
+    headless: false,
     channel: browserChannel,
+    args: ['--headless=new', '--no-sandbox']
   });
 
   const context = await browser.newContext({

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -241,6 +241,7 @@ export const setHeadlessMode = (browser: string, isHeadless: boolean): void => {
   } else {
     process.env.CRAWLEE_HEADLESS = '0';
   }
+
 };
 
 export const setThresholdLimits = setWarnLevel => {


### PR DESCRIPTION
This PR adds... <!-- A brief description of what your PR does -->
- Fix the breaking change introduced by Google Chrome v132:
`Running Chrome with --headless=old now prints a helpful error message instead of launching the old Headless mode.`
`Running Chrome with --headless or --headless=new runs the new Headless mode.`

- Reference:
https://developer.chrome.com/blog/removing-headless-old-from-chrome

<!-- This checklist is just a guideline.-->
<!-- If any of the following does not apply to your PR, please leave them unchecked and explain in the PR -->

- [x] I've kept this PR as small as possible (~500 lines) by splitting it into PRs with manageable chunks of code
- [ ] I've requested reviews from 1 reviewer
- [x] I've tested existing features (website scan, sitemap, custom flow) in both node index and cli
- [ ] I've synced this fork with GovTechSG repo
- [ ] I've added/updated unit tests
- [ ] I've added/updated any necessary dependencies in `package[-lock].json` `npm audit`, portable installation on GitHub Actions
