### PR TITLE
Resolves error due to userDataDir not set correctly with headless=new

### DIFF
--- a/src/crawlers/crawlDomain.ts
+++ b/src/crawlers/crawlDomain.ts
@@ -469,7 +469,7 @@ const crawlDomain = async ({
       launcher: constants.launcher,
       launchOptions: getPlaywrightLaunchOptions(browser),
       // Bug in Chrome which causes browser pool crash when userDataDirectory is set in non-headless mode
-      userDataDir,
+      ...(process.env.CRAWLEE_HEADLESS === '0' && { userDataDir }),
     },
     retryOnBlocked: true,
     browserPoolOptions: {


### PR DESCRIPTION
This PR adds... <!-- A brief description of what your PR does -->
- Resolves error due to userDataDir not set correctly

Error log:
```
Tex{"timestamp":"2025-01-16 10:59:23","level":"error","message":"uncaughtException: Failed to launch browser. Please check the following:\n- Try installing the required dependencies by running `npx playwright install --with-deps` (https://playwright.dev/docs/browsers).\n\nThe original error is available in the `cause` property. Below is the error received when trying to launch a browser:\n​\nFailed to launch browser. Please check the following:\n- Try installing the required dependencies by running `npx playwright install --with-deps` (https://playwright.dev/docs/browsers).\n\nThe original error is available in the `cause` property. Below is the error received when trying to launch a browser:\n​\nbrowserType.launchPersistentContext: Target page, context or browser has been closed\nBrowser logs:\n\n<launching> /Applications/Google Chrome.app/Contents/MacOS/Google Chrome --disable-field-trial-config --disable-background-networking --disable-background-timer-throttling --disable-backgrounding-occluded-windows --disable-back-forward-cache --disable-breakpad --disable-client-side-phishing-detection --disable-component-extensions-with-background-pages --disable-component-update --no-default-browser-check --disable-default-apps --disable-dev-shm-usage --disable-extensions --disable-features=ImprovedCookieControls,LazyFrameLoading,GlobalMediaControls,DestroyProfileOnBrowserClose,MediaRouter,DialMediaRouteProvider,AcceptCHFrame,AutoExpandDetailsElement,CertificateTransparencyComponentUpdater,AvoidUnnecessaryBeforeUnloadCheckSync,Translate,HttpsUpgrades,PaintHolding,PlzDedicatedWorker --allow-pre-commit-input --disable-hang-monitor --disable-ipc-flooding-protection --disable-popup-blocking --disable-prompt-on-repost --disable-renderer-backgrounding --force-color-profile=srgb --metrics-recording-only --no-first-run --enable-automation --password-store=basic --no-service-autorun --export-tagged-pdf --disable-search-engine-choice-screen --unsafely-disable-devtools-self-xss-warnings --enable-use-zoom-for-dsf=false --no-sandbox --proxy-server=http://127.0.0.1:59733 --proxy-bypass-list=<-loopback> --headless=new --headless=new --disable-blink-features=AutomationControlled --user-data-dir=/Users/.../Library/Application Support/Google/Chrome/oobee-20250116_105817_www.tech.gov.sg_680 --remote-debugging-pipe about:blank\n<launched> pid=50336\n[pid=50336][err] [50336:259:0116/105923.133642:ERROR:process_singleton_posix.cc(340)] Failed to create /Users/.../Library/Application Support/Google/Chrome/oobee-20250116_105817_www.tech.gov.sg_680/SingletonLock: File exists (17)\n[pid=50336][err] [50336:259:0116/105923.133816:ERROR:chrome_main_delegate.cc(558)] Failed to create a ProcessSingleton for your profile directory. This means that running multiple instances would start multiple browser processes rather than opening a new window in the existing process. Aborting now to avoid profile corruption.\nCall log:\n  \u001b[2m- <launching> /Applications/Google Chrome.app/Contents/MacOS/Google Chrome --disable-field-trial-config --disable-background-networking --disable-background-timer-throttling --disable-backgrounding-occluded-windows --disable-back-forward-cache --disable-breakpad --disable-client-side-phishing-detection --disable-component-extensions-with-background-pages --disable-component-update --no-default-browser-check --disable-default-apps --disable-dev-shm-usage --disable-extensions --disable-features=ImprovedCookieControls,LazyFrameLoading,GlobalMediaControls,DestroyProfileOnBrowserClose,MediaRouter,DialMediaRouteProvider,AcceptCHFrame,AutoExpandDetailsElement,CertificateTransparencyComponentUpdater,AvoidUnnecessaryBeforeUnloadCheckSync,Translate,HttpsUpgrades,PaintHolding,PlzDedicatedWorker --allow-pre-commit-input --disable-hang-monitor --disable-ipc-flooding-protection --disable-popup-blocking --disable-prompt-on-repost --disable-renderer-backgrounding --force-color-profile=srgb --metrics-recording-only --no-first-run --enable-automation --password-store=basic --no-service-autorun --export-tagged-pdf --disable-search-engine-choice-screen --unsafely-disable-devtools-self-xss-warnings --enable-use-zoom-for-dsf=false --no-sandbox --proxy-server=http://127.0.0.1:59733 --proxy-bypass-list=<-loopback> --headless=new --headless=new --disable-blink-features=AutomationControlled --user-data-dir=/Users/.../Library/Application Support/Google/Chrome/oobee-20250116_105817_www.tech.gov.sg_680 --remote-debugging-pipe about:blank\u001b[22m\n\u001b[2m  - <launched> pid=50336\u001b[22m\n\u001b[2m  - [pid=50336][err] [50336:259:0116/105923.133642:ERROR:process_singleton_posix.cc(340)] Failed to create /Users/.../Library/Application Support/Google/Chrome/oobee-20250116_105817_www.tech.gov.sg_680/SingletonLock: File exists (17)\u001b[22m\n\u001b[2m  - [pid=50336][err] [50336:259:0116/105923.133816:ERROR:chrome_main_delegate.cc(558)] Failed to create a ProcessSingleton for your profile directory. This means that running multiple instances would start multiple browser processes rather than opening a new window in the existing process. Aborting now to avoid profile corruption.\u001b[22m\n\n    at async PlaywrightPlugin._launch (/Users/.../purple-a11y/node_modules/@crawlee/browser-pool/playwright/playwright-plugin.js:106:40)\n    at async BrowserPool._launchBrowser (/Users/.../purple-a11y/node_modules/@crawlee/browser-pool/browser-pool.js:482:29)\n    at /Users/.../purple-a11y/async /Users/.../purple-a11y/node_modules/@crawlee/browser-pool/browser-pool.js:287:37\nError thrown at:\n\n    at PlaywrightPlugin._throwAugmentedLaunchError (/Users/.../purple-a11y/node_modules/@crawlee/browser-pool/abstract-classes/browser-plugin.js:153:15)\n    at PlaywrightPlugin._throwOnFailedLaunch (/Users/.../purple-a11y/node_modules/@crawlee/browser-pool/playwright/playwright-plugin.js:167:14)\n    at /Users/.../purple-a11y/node_modules/@crawlee/browser-pool/playwright/playwright-plugin.js:109:33\n    at async PlaywrightPlugin._launch (/Users/.../purple-a11y/node_modules/@crawlee/browser-pool/playwright/playwright-plugin.js:106:40)\n    at async BrowserPool._launchBrowser (/Users/.../purple-a11y/node_modules/@crawlee/browser-pool/browser-pool.js:482:29)\n    at async /Users/.../purple-a11y/node_modules/@crawlee/browser-pool/browser-pool.js:287:37"}
```
<!-- This checklist is just a guideline.-->
<!-- If any of the following does not apply to your PR, please leave them unchecked and explain in the PR -->

- [ ] I've kept this PR as small as possible (~500 lines) by splitting it into PRs with manageable chunks of code
- [ ] I've requested reviews from 1 reviewer
- [ ] I've tested existing features (website scan, sitemap, custom flow) in both node index and cli
- [ ] I've synced this fork with GovTechSG repo
- [ ] I've added/updated unit tests
- [ ] I've added/updated any necessary dependencies in `package[-lock].json` `npm audit`, portable installation on GitHub Actions
