### PR TITLE
Fix Chrome browser failing to launch introduced in Chrome v132 (For Sitemap and Intelligent)

### DIFF
--- a/src/crawlers/crawlSitemap.ts
+++ b/src/crawlers/crawlSitemap.ts
@@ -144,7 +144,7 @@ const crawlSitemap = async (
       launcher: constants.launcher,
       launchOptions: getPlaywrightLaunchOptions(browser),
       // Bug in Chrome which causes browser pool crash when userDataDirectory is set in non-headless mode
-      userDataDir,
+      ...(process.env.CRAWLEE_HEADLESS === '0' && { userDataDir }),
     },
     retryOnBlocked: true,
     browserPoolOptions: {
@@ -163,19 +163,19 @@ const crawlSitemap = async (
     requestList,
     preNavigationHooks: isBasicAuth
       ? [
-        async ({ page }) => {
-          await page.setExtraHTTPHeaders({
-            Authorization: authHeader,
-            ...extraHTTPHeaders,
-          });
-        },
-      ]
+          async ({ page }) => {
+            await page.setExtraHTTPHeaders({
+              Authorization: authHeader,
+              ...extraHTTPHeaders,
+            });
+          },
+        ]
       : [
-        async () => {
-          preNavigationHooks(extraHTTPHeaders);
-          // insert other code here
-        },
-      ],
+          async () => {
+            preNavigationHooks(extraHTTPHeaders);
+            // insert other code here
+          },
+        ],
     requestHandlerTimeoutSecs: 90,
     requestHandler: async ({ page, request, response, sendRequest }) => {
       await waitForPageLoaded(page, 10000);


### PR DESCRIPTION
This PR adds... 
- Fix the breaking change introduced by Google Chrome v132 for sitemap and Intelligent
`Running Chrome with --headless=old now prints a helpful error message instead of launching the old Headless mode.`
`Running Chrome with --headless or --headless=new runs the new Headless mode.`

<!-- This checklist is just a guideline.-->
<!-- If any of the following does not apply to your PR, please leave them unchecked and explain in the PR -->

- [ ] I've kept this PR as small as possible (~500 lines) by splitting it into PRs with manageable chunks of code
- [ ] I've requested reviews from 1 reviewer
- [ ] I've tested existing features (website scan, sitemap, custom flow) in both node index and cli
- [ ] I've synced this fork with GovTechSG repo
- [ ] I've added/updated unit tests
- [ ] I've added/updated any necessary dependencies in `package[-lock].json` `npm audit`, portable installation on GitHub Actions
