### PR TITLE
Fix compress scanItems.json.gz.b64 failure

### DIFF
--- a/src/mergeAxeResults.ts
+++ b/src/mergeAxeResults.ts
@@ -443,6 +443,36 @@ function writeLargeJsonToFile(obj: object, filePath: string) {
 const writeLargeScanItemsJsonToFile = async (obj: object, filePath: string) => {
   return new Promise((resolve, reject) => {
     const writeStream = fs.createWriteStream(filePath, { flags: 'a', encoding: 'utf8' });
+    const writeQueue: string[] = [];
+    let isWriting = false;
+
+    const processNextWrite = async () => {
+      if (isWriting || writeQueue.length === 0) return;
+
+      isWriting = true;
+      const data = writeQueue.shift()!;
+
+      try {
+        if (!writeStream.write(data)) {
+          await new Promise<void>(resolve => {
+            writeStream.once('drain', () => {
+              resolve();
+            });
+          });
+        }
+      } catch (error) {
+        writeStream.destroy(error as Error);
+        return;
+      }
+
+      isWriting = false;
+      processNextWrite();
+    };
+
+    const queueWrite = (data: string) => {
+      writeQueue.push(data);
+      processNextWrite();
+    };
 
     writeStream.on('error', error => {
       consoleLogger.error(`Error writing object to JSON file: ${error}`);
@@ -455,116 +485,95 @@ const writeLargeScanItemsJsonToFile = async (obj: object, filePath: string) => {
     });
 
     try {
-      writeStream.write('{\n');
-
+      queueWrite('{\n');
       const keys = Object.keys(obj);
 
-      for (let i = 0; i < keys.length; i++) {
-        const key = keys[i];
+      keys.forEach((key, i) => {
         const value = obj[key];
+        queueWrite(`  "${key}": {\n`);
 
-        // Start writing the key object
-        writeStream.write(`  "${key}": {\n`);
+        const { rules, ...otherProperties } = value;
 
-        const { rules, ...otherProperties } = value; // Extract rules and other properties dynamically
-
-        // Write all properties dynamically, excluding rules
-        const otherKeys = Object.keys(otherProperties);
-        for (let j = 0; j < otherKeys.length; j++) {
-          const propKey = otherKeys[j];
-          const propValue = otherProperties[propKey];
-
-          // Serialize and write the property dynamically
-          writeStream.write(`    "${propKey}": ${JSON.stringify(propValue)}`);
-
-          // Add a comma unless it's the last property
-          if (j < otherKeys.length - 1 || (rules && rules.length >= 0)) {
-            writeStream.write(',\n');
+        // Write other properties
+        Object.entries(otherProperties).forEach(([propKey, propValue], j) => {
+          queueWrite(`    "${propKey}": ${JSON.stringify(propValue)}`);
+          if (j < Object.keys(otherProperties).length - 1 || (rules && rules.length >= 0)) {
+            queueWrite(',\n');
           } else {
-            writeStream.write('\n');
+            queueWrite('\n');
           }
-        }
+        });
 
         if (rules && Array.isArray(rules)) {
-          writeStream.write(`    "rules": [\n`);
+          queueWrite('    "rules": [\n');
 
-          for (let j = 0; j < rules.length; j++) {
-            const rule = rules[j];
+          rules.forEach((rule, j) => {
+            queueWrite('      {\n');
+            const { pagesAffected, ...otherRuleProperties } = rule;
 
-            writeStream.write('      {\n'); // Start the rule object
-
-            const { pagesAffected, ...otherRuleProperties } = rule; // Extract pagesAffected dynamically
-
-            // Write other properties dynamically
-            const ruleKeys = Object.keys(otherRuleProperties);
-            for (let k = 0; k < ruleKeys.length; k++) {
-              const ruleKey = ruleKeys[k];
-              const ruleValue = otherRuleProperties[ruleKey];
-
-              // Serialize and write each property dynamically
-              writeStream.write(`        "${ruleKey}": ${JSON.stringify(ruleValue)}`);
-
-              // Add a comma unless it's the last property and no pagesAffected is present
-              if (k < ruleKeys.length - 1 || pagesAffected) {
-                writeStream.write(',\n');
+            Object.entries(otherRuleProperties).forEach(([ruleKey, ruleValue], k) => {
+              queueWrite(`        "${ruleKey}": ${JSON.stringify(ruleValue)}`);
+              if (k < Object.keys(otherRuleProperties).length - 1 || pagesAffected) {
+                queueWrite(',\n');
               } else {
-                writeStream.write('\n');
+                queueWrite('\n');
               }
-            }
+            });
 
             if (pagesAffected && Array.isArray(pagesAffected)) {
-              writeStream.write(`        "pagesAffected": [\n`);
+              queueWrite('        "pagesAffected": [\n');
 
-              for (let p = 0; p < pagesAffected.length; p++) {
-                const page = pagesAffected[p];
+              pagesAffected.forEach((page, p) => {
+                const pageJson = JSON.stringify(page, null, 2)
+                  .split('\n')
+                  .map((line, idx) => (idx === 0 ? `          ${line}` : `          ${line}`))
+                  .join('\n');
 
-                writeStream.write('          '); // Indentation for each page object
-                const pageGenerator = serializeObject(page, 5); // Serialize each page object
-
-                let pageNext: any;
-                while (!(pageNext = pageGenerator.next()).done) {
-                  if (!writeStream.write(pageNext.value)) {
-                    writeStream.once('drain', () => {});
-                  }
-                }
+                queueWrite(pageJson);
 
                 if (p < pagesAffected.length - 1) {
-                  writeStream.write(',\n'); // Comma between pages in the chunk
+                  queueWrite(',\n');
                 } else {
-                  writeStream.write('\n'); // No trailing comma for the last page in the chunk
+                  queueWrite('\n');
                 }
-              }
+              });
 
-              writeStream.write('        ]'); // Close the pagesAffected array
+              queueWrite('        ]');
             }
 
-            writeStream.write('\n      }'); // Close the rule object
-
+            queueWrite('\n      }');
             if (j < rules.length - 1) {
-              writeStream.write(',\n'); // Comma between rules
+              queueWrite(',\n');
             } else {
-              writeStream.write('\n'); // No trailing comma for the last rule
+              queueWrite('\n');
             }
-          }
+          });
 
-          writeStream.write('    ]'); // Close the rules array
+          queueWrite('    ]');
         }
 
-        writeStream.write('\n  }'); // Close the key object here, after processing all fields of the current key
-
-        // Add a comma between keys if not the last key
+        queueWrite('\n  }');
         if (i < keys.length - 1) {
-          writeStream.write(',\n'); // Comma between top-level keys
+          queueWrite(',\n');
         } else {
-          writeStream.write('\n'); // No trailing comma after the last key
+          queueWrite('\n');
         }
-      }
+      });
 
-      writeStream.write('}\n'); // Close the main object
-      writeStream.end();
+      queueWrite('}\n');
+
+      // Ensure all queued writes are processed before ending
+      const checkQueueAndEnd = () => {
+        if (writeQueue.length === 0 && !isWriting) {
+          writeStream.end();
+        } else {
+          setTimeout(checkQueueAndEnd, 100);
+        }
+      };
+
+      checkQueueAndEnd();
     } catch (err) {
-      consoleLogger.error(`Error writing object to JSON file: ${err}`);
-      writeStream.end();
+      writeStream.destroy(err as Error);
       reject(err);
     }
   });


### PR DESCRIPTION
This PR adds...
- Cover function writeLargeScanItemsJsonToFile in a promise so it would need to finish the scanItem processing
- Ensure that scanItems has the right structure even when theres empty rules 
- Implement Queue system on stream, instead of loading all at stream that will cause MaxListenerExceededWarning 

<!-- This checklist is just a guideline.-->
<!-- If any of the following does not apply to your PR, please leave them unchecked and explain in the PR -->

- [x] I've kept this PR as small as possible (~500 lines) by splitting it into PRs with manageable chunks of code
- [ ] I've requested reviews from 1 reviewer
- [x] I've tested existing features (website scan, sitemap, custom flow) in both node index and cli
- [ ] I've synced this fork with GovTechSG repo
- [ ] I've added/updated unit tests
- [ ] I've added/updated any necessary dependencies in `package[-lock].json` `npm audit`, portable installation on GitHub Actions
