### PR TITLE
fix: empty passed json

### DIFF
--- a/src/mergeAxeResults.ts
+++ b/src/mergeAxeResults.ts
@@ -966,8 +966,6 @@ const flattenAndSortResults = (allIssues: AllIssues, isCustomFlow: boolean) => {
   ['mustFix', 'goodToFix', 'needsReview', 'passed'].forEach(category => {
     allIssues.totalItems += allIssues.items[category].totalItems;
 
-    if (category === 'passed') return;
-
     allIssues.items[category].rules = Object.entries(allIssues.items[category].rules)
       .map(ruleEntry => {
         const [rule, ruleInfo] = ruleEntry as [string, RuleInfo];


### PR DESCRIPTION
This PR fixes the bug where the passed items json is empty.

- [x] I've kept this PR as small as possible (~500 lines) by splitting it into PRs with manageable chunks of code
- [x] I've requested reviews from 1 reviewer
