### PR TITLE
fix: unescaped windows storagePath causing report to not work

### DIFF
--- a/src/mergeAxeResults.ts
+++ b/src/mergeAxeResults.ts
@@ -221,7 +221,8 @@ const compileHtmlWithEJS = async (
   const template = ejs.compile(ejsString, {
     filename: path.join(dirname, './static/ejs/report.ejs'),
   });
-  const html = template(allIssues);
+
+  const html = template({...allIssues, storagePath: JSON.stringify(storagePath)});
   await fs.writeFile(htmlFilePath, html);
 
   let htmlContent = await fs.readFile(htmlFilePath, { encoding: 'utf8' });


### PR DESCRIPTION
This PR fixes the problem with report not working

- [x] I've kept this PR as small as possible (~500 lines) by splitting it into PRs with manageable chunks of code
- [x] I've requested reviews from 1 reviewer

