### PR TITLE
fix: page closed while runAxeScript

### DIFF
--- a/src/crawlers/commonCrawlerFunc.ts
+++ b/src/crawlers/commonCrawlerFunc.ts
@@ -217,7 +217,7 @@ export const runAxeScript = async ({
       return new Promise(resolve => {
         let timeout: NodeJS.Timeout;
         let mutationCount = 0;
-        const MAX_MUTATIONS = 100;
+        const MAX_MUTATIONS = 250;
         const MAX_SAME_MUTATION_LIMIT = 10;
         const mutationHash = {};
 

--- a/src/crawlers/crawlDomain.ts
+++ b/src/crawlers/crawlDomain.ts
@@ -496,7 +496,7 @@ const crawlDomain = async ({
           return new Promise(resolve => {
             let timeout;
             let mutationCount = 0;
-            const MAX_MUTATIONS = 100;
+            const MAX_MUTATIONS = 250;
             const MAX_SAME_MUTATION_LIMIT = 10;
             const mutationHash = {};
 


### PR DESCRIPTION
There have been problems scanning some seemingly valid pages on CPF website, with the error: "Target page, context or browser has been closed" while running runAxeScript.

This PR adds logging when page is closed while running runAxeScript, and retries getting the page title if needed.

This will address most of the occurrences, which happens while getting pageTitle. But there are still other areas that can error out:
1. when waiting for DOM mutations
2. when actually checking the page for accessibility issues
3. when trying to reload the page to get the page title (it can still fail)

- [x] I've kept this PR as small as possible (~500 lines) by splitting it into PRs with manageable chunks of code
- [x] I've requested reviews from 1 reviewer
