### PR TITLE
Shrink scanItemsSummary to just required fields

### DIFF
--- a/src/mergeAxeResults.ts
+++ b/src/mergeAxeResults.ts
@@ -779,16 +779,16 @@ const writeJsonAndBase64Files = async (
 
   const summaryItems = {
     mustFix: {
-      totalItems: items.mustFix.totalItems,
-      totalRuleIssues: items.mustFix.totalRuleIssues,
+      totalItems: items.mustFix?.totalItems || 0,
+      totalRuleIssues: items.mustFix?.totalRuleIssues || 0,
     },
     goodToFix: {
-      totalItems: items.goodToFix.totalItems,
-      totalRuleIssues: items.goodToFix.totalRuleIssues,
+      totalItems: items.goodToFix?.totalItems || 0,
+      totalRuleIssues: items.goodToFix?.totalRuleIssues || 0,
     },
     needsReview: {
-      totalItems: items.needsReview.totalItems,
-      totalRuleIssues: items.needsReview.totalRuleIssues,
+      totalItems: items.needsReview?.totalItems || 0,
+      totalRuleIssues: items.needsReview?.totalRuleIssues || 0,
     },
     topTenPagesWithMostIssues,
     wcagLinks,

--- a/src/mergeAxeResults.ts
+++ b/src/mergeAxeResults.ts
@@ -767,9 +767,7 @@ const writeJsonAndBase64Files = async (
   items.passed.totalRuleIssues = items.passed.rules.length;
 
   const {
-    pagesScanned,
     topTenPagesWithMostIssues,
-    pagesNotScanned,
     wcagLinks,
     wcagPassPercentage,
     totalPagesScanned,

--- a/src/mergeAxeResults.ts
+++ b/src/mergeAxeResults.ts
@@ -778,10 +778,19 @@ const writeJsonAndBase64Files = async (
   } = rest;
 
   const summaryItems = {
-    ...items,
-    pagesScanned,
+    mustFix: {
+      totalItems: items.mustFix.totalItems,
+      totalRuleIssues: items.mustFix.totalRuleIssues,
+    },
+    goodToFix: {
+      totalItems: items.goodToFix.totalItems,
+      totalRuleIssues: items.goodToFix.totalRuleIssues,
+    },
+    needsReview: {
+      totalItems: items.needsReview.totalItems,
+      totalRuleIssues: items.needsReview.totalRuleIssues,
+    },
     topTenPagesWithMostIssues,
-    pagesNotScanned,
     wcagLinks,
     wcagPassPercentage,
     totalPagesScanned,


### PR DESCRIPTION
This PR adds... <!-- A brief description of what your PR does -->
- Emit scanItemsSummary as:
```
 const summaryItems = {
    mustFix: {
      totalItems: items.mustFix.totalItems,
      totalRuleIssues: items.mustFix.totalRuleIssues,
    },
    goodToFix: {
      totalItems: items.goodToFix.totalItems,
      totalRuleIssues: items.goodToFix.totalRuleIssues,
    },
    needsReview: {
      totalItems: items.needsReview.totalItems,
      totalRuleIssues: items.needsReview.totalRuleIssues,
    },
    topTenPagesWithMostIssues,
    wcagLinks,
    wcagPassPercentage,
    totalPagesScanned,
    totalPagesNotScanned,
    topTenIssues,
  };
  ```
<!-- This checklist is just a guideline.-->
<!-- If any of the following does not apply to your PR, please leave them unchecked and explain in the PR -->

- [x] I've kept this PR as small as possible (~500 lines) by splitting it into PRs with manageable chunks of code
- [ ] I've requested reviews from 1 reviewer
- [ ] I've tested existing features (website scan, sitemap, custom flow) in both node index and cli
- [ ] I've synced this fork with GovTechSG repo
- [ ] I've added/updated unit tests
- [ ] I've added/updated any necessary dependencies in `package[-lock].json` `npm audit`, portable installation on GitHub Actions
