### PR TITLE
fix: make crawlee one tab per browser to avoid multiple tabs on corppass

### DIFF
--- a/src/crawlers/crawlDomain.ts
+++ b/src/crawlers/crawlDomain.ts
@@ -457,6 +457,7 @@ const crawlDomain = async ({
 
   const crawler = new crawlee.PlaywrightCrawler({
     launchContext: {
+      useIncognitoPages: true,
       launcher: constants.launcher,
       launchOptions: getPlaywrightLaunchOptions(browser),
       // Bug in Chrome which causes browser pool crash when userDataDirectory is set in non-headless mode
@@ -464,7 +465,7 @@ const crawlDomain = async ({
     },
     retryOnBlocked: true,
     browserPoolOptions: {
-      maxOpenPagesPerBrowser: 1,
+
       useFingerprints: false,
       preLaunchHooks: [
         async (_pageId, launchContext) => {

--- a/src/crawlers/crawlDomain.ts
+++ b/src/crawlers/crawlDomain.ts
@@ -560,7 +560,7 @@ const crawlDomain = async ({
     ],
     preNavigationHooks: isBasicAuth
       ? [
-          async ({ page }) => {
+          async ({ page, request }) => {
             // Inject script to override localStorage before navigation
             await page.addInitScript(
               ({ fakeStorageFunctionString }) => {
@@ -575,8 +575,7 @@ const crawlDomain = async ({
               Authorization: authHeader,
               ...extraHTTPHeaders,
             });
-          },
-          async ({ page, request }) => {
+
             const processible = await isProcessibleUrl(request.url);
             if (!processible) {
               request.skipNavigation = true;
@@ -585,7 +584,7 @@ const crawlDomain = async ({
           },
         ]
       : [
-          async ({ page }) => {
+          async ({ page, request }) => {
             // Inject script to override localStorage before navigation
             await page.addInitScript(
               ({ fakeStorageFunctionString }) => {
@@ -599,8 +598,7 @@ const crawlDomain = async ({
             await page.setExtraHTTPHeaders({
               ...extraHTTPHeaders,
             });
-          },
-          async ({ page, request }) => {
+
             const processible = await isProcessibleUrl(request.url);
             if (!processible) {
               request.skipNavigation = true;

--- a/src/crawlers/custom/fakeStorage.ts
+++ b/src/crawlers/custom/fakeStorage.ts
@@ -1,0 +1,48 @@
+export function fakeStorage() {
+  const fakeLocalStorage = (function () {
+    let store = {};
+
+    return {
+      getItem(key) {
+        return store[key] || null;
+      },
+      setItem(key, value) {
+        store[key] = String(value);
+      },
+      removeItem(key) {
+        delete store[key];
+      },
+      clear() {
+        store = {};
+      },
+    };
+  })();
+
+  const fakeSessionStorage = (function () {
+    let store = {};
+
+    return {
+      getItem(key) {
+        return store[key] || null;
+      },
+      setItem(key, value) {
+        store[key] = String(value);
+      },
+      removeItem(key) {
+        delete store[key];
+      },
+      clear() {
+        store = {};
+      },
+    };
+  })();
+  // Replace the global localStorage with the fake one (for testing):
+  Object.defineProperty(window, 'localStorage', {
+    value: fakeLocalStorage,
+    writable: true, // Important for resetting it later
+  });
+  Object.defineProperty(window, 'sessionStorage', {
+    value: fakeSessionStorage,
+    writable: true, // Important for resetting it later
+  });
+}


### PR DESCRIPTION
Problem:
- corppass.gov.sg only allows one tab to be open at a time
- when a new tab is opened onto any page of corppass.gov.sg, the other tabs show an error
- this is done by updating `currentActiveTabUIDPRD` on localStorage whenever a new tab is open
- each tab also stores their own `browserTabUIDPRD` on sessionStorage
- when `currentActiveTabUIDPRD` changes to a value which is different from `browserTabUIDPRD`, the error message shows
- if you change `currentActiveTabUIDPRD` to match `browserTabUIDPRD`, the error message goes away

Changes in this PR:
- change the page's local and session storage to fake ones that are not shared across pages, so that changes are not shared across pages and therefore would not trigger corppass' mechanism
- get page title in the same page.evaluate as axe run (to avoid additional page.eval that could cause problems if the page is already closed)

Changes tried but decided not to use:
- temporarily test one tab per browser crawlee setting (`maxOpenPagesPerBrowser: 1,`) to see if it avoids corppass problem (if this approach is ok, maybe we add an cli option for this)

- [x] I've kept this PR as small as possible (~500 lines) by splitting it into PRs with manageable chunks of code
- [x] I've requested reviews from 1 reviewer
