### PR TITLE
Feat/modify user agent headless

### DIFF
--- a/src/constants/common.ts
+++ b/src/constants/common.ts
@@ -1779,38 +1779,41 @@ export const submitForm = async (
 
 export async function initModifiedUserAgent(browser?: string, playwrightDeviceDetailsObject?: object) {
   const isHeadless = process.env.CRAWLEE_HEADLESS === '1';
-  if (isHeadless) {
-    // Ensure the headless flag is set.
-    if (!constants.launchOptionsArgs.includes('--headless=new')) {
-      constants.launchOptionsArgs.push('--headless=new');
-    }
-    
-    // Build the launch options using your production settings:
-    // - headless is forced to false (as in your production persistent context).
-    // - Merge in getPlaywrightLaunchOptions(browser) and the device details.
-    const launchOptions = {
-      headless: false,
-      ...getPlaywrightLaunchOptions(browser),
-      ...playwrightDeviceDetailsObject,
-    };
-
-    // Launch a temporary persistent context with an empty userDataDir,
-    // so that we mimic exactly your production browser setup.
-    const browserContext = await constants.launcher.launchPersistentContext('', launchOptions);
-    const page = await browserContext.newPage();
-
-    // Retrieve the default user agent.
-    const defaultUA = await page.evaluate(() => navigator.userAgent);
-    await browserContext.close();
-
-    // Modify the UA: replace "HeadlessChrome" with "Chrome" and append "; Oobee".
-    const modifiedUA = defaultUA.replace('HeadlessChrome', 'Chrome') + '; Oobee';
-    
-    // Push the modified UA flag into your global launch options.
-    constants.launchOptionsArgs.push(`--user-agent=${modifiedUA}`);
-    // console.log('Modified User Agent:', modifiedUA);
+  
+  // If headless mode is enabled, ensure the headless flag is set.
+  if (isHeadless && !constants.launchOptionsArgs.includes('--headless=new')) {
+    constants.launchOptionsArgs.push('--headless=new');
   }
+  
+  // Build the launch options using your production settings.
+  // headless is forced to false as in your persistent context, and we merge in getPlaywrightLaunchOptions and device details.
+  const launchOptions = {
+    headless: false,
+    ...getPlaywrightLaunchOptions(browser),
+    ...playwrightDeviceDetailsObject,
+  };
+
+  // Launch a temporary persistent context with an empty userDataDir to mimic your production browser setup.
+  const browserContext = await constants.launcher.launchPersistentContext('', launchOptions);
+  const page = await browserContext.newPage();
+
+  // Retrieve the default user agent.
+  const defaultUA = await page.evaluate(() => navigator.userAgent);
+  await browserContext.close();
+
+  // Modify the UA:
+  // Replace "HeadlessChrome" with "Chrome" if present, and always append "; Oobee".
+  let modifiedUA = defaultUA.includes('HeadlessChrome')
+    ? defaultUA.replace('HeadlessChrome', 'Chrome')
+    : defaultUA;
+  modifiedUA += '; Oobee';
+
+  // Push the modified UA flag into your global launch options.
+  constants.launchOptionsArgs.push(`--user-agent=${modifiedUA}`);
+  // Optionally log the modified UA.
+  // console.log('Modified User Agent:', modifiedUA);
 }
+
 
 /**
  * @param {string} browser browser name ("chrome" or "edge", null for chromium, the default Playwright browser)

--- a/src/constants/common.ts
+++ b/src/constants/common.ts
@@ -1776,6 +1776,42 @@ export const submitForm = async (
     }
   }
 };
+
+export async function initModifiedUserAgent(browser?: string, playwrightDeviceDetailsObject?: object) {
+  const isHeadless = process.env.CRAWLEE_HEADLESS === '1';
+  if (isHeadless) {
+    // Ensure the headless flag is set.
+    if (!constants.launchOptionsArgs.includes('--headless=new')) {
+      constants.launchOptionsArgs.push('--headless=new');
+    }
+    
+    // Build the launch options using your production settings:
+    // - headless is forced to false (as in your production persistent context).
+    // - Merge in getPlaywrightLaunchOptions(browser) and the device details.
+    const launchOptions = {
+      headless: false,
+      ...getPlaywrightLaunchOptions(browser),
+      ...playwrightDeviceDetailsObject,
+    };
+
+    // Launch a temporary persistent context with an empty userDataDir,
+    // so that we mimic exactly your production browser setup.
+    const browserContext = await constants.launcher.launchPersistentContext('', launchOptions);
+    const page = await browserContext.newPage();
+
+    // Retrieve the default user agent.
+    const defaultUA = await page.evaluate(() => navigator.userAgent);
+    await browserContext.close();
+
+    // Modify the UA: replace "HeadlessChrome" with "Chrome" and append "; Oobee".
+    const modifiedUA = defaultUA.replace('HeadlessChrome', 'Chrome') + '; Oobee';
+    
+    // Push the modified UA flag into your global launch options.
+    constants.launchOptionsArgs.push(`--user-agent=${modifiedUA}`);
+    // console.log('Modified User Agent:', modifiedUA);
+  }
+}
+
 /**
  * @param {string} browser browser name ("chrome" or "edge", null for chromium, the default Playwright browser)
  * @returns playwright launch options object. For more details: https://playwright.dev/docs/api/class-browsertype#browser-type-launch

--- a/src/constants/common.ts
+++ b/src/constants/common.ts
@@ -1802,12 +1802,11 @@ export async function initModifiedUserAgent(browser?: string, playwrightDeviceDe
   await browserContext.close();
 
   // Modify the UA:
-  // Replace "HeadlessChrome" with "Chrome" if present, and always append "; Oobee".
+  // Replace "HeadlessChrome" with "Chrome" if present.
   let modifiedUA = defaultUA.includes('HeadlessChrome')
     ? defaultUA.replace('HeadlessChrome', 'Chrome')
     : defaultUA;
-  modifiedUA += '; Oobee';
-
+    
   // Push the modified UA flag into your global launch options.
   constants.launchOptionsArgs.push(`--user-agent=${modifiedUA}`);
   // Optionally log the modified UA.

--- a/src/crawlers/crawlDomain.ts
+++ b/src/crawlers/crawlDomain.ts
@@ -601,9 +601,7 @@ const crawlDomain = async ({
           currentUrl.password = password;
           request.url = currentUrl.href;
         }
-        // const htmlContent = await page.content();
-        const userAgent = await page.evaluate(() => navigator.userAgent);
-        console.log(userAgent);
+
         await waitForPageLoaded(page, 10000);
         let actualUrl = page.url() || request.loadedUrl || request.url;
 

--- a/src/crawlers/crawlDomain.ts
+++ b/src/crawlers/crawlDomain.ts
@@ -29,6 +29,7 @@ import {
   getBlackListedPatterns,
   urlWithoutAuth,
   waitForPageLoaded,
+  initModifiedUserAgent,
 } from '../constants/common.js';
 import { areLinksEqual, isFollowStrategy } from '../utils.js';
 import {
@@ -455,6 +456,8 @@ const crawlDomain = async ({
     userDataDir = process.env.CRAWLEE_HEADLESS !== '0' ? userDataDirectory : '';
   }
 
+  await initModifiedUserAgent(browser, playwrightDeviceDetailsObject);
+  
   const crawler = new crawlee.PlaywrightCrawler({
     launchContext: {
       launcher: constants.launcher,
@@ -598,7 +601,9 @@ const crawlDomain = async ({
           currentUrl.password = password;
           request.url = currentUrl.href;
         }
-
+        // const htmlContent = await page.content();
+        const userAgent = await page.evaluate(() => navigator.userAgent);
+        console.log(userAgent);
         await waitForPageLoaded(page, 10000);
         let actualUrl = page.url() || request.loadedUrl || request.url;
 

--- a/src/crawlers/crawlLocalFile.ts
+++ b/src/crawlers/crawlLocalFile.ts
@@ -10,6 +10,7 @@ import {
   isFilePath,
   convertLocalFileToPath,
   convertPathToLocalFile,
+  initModifiedUserAgent,
 } from '../constants/common.js';
 import { runPdfScan, mapPdfScanResults, doPdfScreenshots } from './pdfScanFunc.js';
 import { guiInfoLog } from '../logs.js';
@@ -142,13 +143,14 @@ const crawlLocalFile = async (
   uuidToPdfMapping[pdfFileName] = trimmedUrl;
 
   if (!isUrlPdf(request.url)) {
+    await initModifiedUserAgent(browser);
     const browserContext = await constants.launcher.launchPersistentContext('', {
       headless: false,
       ...getPlaywrightLaunchOptions(browser),
       ...playwrightDeviceDetailsObject,
     });
 
-    const page = await browserContext.newPage();
+    const page = await browserContext.newPage(););
     request.url = convertPathToLocalFile(request.url);
     await page.goto(request.url);
     const results = await runAxeScript({ includeScreenshots, page, randomToken });

--- a/src/crawlers/crawlSitemap.ts
+++ b/src/crawlers/crawlSitemap.ts
@@ -17,6 +17,7 @@ import {
   urlWithoutAuth,
   waitForPageLoaded,
   isFilePath,
+  initModifiedUserAgent,
 } from '../constants/common.js';
 import { areLinksEqual, isWhitelistedContentType, isFollowStrategy } from '../utils.js';
 import { handlePdfDownload, runPdfScan, mapPdfScanResults } from './pdfScanFunc.js';
@@ -139,6 +140,7 @@ const crawlSitemap = async (
     userDataDir = process.env.CRAWLEE_HEADLESS !== '0' ? userDataDirectory : '';
   }
 
+  await initModifiedUserAgent(browser, playwrightDeviceDetailsObject);
   const crawler = new crawlee.PlaywrightCrawler({
     launchContext: {
       launcher: constants.launcher,


### PR DESCRIPTION
This PR adds... <!-- A brief description of what your PR does -->

modifies the default user agent string used by our Playwright crawler. The changes ensure that:

- When headless mode is active, the substring "HeadlessChrome" is replaced with "Chrome" to better mimic a regular browser and help bypass detection.

<!-- This checklist is just a guideline.-->
<!-- If any of the following does not apply to your PR, please leave them unchecked and explain in the PR -->

- [x] I've kept this PR as small as possible (~500 lines) by splitting it into PRs with manageable chunks of code
- [ ] I've requested reviews from 1 reviewer
- [ ] I've tested existing features (website scan, sitemap, custom flow) in both node index and cli
- [ ] I've synced this fork with GovTechSG repo
- [ ] I've added/updated unit tests
- [ ] I've added/updated any necessary dependencies in `package[-lock].json` `npm audit`, portable installation on GitHub Actions
