### PR TITLE
fix: move element screenshots to report folder

### DIFF
--- a/src/mergeAxeResults.ts
+++ b/src/mergeAxeResults.ts
@@ -1644,6 +1644,7 @@ const generateArtifacts = async (
   ]);
 
   // move screenshots folder to report folders
+  moveElemScreenshots(randomToken, storagePath);
   if (isCustomFlow) {
     createScreenshotsFolder(randomToken);
   }


### PR DESCRIPTION
This PR adds back the function call that moves the screenshots to the reports folder.

- [x] I've kept this PR as small as possible (~500 lines) by splitting it into PRs with manageable chunks of code
- [x] I've requested reviews from 1 reviewer
- [x] I've tested existing features (website scan, sitemap, custom flow) in both node index and cli
