### PR TITLE
fix: use custom canvasFactory and crawl PDFs

### DIFF
--- a/src/crawlers/crawlDomain.ts
+++ b/src/crawlers/crawlDomain.ts
@@ -635,7 +635,7 @@ const crawlDomain = async ({
         }
 
         // handle pdfs
-        if (request.skipNavigation && isUrlPdf(actualUrl)) {
+        if (isScanPdfs && request.skipNavigation && actualUrl === "about:blank") {
           if (!isScanPdfs) {
             guiInfoLog(guiInfoStatusTypes.SKIPPED, {
               numScanned: urlsCrawled.scanned.length,
@@ -662,22 +662,6 @@ const crawlDomain = async ({
         }
 
         const resHeaders = response ? response.headers() : {}; // Safely access response headers
-        const contentType = resHeaders['content-type'] || ''; // Ensure contentType is defined
-
-        // Skip non-HTML and non-PDF URLs
-        if (!contentType.includes('text/html') && !contentType.includes('application/pdf')) {
-          guiInfoLog(guiInfoStatusTypes.SKIPPED, {
-            numScanned: urlsCrawled.scanned.length,
-            urlScanned: request.url,
-          });
-          urlsCrawled.blacklisted.push({
-            url: request.url,
-            pageTitle: request.url,
-            actualUrl: actualUrl, // i.e. actualUrl
-          });
-
-          return;
-        }
 
         if (isBlacklistedFileExtensions(actualUrl, blackListedFileExtensions)) {
           guiInfoLog(guiInfoStatusTypes.SKIPPED, {
@@ -704,7 +688,7 @@ const crawlDomain = async ({
           return;
         }
 
-        if (response.status() === 403) {
+        if (response && response.status() === 403) {
           guiInfoLog(guiInfoStatusTypes.SKIPPED, {
             numScanned: urlsCrawled.scanned.length,
             urlScanned: request.url,
@@ -718,7 +702,8 @@ const crawlDomain = async ({
           return;
         }
 
-        if (response.status() !== 200) {
+        if (response && response.status() !== 200) {
+
           guiInfoLog(guiInfoStatusTypes.SKIPPED, {
             numScanned: urlsCrawled.scanned.length,
             urlScanned: request.url,

--- a/src/crawlers/crawlDomain.ts
+++ b/src/crawlers/crawlDomain.ts
@@ -635,7 +635,7 @@ const crawlDomain = async ({
         }
 
         // handle pdfs
-        if (isScanPdfs && request.skipNavigation && actualUrl === "about:blank") {
+        if (request.skipNavigation && actualUrl === "about:blank") {
           if (!isScanPdfs) {
             guiInfoLog(guiInfoStatusTypes.SKIPPED, {
               numScanned: urlsCrawled.scanned.length,
@@ -660,8 +660,6 @@ const crawlDomain = async ({
           uuidToPdfMapping[pdfFileName] = url;
           return;
         }
-
-        const resHeaders = response ? response.headers() : {}; // Safely access response headers
 
         if (isBlacklistedFileExtensions(actualUrl, blackListedFileExtensions)) {
           guiInfoLog(guiInfoStatusTypes.SKIPPED, {

--- a/src/crawlers/crawlSitemap.ts
+++ b/src/crawlers/crawlSitemap.ts
@@ -246,7 +246,7 @@ const crawlSitemap = async (
         return;
       }
 
-      if (isUrlPdf(actualUrl)) {
+      if (request.skipNavigation && actualUrl === "about:blank") {
         if (!isScanPdfs) {
           guiInfoLog(guiInfoStatusTypes.SKIPPED, {
             numScanned: urlsCrawled.scanned.length,

--- a/src/crawlers/pdfScanFunc.ts
+++ b/src/crawlers/pdfScanFunc.ts
@@ -374,14 +374,21 @@ export const mapPdfScanResults = async (
       const { itemDetails, validationResult } = jobs[jobIdx];
       const { name: fileName } = itemDetails;
 
-      const uuid = fileName
-        .split(os.platform() === 'win32' ? '\\' : '/')
-        .pop()
-        .split('.')[0];
-      const url = uuidToUrlMapping[uuid];
-      const pageTitle = decodeURI(url).split('/').pop();
-      const filePath = `${randomToken}/${uuid}.pdf`;
+      const rawFileName = fileName.split(os.platform() === 'win32' ? '\\' : '/').pop();
+      const fileNameWithoutExt = rawFileName.replace(/\.pdf$/i, '');
 
+      const url =
+        uuidToUrlMapping[rawFileName] || // exact match like 'Some-filename.pdf'
+        uuidToUrlMapping[fileNameWithoutExt] || // uuid-based key like 'a9f7ebbd-5a90...'
+        `file://${fileName}`; // fallback
+
+      const filePath = `${randomToken}/${rawFileName}`;
+
+
+      const pageTitle = decodeURI(url).split('/').pop();
+      translated.url = url;
+      translated.pageTitle = pageTitle;
+      
       translated.url = url;
       translated.pageTitle = pageTitle;
       translated.filePath = filePath;

--- a/src/screenshotFunc/pdfScreenshotFunc.ts
+++ b/src/screenshotFunc/pdfScreenshotFunc.ts
@@ -69,6 +69,7 @@ export async function getPdfScreenshots(
   const newItems = _.cloneDeep(items);
   const loadingTask = getDocument({
     url: pdfFilePath,
+    canvasFactory,
     standardFontDataUrl: path.join(dirname, '../node_modules/pdfjs-dist/standard_fonts/'),
     disableFontFace: true,
     verbosity: 0,

--- a/src/screenshotFunc/pdfScreenshotFunc.ts
+++ b/src/screenshotFunc/pdfScreenshotFunc.ts
@@ -1,3 +1,10 @@
+// Monkey patch Path2D to avoid PDF.js crashing
+(globalThis as any).Path2D = class {
+  constructor(_path?: string) {}
+  rect(_x: number, _y: number, _width: number, _height: number) {}
+  addPath(_path: any, _transform?: any) {}
+};
+
 import _ from 'lodash';
 import  { getDocument, PDFPageProxy } from 'pdfjs-dist';
 import fs from 'fs';
@@ -25,11 +32,36 @@ interface pathObject {
   annot?: number;
 }
 
+// Ise safe canvas to avoid Path2D issues
+function createSafeCanvas(width: number, height: number) {
+  const canvas = createCanvas(width, height);
+  const ctx = canvas.getContext('2d');
+
+  // Patch clip/stroke/fill/etc. to skip if Path2D is passed
+  const wrapIgnorePath2D = (fn: Function) =>
+    function (...args: any[]) {
+      if (args.length > 0 && args[0] instanceof (globalThis as any).Path2D) {
+        // Skip the operation
+        return;
+      }
+      return fn.apply(this, args);
+    };
+
+  ctx.clip = wrapIgnorePath2D(ctx.clip);
+  ctx.fill = wrapIgnorePath2D(ctx.fill);
+  ctx.stroke = wrapIgnorePath2D(ctx.stroke);
+  ctx.isPointInPath = wrapIgnorePath2D(ctx.isPointInPath);
+  ctx.isPointInStroke = wrapIgnorePath2D(ctx.isPointInStroke);
+
+  return canvas;
+}
+
+// CanvasFactory for Node.js
 function NodeCanvasFactory() {}
 NodeCanvasFactory.prototype = {
   create: function NodeCanvasFactory_create(width: number, height: number) {
     assert(width > 0 && height > 0, 'Invalid canvas size');
-    const canvas = createCanvas(width, height);
+    const canvas = createSafeCanvas(width, height);
     const context = canvas.getContext('2d');
     return {
       canvas,

--- a/src/screenshotFunc/pdfScreenshotFunc.ts
+++ b/src/screenshotFunc/pdfScreenshotFunc.ts
@@ -32,7 +32,7 @@ interface pathObject {
   annot?: number;
 }
 
-// Ise safe canvas to avoid Path2D issues
+// Use safe canvas to avoid Path2D issues
 function createSafeCanvas(width: number, height: number) {
   const canvas = createCanvas(width, height);
   const ctx = canvas.getContext('2d');


### PR DESCRIPTION
This PR fixes:
- PDF screenshot by providing a custom canvasFactory to the PDF.
- Undefined filename and path for localFileScan
- Crawling and downloading PDFs with crawlDomain
- Safe canvasFactory to prevent screenshotting errors

- [x] I've kept this PR as small as possible (~500 lines) by splitting it into PRs with manageable chunks of code
- [x] I've requested reviews from 1 reviewer
- [x] I've tested existing features (website scan, sitemap, custom flow) in both node index and cli
