### PR TITLE
Double mutation count to account for websites loading

### DIFF
--- a/src/constants/common.ts
+++ b/src/constants/common.ts
@@ -1841,7 +1841,7 @@ export const waitForPageLoaded = async (page: Page, timeout = 10000) => {
 
         let timeout: NodeJS.Timeout;
         let mutationCount = 0;
-        const MAX_MUTATIONS = 250;
+        const MAX_MUTATIONS = 500;
         const mutationHash: Record<string, number> = {};
 
         const observer = new MutationObserver(mutationsList => {

--- a/src/crawlers/commonCrawlerFunc.ts
+++ b/src/crawlers/commonCrawlerFunc.ts
@@ -254,7 +254,7 @@ export const runAxeScript = async ({
       return new Promise(resolve => {
         let timeout: NodeJS.Timeout;
         let mutationCount = 0;
-        const MAX_MUTATIONS = 250;
+        const MAX_MUTATIONS = 500;
         const MAX_SAME_MUTATION_LIMIT = 10;
         const mutationHash: Record<string, number> = {};
 

--- a/src/crawlers/crawlDomain.ts
+++ b/src/crawlers/crawlDomain.ts
@@ -424,7 +424,7 @@ const crawlDomain = async ({
           return new Promise(resolve => {
             let timeout;
             let mutationCount = 0;
-            const MAX_MUTATIONS = 250; // stop if things never quiet down
+            const MAX_MUTATIONS = 500; // stop if things never quiet down
             const OBSERVER_TIMEOUT = 5000; // hard cap on total wait
 
             const observer = new MutationObserver(() => {

--- a/src/crawlers/crawlSitemap.ts
+++ b/src/crawlers/crawlSitemap.ts
@@ -206,7 +206,7 @@ const crawlSitemap = async ({
             return new Promise(resolve => {
               let timeout;
               let mutationCount = 0;
-              const MAX_MUTATIONS = 250; // stop if things never quiet down
+              const MAX_MUTATIONS = 500; // stop if things never quiet down
               const OBSERVER_TIMEOUT = 5000; // hard cap on total wait
 
               const observer = new MutationObserver(() => {


### PR DESCRIPTION
E.g. overlay loading at https://www.digitalforlife.gov.sg/about/contact/sg-digital-community-hub

This PR adds... <!-- A brief description of what your PR does -->

<!-- This checklist is just a guideline.-->
<!-- If any of the following does not apply to your PR, please leave them unchecked and explain in the PR -->

- [ ] I've kept this PR as small as possible (~500 lines) by splitting it into PRs with manageable chunks of code
- [ ] I've requested reviews from 1 reviewer
- [ ] I've tested existing features (website scan, sitemap, custom flow) in both node index and cli
- [ ] I've synced this fork with GovTechSG repo
- [ ] I've added/updated unit tests
- [ ] I've added/updated any necessary dependencies in `package[-lock].json` `npm audit`, portable installation on GitHub Actions
