### PR TITLE
Uses new system info v2 to avoid wmic dependency

### DIFF
--- a/src/combine.ts
+++ b/src/combine.ts
@@ -67,6 +67,12 @@ const combineRun = async (details: Data, deviceToScan: string) => {
   process.env.CRAWLEE_LOG_LEVEL = 'ERROR';
   process.env.CRAWLEE_STORAGE_DIR = randomToken;
 
+  if (process.env.CRAWLEE_SYSTEM_INFO_V2 === undefined) {
+  // Set the environment variable to enable system info v2
+  // Resolves issue with when wmic is not installed on Windows
+    process.env.CRAWLEE_SYSTEM_INFO_V2 = '1';
+  }
+  
   const host = type === ScannerTypes.SITEMAP || type === ScannerTypes.LOCALFILE ? '' : getHost(url);
 
   let blacklistedPatterns: string[] | null = null;


### PR DESCRIPTION
This PR adds... <!-- A brief description of what your PR does -->
- On Windows, wmic is a requirement to run crawlee.  Move to system info v2 to avoid the fatal error:
```
ERROR Memory snapshot failed.
  spawn wmic.exe ENOENT
      at ChildProcess._handle.onexit (node:internal/child_process:285:19)
      at onErrorNT (node:internal/child_process:483:16)
      at process.processTicksAndRejections (node:internal/process/task_queues:90:21)
{"timestamp":"2025-08-04 18:04:48","level":"error","message":"uncaughtException: spawn wmic.exe ENOENT\nError: spawn wmic.exe ENOENT\n    at ChildProcess._handle.onexit (node:internal/child_process:285:19)\n    at onErrorNT (node:internal/child_process:483:16)\n    at process.processTicksAndRejections (node:internal/process/task_queues:90:21)"}

```

<!-- This checklist is just a guideline.-->
<!-- If any of the following does not apply to your PR, please leave them unchecked and explain in the PR -->

- [x] I've kept this PR as small as possible (~500 lines) by splitting it into PRs with manageable chunks of code
- [ ] I've requested reviews from 1 reviewer
- [ ] I've tested existing features (website scan, sitemap, custom flow) in both node index and cli
- [ ] I've synced this fork with GovTechSG repo
- [ ] I've added/updated unit tests
- [ ] I've added/updated any necessary dependencies in `package[-lock].json` `npm audit`, portable installation on GitHub Actions
