### PR TITLE
Proxy Pac support, experimental flag disable file download

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,8 @@ verapdf --version
 | OOBEE_VALIDATE_URL| When set to `true`, validates if URLs are valid and exits. | `false` |
 | OOBEE_LOGS_PATH | When set, logs are written to this path. |  |
 | WARN_LEVEL | Only used in tests. |  |
+| OOBEE_DISABLE_BROWSER_DOWNLOAD | Experimental flag to disable file downloads on Chrome/Chromium/Edge.  Does not affect Local File scan | |
+| OOBEE_SLOWMO | Experimental flag to slow down web browser behaviour by specified duration (in miliseconds) | |
 
 #### Environment variables used internally (Do not set)
 Do not set these environment variables or behaviour might change unexpectedly.

--- a/src/constants/common.ts
+++ b/src/constants/common.ts
@@ -1742,6 +1742,17 @@ export const getPlaywrightLaunchOptions = (browser?: string): LaunchOptions => {
     if (!finalArgs.includes('--mute-audio')) finalArgs.push('--mute-audio');
   }
 
+  if (process.env.OOBEE_DISABLE_BROWSER_DOWNLOAD) {
+    const disableDownloadArgs = [
+        '--safebrowsing-disable-download-protection',
+        '--disable-features=DownloadInProgressEvent',
+    ];
+
+    for (const a of disableDownloadArgs) {
+        if (!finalArgs.includes(a)) finalArgs.push(a);
+    }
+  }
+
   // Map resolution to Playwright options
   let proxyOpt: ProxySettings | undefined;
   switch (resolution.kind) {

--- a/src/constants/common.ts
+++ b/src/constants/common.ts
@@ -304,6 +304,7 @@ const checkUrlConnectivityWithBrowser = async (
       ignoreHTTPSErrors: true,
       ...getPlaywrightLaunchOptions(browserToRun),
       ...playwrightDeviceDetailsObject,
+      ...(process.env.OOBEE_DISABLE_BROWSER_DOWNLOAD && { acceptDownloads: false }),
     });
 
     register(browserContext);
@@ -1740,17 +1741,6 @@ export const getPlaywrightLaunchOptions = (browser?: string): LaunchOptions => {
   if (process.env.CRAWLEE_HEADLESS === '1') {
     if (!finalArgs.includes('--headless=new')) finalArgs.push('--headless=new');
     if (!finalArgs.includes('--mute-audio')) finalArgs.push('--mute-audio');
-  }
-
-  if (process.env.OOBEE_DISABLE_BROWSER_DOWNLOAD) {
-    const disableDownloadArgs = [
-        '--safebrowsing-disable-download-protection',
-        '--disable-features=DownloadInProgressEvent',
-    ];
-
-    for (const a of disableDownloadArgs) {
-        if (!finalArgs.includes(a)) finalArgs.push(a);
-    }
   }
 
   // Map resolution to Playwright options

--- a/src/crawlers/crawlDomain.ts
+++ b/src/crawlers/crawlDomain.ts
@@ -368,6 +368,7 @@ const crawlDomain = async ({
             ...launchContext.launchOptions,
             ignoreHTTPSErrors: true,
             ...playwrightDeviceDetailsObject,
+            ...(process.env.OOBEE_DISABLE_BROWSER_DOWNLOAD && { acceptDownloads: false }),
             ...(extraHTTPHeaders && { extraHTTPHeaders }),
           };
 

--- a/src/crawlers/crawlLocalFile.ts
+++ b/src/crawlers/crawlLocalFile.ts
@@ -150,6 +150,7 @@ export const crawlLocalFile = async ({
       headless: process.env.CRAWLEE_HEADLESS === '1',
       ...getPlaywrightLaunchOptions(browser),
       ...playwrightDeviceDetailsObject,
+      ...(process.env.OOBEE_DISABLE_BROWSER_DOWNLOAD && { acceptDownloads: false }),
     });
 
     register(browserContext);

--- a/src/crawlers/crawlSitemap.ts
+++ b/src/crawlers/crawlSitemap.ts
@@ -135,6 +135,7 @@ const crawlSitemap = async ({
             ...launchContext.launchOptions,
             ignoreHTTPSErrors: true,
             ...playwrightDeviceDetailsObject,
+            ...(process.env.OOBEE_DISABLE_BROWSER_DOWNLOAD && { acceptDownloads: false }),
           };
 
           // Optionally log for debugging


### PR DESCRIPTION
This PR adds... <!-- A brief description of what your PR does -->
- Support for proxy.pac endpoint proxy
- Experimental flag to disable file downloads in Chrome/Chromium/Edge

<!-- This checklist is just a guideline.-->
<!-- If any of the following does not apply to your PR, please leave them unchecked and explain in the PR -->

- [x] I've kept this PR as small as possible (~500 lines) by splitting it into PRs with manageable chunks of code
- [ ] I've requested reviews from 1 reviewer
- [ ] I've tested existing features (website scan, sitemap, custom flow) in both node index and cli
- [ ] I've synced this fork with GovTechSG repo
- [ ] I've added/updated unit tests
- [ ] I've added/updated any necessary dependencies in `package[-lock].json` `npm audit`, portable installation on GitHub Actions
