### PR TITLE
fix: node bug preventing node e2e test from completion

### DIFF
--- a/src/constants/common.ts
+++ b/src/constants/common.ts
@@ -1257,14 +1257,14 @@ const cloneChromeProfileCookieFiles = (options: GlobOptionsWithFileTypesFalse, d
   if (os.platform() === 'win32') {
     profileCookiesDir = globSync('**/Network/Cookies', {
       ...options,
-      ignore: ['oobee/**'],
+      ignore: ['oobee*/**'],
     });
     profileNamesRegex = /User Data\\(.*?)\\Network/;
   } else if (os.platform() === 'darwin') {
     // maxDepth 2 to avoid copying cookies from the oobee directory if it exists
     profileCookiesDir = globSync('**/Cookies', {
       ...options,
-      ignore: 'oobee/**',
+      ignore: 'oobee*/**',
     });
     profileNamesRegex = /Chrome\/(.*?)\/Cookies/;
   }


### PR DESCRIPTION
This PR fixes a Node.js bug preventing e2e test completion when using Oobee as a module

<!-- This checklist is just a guideline.-->
<!-- If any of the following does not apply to your PR, please leave them unchecked and explain in the PR -->

- [x] I've kept this PR as small as possible (~500 lines) by splitting it into PRs with manageable chunks of code
- [ ] I've requested reviews from 1 reviewer
- [ ] I've tested existing features (website scan, sitemap, custom flow) in both node index and cli
- [ ] I've synced this fork with GovTechSG repo
- [ ] I've added/updated unit tests
- [ ] I've added/updated any necessary dependencies in `package[-lock].json` `npm audit`, portable installation on GitHub Actions
