### PR TITLE
N/A page counts in scan report when pagesScanned contains null pageTitle

### DIFF
--- a/src/static/ejs/partials/scripts/header/aboutScanModal/ScanConfiguration.ejs
+++ b/src/static/ejs/partials/scripts/header/aboutScanModal/ScanConfiguration.ejs
@@ -21,7 +21,7 @@
             >
           </div>
           <div class="display-url-container">
-            <a href="${page.url}" target="_blank">${page.pageTitle.length > 0 ? page.pageTitle : page.url}</a>
+            <a href="${page.url}" target="_blank">${page.pageTitle?.length > 0 ? page.pageTitle : page.url}</a>
             <p>${page.url}</p>
           </div>
         </div>
@@ -29,7 +29,7 @@
     } else {
       listItem.innerHTML = `
         <a href="${page.url}" target="_blank">
-          ${page.pageTitle.length > 0 ? page.pageTitle : page.url}
+          ${page.pageTitle?.length > 0 ? page.pageTitle : page.url}
           <svg class="link-external-icon" width="16" height="12" viewBox="0 0 8 8" aria-hidden="true" focusable="false">
             <path d="M7.11111 7.11111H0.888889V0.888889H4V0H0.888889C0.395556 0 0 0.4 0 0.888889V7.11111C0 7.6 0.395556 8 0.888889 8H7.11111C7.6 8 8 7.6 8 7.11111V4H7.11111V7.11111ZM4.88889 0V0.888889H6.48444L2.11556 5.25778L2.74222 5.88444L7.11111 1.51556V3.11111H8V0H4.88889Z" fill="#5735DF"/>
           </svg>


### PR DESCRIPTION
## Problem

In large scans, some entries in `pagesScanned` can have `pageTitle: null`. In
`ScanConfiguration.ejs`, the `forEach` that renders the pages scanned list
accessed `page.pageTitle.length` without a null guard, causing:

    Uncaught TypeError: Cannot read properties of null (reading 'length')

<img width="739" height="748" alt="image" src="https://github.com/user-attachments/assets/4a9cdbcb-04b6-4896-82aa-a57d26ecb098" />

This crash aborted the entire `forEach`, so all the code that follows — which
sets the "N/A" placeholders in the segmented tab labels to real counts — never
ran. The result: all three tab buttons ("Pages Scanned", "Pages Not Scanned",
"Unsupported Documents") permanently showed "N/A", even though the scan data
was valid.

## Fix

Use optional chaining (`page.pageTitle?.length`) in both the custom-flow and
standard branches of the `pagesScanned.forEach` loop so a null `pageTitle`
falls back to the URL instead of throwing.

This PR adds... <!-- A brief description of what your PR does -->

<!-- This checklist is just a guideline.-->
<!-- If any of the following does not apply to your PR, please leave them unchecked and explain in the PR -->

- [x] I've kept this PR as small as possible (~500 lines) by splitting it into PRs with manageable chunks of code
- [ ] I've requested reviews from 1 reviewer
- [ ] I've tested existing features (website scan, sitemap, custom flow) in both node index and cli
- [ ] I've synced this fork with GovTechSG repo
- [ ] I've added/updated unit tests
- [ ] I've added/updated any necessary dependencies in `package[-lock].json` `npm audit`, portable installation on GitHub Actions
