### PR TITLE
fix: correct ALL_PROXY scheme handling and warn on INCLUDE_PROXY with PAC-only proxy

### DIFF
--- a/src/proxyService.ts
+++ b/src/proxyService.ts
@@ -17,7 +17,9 @@ import path from 'path';
 import { spawnSync } from 'child_process';
 
 export interface ProxyInfo {
-  // host:port OR user:pass@host:port (no scheme)
+  // http/https: host:port OR user:pass@host:port (no scheme)
+  // socks: scheme://host:port OR scheme://user:pass@host:port (scheme preserved from ALL_PROXY)
+  //        OR bare host:port when sourced from scutil (defaults to socks5:// on use)
   http?: string;
   https?: string;
   socks?: string;
@@ -88,7 +90,7 @@ function parseEnvProxyCommon(): ProxyInfo | null {
   const info: ProxyInfo = {};
   if (http) info.http = stripScheme(http);
   if (https) info.https = stripScheme(https);
-  if (socks) info.socks = stripScheme(socks);
+  if (socks) info.socks = socks; // keep original scheme so proxyInfoToResolution can use the right protocol
   if (noProxy) info.bypassList = semiJoin(noProxy.split(/[,;]/));
 
   const { username, password } = readCredsFromEnv();
@@ -435,6 +437,15 @@ function buildIncludeOnlyPac(proxyServer: string, includeList: string[]): string
   return pac;
 }
 
+/**
+ * Convert an info.socks value to a full proxy server URL.
+ * When the value already carries a scheme (e.g. ALL_PROXY=http://..., socks4://...),
+ * it is used as-is. Bare host:port values (from scutil) default to socks5://.
+ */
+function toSocksServer(socks: string): string {
+  return /^[a-zA-Z][a-zA-Z0-9+.-]*:\/\//.test(socks) ? socks : `socks5://${socks}`;
+}
+
 export function proxyInfoToResolution(info: ProxyInfo | null): ProxyResolution {
   if (!info) return { kind: 'none' };
 
@@ -444,7 +455,7 @@ export function proxyInfoToResolution(info: ProxyInfo | null): ProxyResolution {
     let proxyServer: string | undefined;
     if (info.http) proxyServer = `http://${info.http}`;
     else if (info.https) proxyServer = `http://${info.https}`;
-    else if (info.socks) proxyServer = `socks5://${info.socks}`;
+    else if (info.socks) proxyServer = toSocksServer(info.socks);
 
     if (proxyServer) {
       // If credentials exist, embed them for the manual proxy auth
@@ -457,6 +468,16 @@ export function proxyInfoToResolution(info: ProxyInfo | null): ProxyResolution {
       const pacDataUrl = `data:application/x-ns-proxy-autoconfig;base64,${Buffer.from(pac).toString('base64')}`;
       return { kind: 'pac', pacUrl: pacDataUrl, bypass: info.bypassList };
     }
+
+    // No direct proxy server was found — the configured proxy is PAC-based or auto-detect only.
+    // INCLUDE_PROXY needs a concrete server address to build a routing PAC script, so it cannot
+    // be applied here. Warn and fall through to use the existing PAC/autodetect as-is.
+    console.warn(
+      'INCLUDE_PROXY is set but no direct proxy server address was found. ' +
+      'INCLUDE_PROXY requires HTTP_PROXY, HTTPS_PROXY, or ALL_PROXY to be set with a direct ' +
+      'server address; it cannot be applied to a PAC URL or auto-detect proxy. ' +
+      'INCLUDE_PROXY will be ignored.',
+    );
   }
 
   // Prefer manual proxies first (these work with Playwright's proxy option)
@@ -478,7 +499,7 @@ export function proxyInfoToResolution(info: ProxyInfo | null): ProxyResolution {
   }
   if (info.socks) {
     return { kind: 'manual', settings: {
-      server: `socks5://${info.socks}`,
+      server: toSocksServer(info.socks),
       username: info.username,
       password: info.password,
       bypass: info.bypassList,


### PR DESCRIPTION
<h2 style="color: rgb(191, 191, 191); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(18, 19, 20); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Summary</h2><ul style="padding-inline-start: 2em; color: rgb(191, 191, 191); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(18, 19, 20); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">ALL_PROXY=http://proxy:8080</code><span> </span>was silently mis-routed as a SOCKS5 proxy because<span> </span><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">stripScheme()</code><span> </span>discarded the original scheme and<span> </span><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">proxyInfoToResolution</code><span> </span>always reconstructed it with<span> </span><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">socks5://</code>. The scheme is now preserved in<span> </span><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">ProxyInfo.socks</code><span> </span>and a new<span> </span><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">toSocksServer()</code><span> </span>helper is used to apply the correct scheme (defaulting to<span> </span><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">socks5://</code><span> </span>only for bare<span> </span><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">host:port</code><span> </span>values that come from macOS scutil).</li><li>When<span> </span><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">INCLUDE_PROXY</code><span> </span>is set but the configured proxy is PAC-based or auto-detect only (e.g. Windows registry with<span> </span><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">AutoConfigURL</code><span> </span>but no<span> </span><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">ProxyServer</code>),<span> </span><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">INCLUDE_PROXY</code><span> </span>was silently dropped with no feedback. It now emits a<span> </span><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">console.warn</code><span> </span>explaining the incompatibility and what the user must set to resolve it.</li></ul><h2 style="color: rgb(191, 191, 191); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(18, 19, 20); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Root causes</h2><h3 style="color: rgb(191, 191, 191); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(18, 19, 20); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">ALL_PROXY</code><span> </span>scheme forced to<span> </span><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">socks5://</code><span> </span>on all platforms</h3><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(191, 191, 191); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(18, 19, 20); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">In <code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">parseEnvProxyCommon</code>, the value of <code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">ALL_PROXY</code> was passed through <code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">stripScheme()</code> before storing in <code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">info.socks</code>. Every downstream consumer then unconditionally prepended <code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">socks5://</code>, so <code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">ALL_PROXY=http://proxy:8080</code> became <code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">socks5://proxy:8080</code> — causing connection failures against standard HTTP forward proxies.</p><h3 style="color: rgb(191, 191, 191); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(18, 19, 20); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">INCLUDE_PROXY</code><span> </span>silently ignored with PAC-based proxy (common on Windows)</h3><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(191, 191, 191); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(18, 19, 20); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">proxyInfoToResolution</code> can only build an INCLUDE-only PAC script when a concrete server address (<code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">info.http</code>, <code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">info.https</code>, or <code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">info.socks</code>) is available. When the proxy comes from a PAC URL (<code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">info.pacUrl</code>) — typical in enterprise Windows environments where <code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">AutoConfigURL</code> is set in the registry but <code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">ProxyServer</code> is not — <code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">proxyServer</code> resolved to <code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">undefined</code>, the PAC-building branch was skipped without any log output, and the original registry PAC URL was returned unchanged.</p><h2 style="color: rgb(191, 191, 191); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(18, 19, 20); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Changes (<code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">src/proxyService.ts</code>)</h2>

```
Location | Change
-- | --
ProxyInfo.socks (interface comment) | Updated to document that socks may carry a full scheme when sourced from ALL_PROXY
parseEnvProxyCommon | info.socks = socks — scheme no longer stripped from ALL_PROXY
new toSocksServer() | Returns the value as-is when a scheme is present; prepends socks5:// for bare host:port (scutil)
proxyInfoToResolution — INCLUDE_PROXY branch | Uses toSocksServer(info.socks) instead of template literal
proxyInfoToResolution — INCLUDE_PROXY branch | Emits console.warn when proxyServer is undefined (PAC-only proxy), then falls through
proxyInfoToResolution — manual SOCKS branch | Uses toSocksServer(info.socks) instead of template literal
```

<h2 style="color: rgb(191, 191, 191); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(18, 19, 20); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Test plan</h2><ul class="contains-task-list" style="padding-inline-start: 2em; color: rgb(191, 191, 191); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(18, 19, 20); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li class="task-list-item"><input type="checkbox" disabled="" style="appearance: none; border-color: rgb(42, 43, 44); border-style: solid; border-width: 0.833333px; border-image: none 100% / 1 / 0 stretch; position: relative; pointer-events: none; vertical-align: middle; border-radius: 2px; width: 1em; height: 1em; margin: 2px 4px 2px 2px;"><span> </span><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">ALL_PROXY=socks5://proxy:1080</code><span> </span>— proxy server is<span> </span><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">socks5://proxy:1080</code><span> </span>(unchanged behaviour)</li><li class="task-list-item"><input type="checkbox" disabled="" style="appearance: none; border-color: rgb(42, 43, 44); border-style: solid; border-width: 0.833333px; border-image: none 100% / 1 / 0 stretch; position: relative; pointer-events: none; vertical-align: middle; border-radius: 2px; width: 1em; height: 1em; margin: 2px 4px 2px 2px;"><span> </span><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">ALL_PROXY=socks4://proxy:1080</code><span> </span>— proxy server is<span> </span><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">socks4://proxy:1080</code><span> </span>(was<span> </span><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">socks5://</code><span> </span>before)</li><li class="task-list-item"><input type="checkbox" disabled="" style="appearance: none; border-color: rgb(42, 43, 44); border-style: solid; border-width: 0.833333px; border-image: none 100% / 1 / 0 stretch; position: relative; pointer-events: none; vertical-align: middle; border-radius: 2px; width: 1em; height: 1em; margin: 2px 4px 2px 2px;"><span> </span><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">ALL_PROXY=http://proxy:8080</code><span> </span>— proxy server is<span> </span><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">http://proxy:8080</code><span> </span>(was<span> </span><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">socks5://</code><span> </span>before)</li><li class="task-list-item"><input type="checkbox" disabled="" style="appearance: none; border-color: rgb(42, 43, 44); border-style: solid; border-width: 0.833333px; border-image: none 100% / 1 / 0 stretch; position: relative; pointer-events: none; vertical-align: middle; border-radius: 2px; width: 1em; height: 1em; margin: 2px 4px 2px 2px;"><span> </span><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">ALL_PROXY=socks5://proxy:1080</code><span> </span>+<span> </span><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">INCLUDE_PROXY=*.example.com</code><span> </span>— PAC built with<span> </span><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">SOCKS5 proxy:1080</code></li><li class="task-list-item"><input type="checkbox" disabled="" style="appearance: none; border-color: rgb(42, 43, 44); border-style: solid; border-width: 0.833333px; border-image: none 100% / 1 / 0 stretch; position: relative; pointer-events: none; vertical-align: middle; border-radius: 2px; width: 1em; height: 1em; margin: 2px 4px 2px 2px;"><span> </span><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">HTTP_PROXY=http://proxy:8080</code><span> </span>+<span> </span><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">INCLUDE_PROXY=*.example.com</code><span> </span>— PAC built with<span> </span><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">PROXY proxy:8080</code></li><li class="task-list-item"><input type="checkbox" disabled="" style="appearance: none; border-color: rgb(42, 43, 44); border-style: solid; border-width: 0.833333px; border-image: none 100% / 1 / 0 stretch; position: relative; pointer-events: none; vertical-align: middle; border-radius: 2px; width: 1em; height: 1em; margin: 2px 4px 2px 2px;"><span> </span>Windows registry with<span> </span><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">AutoConfigURL</code><span> </span>only +<span> </span><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">INCLUDE_PROXY</code><span> </span>set —<span> </span><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">console.warn</code><span> </span>is printed, original PAC URL is used</li><li class="task-list-item"><input type="checkbox" disabled="" style="appearance: none; border-color: rgb(42, 43, 44); border-style: solid; border-width: 0.833333px; border-image: none 100% / 1 / 0 stretch; position: relative; pointer-events: none; vertical-align: middle; border-radius: 2px; width: 1em; height: 1em; margin: 2px 4px 2px 2px;"><span> </span>macOS scutil SOCKS (<code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">host:port</code>, no scheme) — still resolves to<span> </span><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">socks5://host:port</code></li></ul>

This PR adds... <!-- A brief description of what your PR does -->

<!-- This checklist is just a guideline.-->
<!-- If any of the following does not apply to your PR, please leave them unchecked and explain in the PR -->

- [ ] I've kept this PR as small as possible (~500 lines) by splitting it into PRs with manageable chunks of code
- [ ] I've requested reviews from 1 reviewer
- [ ] I've tested existing features (website scan, sitemap, custom flow) in both node index and cli
- [ ] I've synced this fork with GovTechSG repo
- [ ] I've added/updated unit tests
- [ ] I've added/updated any necessary dependencies in `package[-lock].json` `npm audit`, portable installation on GitHub Actions
