### PR TITLE
feat: add OOBEE_SCAN_METADATA and OOBEE_SCAN_PRODUCT Sentry context overrides

### DIFF
--- a/src/mergeAxeResults/sentryTelemetry.ts
+++ b/src/mergeAxeResults/sentryTelemetry.ts
@@ -140,7 +140,10 @@ const sendWcagBreakdownToSentry = async (
         event_type: 'accessibility_scan',
         scanType: scanInfo.scanType,
         browser: scanInfo.browser,
-        entryUrl: scanInfo.entryUrl,
+        entryUrl: process.env.OOBEE_SCAN_METADATA ?? scanInfo.entryUrl,
+        ...(process.env.OOBEE_SCAN_PRODUCT && {
+          scanProduct: process.env.OOBEE_SCAN_PRODUCT,
+        }),
       },
       user: {
         ...(scanInfo.email && scanInfo.name


### PR DESCRIPTION
## Summary

- Override Sentry `entryUrl` tag with `OOBEE_SCAN_METADATA` env var when set, so tenant scans are identifiable by live product URL rather than the internal crawl seed URL
- Add `scanProduct` Sentry tag from `OOBEE_SCAN_PRODUCT` env var (e.g. `"WebSG"`) — tag is omitted entirely when the env var is absent, so non-tenant scans are unaffected

Both env vars are forwarded by `oobee-engine-wrapper` only when present, injected via ECS `containerOverrides` from the tenant scan submission flow.

This PR adds... <!-- A brief description of what your PR does -->

<!-- This checklist is just a guideline.-->
<!-- If any of the following does not apply to your PR, please leave them unchecked and explain in the PR -->

- [ ] I've kept this PR as small as possible (~500 lines) by splitting it into PRs with manageable chunks of code
- [ ] I've requested reviews from 1 reviewer
- [ ] I've tested existing features (website scan, sitemap, custom flow) in both node index and cli
- [ ] I've synced this fork with GovTechSG repo
- [ ] I've added/updated unit tests
- [ ] I've added/updated any necessary dependencies in `package[-lock].json` `npm audit`, portable installation on GitHub Actions
