### PR TITLE
Fix custom flow entry URL to not use redirected URL

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -250,7 +250,11 @@ const scanInit = async (argvs: Answers): Promise<string> => {
     consoleLogger.info(`Connectivity Check HTTP Response Code: ${res.httpStatus}`);
 
   if (res.status === statuses.success.code) {
-    data.url = res.url;
+    // Custom flow should continue from the user-provided entry URL so auth redirects
+    // do not replace the original domain used for overlay gating and navigation.
+    if (data.type !== ScannerTypes.CUSTOM) {
+      data.url = res.url;
+    }
     if (process.env.OOBEE_VALIDATE_URL) {
       consoleLogger.info('Url is valid');
       cleanUpAndExit(0, data.randomToken);

--- a/src/crawlers/custom/utils.ts
+++ b/src/crawlers/custom/utils.ts
@@ -40,6 +40,7 @@ const RESTRICT_OVERLAY_TO_ENTRY_DOMAIN = parseBoolEnv(
   process.env.RESTRICT_OVERLAY_TO_ENTRY_DOMAIN,
   false,
 );
+const OVERLAY_OPERATION_TIMEOUT_MS = 5000;
 
 const isOverlayAllowed = (currentUrl: string, entryUrl: string) => {
   try {
@@ -306,7 +307,7 @@ export const addOverlayMenu = async (
     collapsed: false,
   },
 ) => {
-  await page.waitForLoadState('domcontentloaded');
+  await page.waitForLoadState('domcontentloaded', { timeout: OVERLAY_OPERATION_TIMEOUT_MS });
   consoleLogger.info(`Overlay menu: adding to ${menuPos}...`);
 
   // Add the overlay menu with initial styling
@@ -1143,6 +1144,7 @@ export const addOverlayMenu = async (
     })
     .catch(error => {
       consoleLogger.error('Overlay menu: failed to add', error);
+      throw error;
     });
 };
 
@@ -1226,7 +1228,18 @@ export const initNewPage = async (page, pageClosePromises, processPageParams, pa
         const allowed = isOverlayAllowed(page.url(), processPageParams.entryUrl);
 
         if (!allowed) {
-          await removeOverlayMenu(page);
+          await Promise.race([
+            removeOverlayMenu(page),
+            new Promise((_, reject) => {
+              setTimeout(() => {
+                reject(
+                  new Error(
+                    `removeOverlayMenu timed out after ${OVERLAY_OPERATION_TIMEOUT_MS}ms`,
+                  ),
+                );
+              }, OVERLAY_OPERATION_TIMEOUT_MS);
+            }),
+          ]);
           return;
         }
 
@@ -1239,11 +1252,20 @@ export const initNewPage = async (page, pageClosePromises, processPageParams, pa
         if (!hasOverlay) {
           // Recreate the overlay after allowed redirects while preserving current UI state.
           consoleLogger.info(`Adding overlay menu to page (${trigger}): ${page.url()}`);
-          await addOverlayMenu(page, processPageParams.urlsCrawled, menuPos, {
-            inProgress: !!pagesDict[pageId]?.isScanning,
-            collapsed: !!pagesDict[pageId]?.collapsed,
-            hideStopInput: !!processPageParams.customFlowLabel,
-          });
+          await Promise.race([
+            addOverlayMenu(page, processPageParams.urlsCrawled, menuPos, {
+              inProgress: !!pagesDict[pageId]?.isScanning,
+              collapsed: !!pagesDict[pageId]?.collapsed,
+              hideStopInput: !!processPageParams.customFlowLabel,
+            }),
+            new Promise((_, reject) => {
+              setTimeout(() => {
+                reject(
+                  new Error(`addOverlayMenu timed out after ${OVERLAY_OPERATION_TIMEOUT_MS}ms`),
+                );
+              }, OVERLAY_OPERATION_TIMEOUT_MS);
+            }),
+          ]);
         }
       })
       .catch(() => {

--- a/src/crawlers/custom/utils.ts
+++ b/src/crawlers/custom/utils.ts
@@ -1165,6 +1165,8 @@ export const removeOverlayMenu = async page => {
 
 export const initNewPage = async (page, pageClosePromises, processPageParams, pagesDict) => {
   let menuPos = MENU_POSITION.right;
+  let overlayRefreshSeq = 0;
+  let overlayRefreshChain = Promise.resolve();
 
   // eslint-disable-next-line no-underscore-dangle
   const pageId = page._guid;
@@ -1194,6 +1196,63 @@ export const initNewPage = async (page, pageClosePromises, processPageParams, pa
     };
   }
 
+  const reconcileOverlayMenu = async (trigger: string) => {
+    // Mark this as the latest refresh so older ones can stop.
+    const refreshSeq = ++overlayRefreshSeq;
+
+    // Serialize overlay updates so multiple navigation events do not add/remove concurrently.
+    overlayRefreshChain = overlayRefreshChain
+      .catch(() => {})
+      .then(async () => {
+        if (refreshSeq !== overlayRefreshSeq || page.isClosed()) return;
+
+        try {
+          // `framenavigated` can fire before the new document is ready for DOM inspection/injection.
+          await page.waitForLoadState('domcontentloaded', { timeout: 5000 });
+        } catch {
+          // Best effort only. The page may still be mid-navigation.
+        }
+
+        try {
+          // Give fast redirect chains a brief chance to advance before we inject/remove the overlay.
+          await page.waitForTimeout(300);
+        } catch {
+          // Best effort only. The page may already be closing.
+        }
+
+        // Re-check staleness after waiting because a newer navigation may have happened meanwhile.
+        if (refreshSeq !== overlayRefreshSeq || page.isClosed()) return;
+
+        const allowed = isOverlayAllowed(page.url(), processPageParams.entryUrl);
+
+        if (!allowed) {
+          await removeOverlayMenu(page);
+          return;
+        }
+
+        const hasOverlay = await page.evaluate(() =>
+          Boolean(document.querySelector('#oobeeShadowHost')),
+        );
+
+        consoleLogger.info(`Overlay state (${trigger}): ${hasOverlay}`);
+
+        if (!hasOverlay) {
+          // Recreate the overlay after allowed redirects while preserving current UI state.
+          consoleLogger.info(`Adding overlay menu to page (${trigger}): ${page.url()}`);
+          await addOverlayMenu(page, processPageParams.urlsCrawled, menuPos, {
+            inProgress: !!pagesDict[pageId]?.isScanning,
+            collapsed: !!pagesDict[pageId]?.collapsed,
+            hideStopInput: !!processPageParams.customFlowLabel,
+          });
+        }
+      })
+      .catch(() => {
+        consoleLogger.info('Error in adding overlay menu to page');
+      });
+
+    await overlayRefreshChain;
+  };
+
   type handleOnScanClickFunction = () => void;
 
   // Window functions exposed in browser
@@ -1208,17 +1267,7 @@ export const initNewPage = async (page, pageClosePromises, processPageParams, pa
       pagesDict[pageId].isScanning = false;
 
       if (page.isClosed()) return;
-      const allowed = isOverlayAllowed(page.url(), processPageParams.entryUrl);
-
-      if (allowed) {
-        await addOverlayMenu(page, processPageParams.urlsCrawled, menuPos, {
-          inProgress: false,
-          collapsed: !!pagesDict[pageId]?.collapsed,
-          hideStopInput: !!processPageParams.customFlowLabel,
-        });
-      } else {
-        await removeOverlayMenu(page);
-      }
+      await reconcileOverlayMenu('scan-click');
     } catch (error) {
       log(`Scan failed ${error}`);
     }
@@ -1282,40 +1331,23 @@ export const initNewPage = async (page, pageClosePromises, processPageParams, pa
 
   page.on('domcontentloaded', async () => {
     if (page.isClosed()) return;
-    try {
-      const allowed = isOverlayAllowed(page.url(), processPageParams.entryUrl);
+    await reconcileOverlayMenu('domcontentloaded');
 
-      if (!allowed) {
-        await removeOverlayMenu(page);
-        return;
+    if (isCypressTest) {
+      try {
+        await handleOnScanClick();
+        page.close();
+      } catch {
+        consoleLogger.info(
+          `Error in calling handleOnScanClick, isCypressTest: ${isCypressTest}`,
+        );
       }
-
-      const existingOverlay = await page.evaluate(() => {
-        return document.querySelector('#oobeeShadowHost');
-      });
-
-      consoleLogger.info(`Overlay state: ${existingOverlay}`);
-
-      if (!existingOverlay) {
-        consoleLogger.info(`Adding overlay menu to page: ${page.url()}`);
-        await addOverlayMenu(page, processPageParams.urlsCrawled, menuPos, {
-          inProgress: !!pagesDict[pageId]?.isScanning,
-          collapsed: !!pagesDict[pageId]?.collapsed,
-          hideStopInput: !!processPageParams.customFlowLabel,
-        });
-      }
-
-      if (isCypressTest) {
-        try {
-          await handleOnScanClick();
-          page.close();
-        } catch {
-          consoleLogger.info(`Error in calling handleOnScanClick, isCypressTest: ${isCypressTest}`);
-        }
-      }
-    } catch {
-      consoleLogger.info('Error in adding overlay menu to page');
     }
+  });
+
+  page.on('framenavigated', async (frame: any) => {
+    if (frame !== page.mainFrame() || page.isClosed()) return;
+    await reconcileOverlayMenu('framenavigated');
   });
 
   try {
@@ -1336,6 +1368,8 @@ export const initNewPage = async (page, pageClosePromises, processPageParams, pa
   } catch (e) {
     log(`Error exposing functions on page: ${e}`);
   }
+
+  await reconcileOverlayMenu('init');
 
   return page;
 };


### PR DESCRIPTION
### Problem

Custom flow scans were broken in two ways:

1. Entry URL was replaced by the redirected URL after the connectivity
   check. This caused isOverlayAllowed() to compare against the wrong
   domain, so the overlay would disappear or fail to appear on pages
   that should have shown it.

2. Race conditions in overlay management - domcontentloaded and other
   navigation events could fire concurrently, causing the overlay to be
   injected and removed out of order, leading to flickering or a
   missing overlay.

### Changes

src/cli.ts
- Skip overwriting data.url with the redirected URL when the scan type
  is CUSTOM, preserving the user-provided entry URL for overlay domain
  gating.

src/crawlers/custom/utils.ts
- Introduced reconcileOverlayMenu(), a serialized helper that
  consolidates all overlay add/remove logic previously duplicated
  across event handlers.
- Uses a sequence counter (overlayRefreshSeq) to cancel stale updates
  when a newer navigation supersedes them.
- Uses a promise chain (overlayRefreshChain) to serialize concurrent
  navigation events so overlay updates never race.
- Adds a 300ms debounce after domcontentloaded to let fast redirect
  chains settle before injecting the overlay.
- Adds a framenavigated listener to handle SPA-style navigations that
  do not trigger domcontentloaded.
- Calls reconcileOverlayMenu('init') at page setup to seed the overlay
  immediately on page creation.

### Testing

- Verify custom flow scans on sites that redirect on login (e.g.
  SSO/OAuth flows) retain the overlay on the original domain.
- Verify the overlay does not flicker or disappear during multi-step
  redirect chains.
- Verify SPA navigation within an allowed domain keeps the overlay
  visible.
- Verify navigation to a disallowed domain correctly removes the
  overlay.