### PR TITLE
Reduce embedded report payload by omitting page.items from scanItems-…

### DIFF
--- a/src/generateHtmlReport.ts
+++ b/src/generateHtmlReport.ts
@@ -22,6 +22,7 @@ import constants, {
   a11yRuleShortDescriptionMap,
   disabilityBadgesMap,
   a11yRuleLongDescriptionMap,
+  a11yRuleStepByStepGuide,
 } from './constants/constants.js';
 
 import { consoleLogger } from './logs.js';
@@ -65,7 +66,12 @@ const ensureCategory = (
     if (typeof rule.totalItems !== 'number') {
       rule.totalItems = rule.pagesAffected.reduce(
         (accumulate: number, page: any) =>
-          accumulate + (Array.isArray(page.items) ? page.items.length : 0),
+          accumulate +
+          (Array.isArray(page.items)
+            ? page.items.length
+            : typeof page.itemsCount === 'number'
+              ? page.itemsCount
+              : 0),
         0,
       );
     }
@@ -87,7 +93,10 @@ const ensureCategory = (
   };
 };
 
-export const generateHtmlReport = async (resultDir: string): Promise<string> => {
+export const generateHtmlReport = async (
+  resultDir: string,
+  htmlFilename = 'report',
+): Promise<string> => {
   try {
     const storagePath = path.resolve(resultDir);
     const scanDataJsonPath = path.join(storagePath, 'scanData.json');
@@ -117,24 +126,22 @@ export const generateHtmlReport = async (resultDir: string): Promise<string> => 
     const scanData = JSON.parse(await fs.readFile(scanDataJsonPath, 'utf8'));
     const scanItemsAll = JSON.parse(await fs.readFile(scanItemsJsonPath, 'utf8'));
 
-    // Use convertItemsToReferences to normalize items structure to match scanItemsWithHtmlGroupRefs format
-    const scanItemsWithHtmlGroupRefs = convertItemsToReferences({
+    // Build the lighter scanItems payload used by the HTML report.
+    const lightScanItemsPayload = convertItemsToReferences({
       items: scanItemsAll,
-      ...scanData
     });
 
     const {
       mustFix = {},
       goodToFix = {},
       needsReview = {},
-      passed = {},
-    } = scanItemsWithHtmlGroupRefs;
+    } = lightScanItemsPayload;
 
     const items = {
       mustFix: ensureCategory(mustFix, 'mustFix'),
       goodToFix: ensureCategory(goodToFix, 'goodToFix'),
       needsReview: ensureCategory(needsReview, 'needsReview'),
-      passed: ensureCategory(passed, 'passed'),
+      passed: ensureCategory(scanItemsAll.passed || {}, 'passed'),
     };
 
     const pagesScanned = Array.isArray(scanData.pagesScanned) ? scanData.pagesScanned : [];
@@ -183,6 +190,8 @@ export const generateHtmlReport = async (resultDir: string): Promise<string> => 
       a11yRuleShortDescriptionMap,
       disabilityBadgesMap,
       a11yRuleLongDescriptionMap,
+      a11yRuleStepByStepGuide,
+      wcagCriteriaLabels: constants.wcagCriteriaLabels,
       advancedScanOptionsSummaryItems: {
         showIncludeScreenshots: !!scanData.advancedScanOptionsSummaryItems?.showIncludeScreenshots,
         showAllowSubdomains: !!scanData.advancedScanOptionsSummaryItems?.showAllowSubdomains,
@@ -217,10 +226,11 @@ export const generateHtmlReport = async (resultDir: string): Promise<string> => 
       (allIssues as any).advancedScanOptionsSummaryItems?.disableOobee,
     );
 
-    await writeHTML(allIssues, storagePath, 'report', scanDataB64Path, scanItemsB64Path);
+    await writeHTML(allIssues, storagePath, htmlFilename, scanDataB64Path, scanItemsB64Path);
 
-    consoleLogger.info(`Report generated at: ${path.join(storagePath, 'report.html')}`);
-    return path.join(storagePath, 'report.html');
+    const outputPath = path.join(storagePath, `${htmlFilename}.html`);
+    consoleLogger.info(`Report generated at: ${outputPath}`);
+    return outputPath;
   } catch (err: any) {
     consoleLogger.error(`generateHtmlReport failed: ${err?.message || err}`);
     throw err;

--- a/src/mergeAxeResults.ts
+++ b/src/mergeAxeResults.ts
@@ -185,15 +185,15 @@ const writeHTML = async (
     'utf-8',
   );
 
-  // Create lighter version with item references for embedding in HTML
-  const scanItemsWithHtmlGroupRefs = convertItemsToReferences(allIssues);
+  // Create the lighter scanItems payload for embedding in the HTML report.
+  const lightScanItemsPayload = convertItemsToReferences(allIssues);
 
   // Write the lighter items to a file and get the base64 path
   const {
-    jsonFilePath: scanItemsWithHtmlGroupRefsJsonFilePath,
-    base64FilePath: scanItemsWithHtmlGroupRefsBase64FilePath,
+    jsonFilePath: lightScanItemsPayloadJsonFilePath,
+    base64FilePath: lightScanItemsPayloadBase64FilePath,
   } = await writeJsonFileAndCompressedJsonFile(
-    scanItemsWithHtmlGroupRefs.items,
+    lightScanItemsPayload,
     storagePath,
     'scanItems-light',
   );
@@ -212,8 +212,8 @@ const writeHTML = async (
         await Promise.all([
           fs.promises.unlink(topFilePath),
           fs.promises.unlink(bottomFilePath),
-          fs.promises.unlink(scanItemsWithHtmlGroupRefsBase64FilePath),
-          fs.promises.unlink(scanItemsWithHtmlGroupRefsJsonFilePath),
+          fs.promises.unlink(lightScanItemsPayloadBase64FilePath),
+          fs.promises.unlink(lightScanItemsPayloadJsonFilePath),
         ]);
       } catch (err) {
         console.error('Error cleaning up temporary files:', err);
@@ -251,6 +251,9 @@ const writeHTML = async (
   } else {
     console.warn('Skipping fetch GenAI feature as it is local report');
   }
+
+  var scanData = null;
+  var scanItems = null;
   \n`);
 
     outputStream.write('</script>\n<script type="text/plain" id="scanDataRaw">');
@@ -259,14 +262,14 @@ const writeHTML = async (
     scanDetailsReadStream.on('end', async () => {
       outputStream.write('</script>\n<script>\n');
       outputStream.write(
-        "var scanDataPromise = (async () => { console.log('Loading scanData...'); scanData = await decodeUnzipParse(document.getElementById('scanDataRaw').textContent); })();\n",
+        "var scanDataPromise = (async () => { console.log('Loading scanData...'); scanData = await decodeUnzipParse(document.getElementById('scanDataRaw').textContent); console.log('[report] scanData loaded'); })();\n",
       );
       outputStream.write('</script>\n');
 
       // Write scanItems in 2MB chunks using a stream to avoid loading entire file into memory
       try {
         let chunkIndex = 1;
-        const scanItemsStream = fs.createReadStream(scanItemsWithHtmlGroupRefsBase64FilePath, {
+        const scanItemsStream = fs.createReadStream(lightScanItemsPayloadBase64FilePath, {
           encoding: 'utf8',
           highWaterMark: CHUNK_SIZE,
         });
@@ -291,6 +294,7 @@ var scanItemsPromise = (async () => {
     i++;
   }
   scanItems = await decodeUnzipParse(chunks);
+  console.log('[report] scanItems loaded');
 })();\n`);
         outputStream.write(suffixData);
         outputStream.end();

--- a/src/mergeAxeResults/itemReferences.ts
+++ b/src/mergeAxeResults/itemReferences.ts
@@ -1,5 +1,9 @@
 import type { AllIssues, ItemsInfo, RuleInfo } from './types.js';
 
+type ScanItems = AllIssues['items'];
+type ScanCategory = ScanItems[keyof ScanItems];
+type ScanItemsLight = Pick<ScanItems, 'mustFix' | 'goodToFix' | 'needsReview' | 'passed'>;
+
 /**
  * Builds pre-computed HTML groups to optimize Group by HTML Element functionality.
  * Keys are composite "html\x00xpath" strings to ensure unique matching per element instance.
@@ -31,32 +35,71 @@ export const buildHtmlGroups = (rule: RuleInfo, items: ItemsInfo[], pageUrl: str
   });
 };
 
+/*
+// Commenting this out for now as we are not including htmlGroups in the embedded report payload to keep it lean.
+// We can revisit this if we want to include htmlGroups in the future and need a reference builder for it.
+const toHtmlGroupReference = (item: any) => {
+  if (typeof item === 'string') {
+    return item;
+  }
+
+  return `${item?.html || 'No HTML element'}\x00${item?.xpath || ''}`;
+};
+
+const cloneCategoryWithReferenceItems = (category: ScanCategory): ScanCategory =>
+  ({
+    ...category,
+    rules: category.rules.map(
+      rule =>
+        ({
+          ...rule,
+          pagesAffected: rule.pagesAffected.map(
+            page => {
+              const { items, ...pageWithoutItems } = page;
+
+              return {
+                ...pageWithoutItems,
+                itemsCount: page.itemsCount ?? (Array.isArray(items) ? items.length : 0),
+                items: Array.isArray(items) ? items.map(toHtmlGroupReference) : items,
+              } as any;
+            },
+          ),
+        }) as any,
+    ),
+  }) as ScanCategory;
+*/
+
+const cloneCategoryWithoutPageItems = (category: ScanCategory): ScanCategory =>
+  ({
+    ...category,
+    rules: category.rules.map(
+      rule =>
+        ({
+          ...rule,
+          pagesAffected: rule.pagesAffected.map(
+            page => {
+              const { items, ...rest } = page;
+
+              return {
+                ...rest,
+                itemsCount: page.itemsCount ?? (Array.isArray(items) ? items.length : 0),
+              } as any;
+            },
+          ),
+        }) as any,
+    ),
+  }) as ScanCategory;
+
 /**
- * Converts items in pagesAffected to references (html\x00xpath composite keys) for embedding in HTML report.
- * Additionally, it deep-clones allIssues, replaces page.items objects with composite reference keys.
- * Those refs are specifically for htmlGroups lookup (html + xpath).
+ * Builds the embedded HTML-report payload from the full scan items.
+ * The current report path omits page.items and relies on htmlGroups + itemsCount
+ * to rebuild per-page occurrences in the browser.
  */
-export const convertItemsToReferences = (allIssues: AllIssues): AllIssues => {
-  const cloned = JSON.parse(JSON.stringify(allIssues));
-
-  ['mustFix', 'goodToFix', 'needsReview', 'passed'].forEach(category => {
-    if (!cloned.items[category]?.rules) return;
-
-    cloned.items[category].rules.forEach((rule: any) => {
-      if (!rule.pagesAffected || !rule.htmlGroups) return;
-
-      rule.pagesAffected.forEach((page: any) => {
-        if (!page.items) return;
-
-        page.items = page.items.map((item: any) => {
-          if (typeof item === 'string') return item; // Already a reference
-          // Use composite key matching buildHtmlGroups
-          const htmlKey = `${item.html || 'No HTML element'}\x00${item.xpath || ''}`;
-          return htmlKey;
-        });
-      });
-    });
-  });
-
-  return cloned;
+export const convertItemsToReferences = (source: Pick<AllIssues, 'items'>): ScanItemsLight => {
+  return {
+    mustFix: cloneCategoryWithoutPageItems(source.items.mustFix),
+    goodToFix: cloneCategoryWithoutPageItems(source.items.goodToFix),
+    needsReview: cloneCategoryWithoutPageItems(source.items.needsReview),
+    passed: cloneCategoryWithoutPageItems(source.items.passed),
+  };
 };

--- a/src/static/ejs/partials/scripts/decodeUnzipParse.ejs
+++ b/src/static/ejs/partials/scripts/decodeUnzipParse.ejs
@@ -28,8 +28,11 @@ async function decodeUnzipParse(input) {
       offset += arr.length;
     }
 
-    // Step 2: Decompress with pako (GZIP)
-    const decompressed = pako.ungzip(merged, { to: 'string' });
+    // Step 2: Decompress with pako (GZIP) to bytes first to avoid large-string
+    // construction inside pako for very large payloads.
+    const decompressedBytes = pako.ungzip(merged);
+
+    const decompressed = new TextDecoder().decode(decompressedBytes);
 
     // Step 3: Parse JSON
     return JSON.parse(decompressed);

--- a/src/static/ejs/partials/scripts/ruleModal/itemCardRenderer.ejs
+++ b/src/static/ejs/partials/scripts/ruleModal/itemCardRenderer.ejs
@@ -1,10 +1,44 @@
 <script>
   /**
-   * Resolves item references (composite "html\x00xpath" strings) to full item data using htmlGroups.
+   * Rebuilds the item list for a page from pre-computed htmlGroups when the light report omits page.items.
+   */
+  function buildItemsFromHtmlGroupsForPage(page, ruleInCategory) {
+    const htmlGroups = ruleInCategory.htmlGroups || {};
+    const resolvedItems = [];
+
+    Object.values(htmlGroups).forEach(groupData => {
+      if (!Array.isArray(groupData.pageUrls) || !groupData.pageUrls.includes(page.url)) {
+        return;
+      }
+
+      resolvedItems.push({
+        html: groupData.html,
+        xpath: groupData.xpath,
+        message: groupData.message,
+        screenshotPath: groupData.screenshotPath,
+        displayNeedsReview: groupData.displayNeedsReview,
+        pageUrl: page.url,
+        pageTitle: page.pageTitle || page.metadata
+      });
+    });
+
+    return resolvedItems;
+  }
+
+  /**
+   * The embedded report payload now omits page.items and rebuilds occurrences from
+   * htmlGroups + page metadata. Keep the older page.items resolution logic below
+   * commented for an easy rollback if we need to restore mixed payload support.
    */
   function resolveItemReferencesForPage(page, ruleInCategory) {
+    return buildItemsFromHtmlGroupsForPage(page, ruleInCategory);
+
+    /*
     const items = page.items || [];
-    if (items.length === 0) return [];
+
+    if (items.length === 0) {
+      return buildItemsFromHtmlGroupsForPage(page, ruleInCategory);
+    }
 
     const isReference = typeof items[0] === 'string';
 
@@ -27,6 +61,7 @@
           pageTitle: page.pageTitle || page.metadata
         };
       }
+
       // Fallback: parse composite key
       const nullByteIndex = compositeKey.indexOf('\x00');
       const html = nullByteIndex !== -1 ? compositeKey.slice(0, nullByteIndex) : compositeKey;
@@ -40,6 +75,7 @@
         pageTitle: page.pageTitle || page.metadata
       };
     });
+    */
   }
 
   function buildItemCardsWithPagination(accordionId, category, ruleInCategory, page, index) {

--- a/src/static/ejs/partials/scripts/ruleModal/ruleOffcanvas.ejs
+++ b/src/static/ejs/partials/scripts/ruleModal/ruleOffcanvas.ejs
@@ -270,8 +270,8 @@ include('./pageAccordionBuilder') %> <%- include('./constants') %>
           if (!Array.isArray(rule.pagesAffected)) return;
 
           rule.pagesAffected.sort((a, b) => {
-            const lenA = Array.isArray(a.items) ? a.items.length : 0;
-            const lenB = Array.isArray(b.items) ? b.items.length : 0;
+            const lenA = Array.isArray(a.items) ? a.items.length : a.itemsCount || 0;
+            const lenB = Array.isArray(b.items) ? b.items.length : b.itemsCount || 0;
             return lenB - lenA; // DESC
           });
         });


### PR DESCRIPTION
This PR makes large HTML reports more reliable by and fixes 2 issues:
1 report.html was not generated:
- reducing the embedded scanItems-light payload size. Omit page.items from scanItems-light. As the pages details can be retrieved from htmlGroups key.

2 report.html could not load scan items:
- switching browser-side report decoding to a safer byte-based gzip decode flow. Ungzip to bytes first, decode bytes with TextDecoder then JSON.parse(...)

Tested and works with
- 1k pages of catch.sg
- 3k pages of mom.gov.sg
