### PR TITLE
feat: skip redirects to external domains and honour domain/hostname strategy in sitemap/intelligent crawls

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -193,8 +193,11 @@ Usage: npm run cli -- -c <crawler> -d <device> -w <viewport> -u <url> OPTIONS`,
   .check(argvs => {
     const scanner = String(argvs.scanner ?? '');
 
-    if (argvs.strategy && scanner !== ScannerTypes.WEBSITE && scanner !== ScannerTypes.CUSTOM) {
-      throw new Error('-s or --strategy is only available in website and custom flow scans.');
+    if (argvs.strategy && scanner !== ScannerTypes.WEBSITE && scanner !== ScannerTypes.CUSTOM && scanner !== ScannerTypes.INTELLIGENT && scanner !== ScannerTypes.SITEMAP) {
+      throw new Error('-s or --strategy is only available in website, custom flow, intelligent, and sitemap scans.');
+    }
+    if (argvs.strategy === 'ignore' && scanner !== ScannerTypes.SITEMAP) {
+      throw new Error('-s ignore is only available for sitemap scans.');
     }
     return true;
   })
@@ -210,13 +213,20 @@ Usage: npm run cli -- -c <crawler> -d <device> -w <viewport> -u <url> OPTIONS`,
     return duration;
   })
   .check(argvs => {
-    if (argvs.scanner !== ScannerTypes.WEBSITE && argvs.strategy) {
-      throw new Error('-s or --strategy is only available in website scans.');
+    if (argvs.scanner !== ScannerTypes.WEBSITE && argvs.scanner !== ScannerTypes.CUSTOM && argvs.scanner !== ScannerTypes.INTELLIGENT && argvs.scanner !== ScannerTypes.SITEMAP && argvs.strategy) {
+      throw new Error('-s or --strategy is only available in website, custom flow, intelligent, and sitemap scans.');
+    }
+    if (argvs.strategy === 'ignore' && argvs.scanner !== ScannerTypes.SITEMAP) {
+      throw new Error('-s ignore is only available for sitemap scans.');
     }
     return true;
   })
   .conflicts('d', 'w')
   .parse() as unknown as Answers;
+
+if (!options.strategy) {
+  options.strategy = options.scanner === ScannerTypes.SITEMAP ? 'ignore' : 'same-domain';
+}
 
 const scanInit = async (argvs: Answers): Promise<string> => {
   const updatedArgvs = { ...argvs };

--- a/src/combine.ts
+++ b/src/combine.ts
@@ -161,6 +161,8 @@ const combineRun = async (details: Data, deviceToScan: string) => {
         blacklistedPatterns,
         includeScreenshots,
         extraHTTPHeaders,
+        strategy,
+        userUrl: url,
         scanDuration,
       });
       urlsCrawledObj = sitemapResult.urlsCrawled;

--- a/src/constants/cliFunctions.ts
+++ b/src/constants/cliFunctions.ts
@@ -168,8 +168,8 @@ export const cliOptions: { [key: string]: Options } = {
   s: {
     alias: 'strategy',
     describe:
-      'Crawls up to general (same parent) domains, or only specific hostname. Defaults to "same-domain".',
-    choices: ['same-domain', 'same-hostname'],
+      'Crawls up to general (same parent) domains, or only specific hostname. Use "ignore" to disable URL filtering (default for sitemap scans). Defaults to "same-domain".',
+    choices: ['same-domain', 'same-hostname', 'ignore'],
     requiresArg: true,
     demandOption: false,
   },

--- a/src/constants/common.ts
+++ b/src/constants/common.ts
@@ -901,6 +901,38 @@ const getRobotsTxtViaPlaywright = async (
   }
 };
 
+export const getSitemapsFromRobotsTxt = async (
+  url: string,
+  browser: string,
+  userDataDirectory: string,
+  extraHTTPHeaders: Record<string, string>,
+): Promise<string[]> => {
+  const domain = new URL(url).origin;
+  const robotsUrl = domain.concat('/robots.txt');
+
+  let robotsTxt: string;
+  try {
+    robotsTxt = await getRobotsTxtViaPlaywright(robotsUrl, browser, userDataDirectory, extraHTTPHeaders);
+  } catch (e) {
+    consoleLogger.info(`Unable to fetch robots.txt from ${robotsUrl} for sitemap discovery`);
+    return [];
+  }
+
+  if (!robotsTxt) return [];
+
+  const sitemaps: string[] = [];
+  const lines = robotsTxt.split(/\r?\n/);
+  for (const line of lines) {
+    if (line.toLowerCase().startsWith('sitemap:')) {
+      const sitemapUrl = line.substring('sitemap:'.length).trim();
+      if (sitemapUrl) {
+        sitemaps.push(sitemapUrl);
+      }
+    }
+  }
+  return sitemaps;
+};
+
 export const isDisallowedInRobotsTxt = (url: string): boolean => {
   if (!constants.robotsTxtUrls) return;
 

--- a/src/constants/common.ts
+++ b/src/constants/common.ts
@@ -33,7 +33,7 @@ import constants, {
 } from './constants.js';
 import { consoleLogger } from '../logs.js';
 import { isUrlPdf } from '../crawlers/commonCrawlerFunc.js';
-import { cleanUpAndExit, randomThreeDigitNumberString, register } from '../utils.js';
+import { cleanUpAndExit, isFollowStrategy, randomThreeDigitNumberString, register } from '../utils.js';
 import { Answers, Data } from '../index.js';
 import { DeviceDescriptor } from '../types/types.js';
 import { getProxyInfo, proxyInfoToResolution, ProxySettings } from '../proxyService.js';
@@ -746,7 +746,9 @@ export const prepareData = async (argv: Answers): Promise<Data> => {
     playwrightDeviceDetailsObject,
     maxRequestsPerCrawl: maxpages || constants.maxRequestsPerCrawl,
     strategy:
-      strategy === 'same-hostname' ? EnqueueStrategy.SameHostname : EnqueueStrategy.SameDomain,
+      strategy === 'same-hostname' ? EnqueueStrategy.SameHostname
+      : strategy === 'ignore' ? EnqueueStrategy.All
+      : EnqueueStrategy.SameDomain,
     isLocalFileScan,
     browser: browserToRun,
     nameEmail,
@@ -931,6 +933,8 @@ export const getLinksFromSitemap = async (
   userUrlInput: string,
   isIntelligent: boolean,
   extraHTTPHeaders: Record<string, string>,
+  strategy: EnqueueStrategy = EnqueueStrategy.All,
+  userUrl: string = userUrlInput,
 ) => {
   const scannedSitemaps = new Set<string>();
   const urls: Record<string, Request> = {}; // dictionary of requests to urls to be scanned
@@ -940,6 +944,7 @@ export const getLinksFromSitemap = async (
   const addToUrlList = (url: string) => {
     if (!url) return;
     if (isDisallowedInRobotsTxt(url)) return;
+    if (!isFollowStrategy(url, userUrl, strategy)) return;
 
     url = convertPathToLocalFile(url);
 

--- a/src/crawlers/crawlDomain.ts
+++ b/src/crawlers/crawlDomain.ts
@@ -654,6 +654,20 @@ const crawlDomain = async ({
 
             const results = await runAxeScript({ includeScreenshots, page, randomToken, ruleset });
 
+            // Re-check page URL after axe scan — JS redirects may have fired during scan
+            try {
+              const postScanUrl = page.url();
+              if (postScanUrl && postScanUrl !== 'about:blank' && !isFollowStrategy(postScanUrl, request.url, 'same-hostname')) {
+                urlsCrawled.notScannedRedirects.push({
+                  fromUrl: request.url,
+                  toUrl: postScanUrl,
+                });
+                return;
+              }
+            } catch (_) {
+              // Page/context was destroyed during scan — handled by outer catch
+            }
+
             if (isRedirected) {
               const isLoadedUrlInCrawledUrls = scannedResolvedUrlSet.has(actualUrl);
 

--- a/src/crawlers/crawlDomain.ts
+++ b/src/crawlers/crawlDomain.ts
@@ -654,9 +654,20 @@ const crawlDomain = async ({
 
             const results = await runAxeScript({ includeScreenshots, page, randomToken, ruleset });
 
-            // Re-check page URL after axe scan — JS redirects may have fired during scan
+            // Detect JS redirects that fire during/after axe scan.
+            // Listen for navigation, then give a brief window for pending redirects to complete.
             try {
-              const postScanUrl = page.url();
+              let navigatedToUrl: string | null = null;
+              const onFrameNavigated = (frame: Frame) => {
+                if (frame === page.mainFrame()) {
+                  navigatedToUrl = frame.url();
+                }
+              };
+              page.on('framenavigated', onFrameNavigated);
+              await page.waitForTimeout(1000);
+              page.off('framenavigated', onFrameNavigated);
+
+              const postScanUrl = navigatedToUrl || page.url();
               if (postScanUrl && postScanUrl !== 'about:blank' && !isFollowStrategy(postScanUrl, request.url, 'same-hostname')) {
                 urlsCrawled.notScannedRedirects.push({
                   fromUrl: request.url,
@@ -665,7 +676,7 @@ const crawlDomain = async ({
                 return;
               }
             } catch (_) {
-              // Page/context was destroyed during scan — handled by outer catch
+              // Page/context was destroyed during navigation — handled by outer catch
             }
 
             if (isRedirected) {

--- a/src/crawlers/crawlIntelligentSitemap.ts
+++ b/src/crawlers/crawlIntelligentSitemap.ts
@@ -7,7 +7,7 @@ import { consoleLogger, guiInfoLog } from '../logs.js';
 import crawlDomain from './crawlDomain.js';
 import crawlSitemap from './crawlSitemap.js';
 import { ViewportSettingsClass } from '../combine.js';
-import { getPlaywrightLaunchOptions } from '../constants/common.js';
+import { getPlaywrightLaunchOptions, getSitemapsFromRobotsTxt } from '../constants/common.js';
 import { register } from '../utils.js';
 
 const crawlIntelligentSitemap = async (
@@ -100,10 +100,28 @@ const crawlIntelligentSitemap = async (
     }
   };
 
+  // Discover sitemaps from robots.txt first (supports multiple Sitemap: directives)
+  let sitemapUrls: string[] = [];
   try {
-    sitemapUrl = await findSitemap(url, userDataDirectory, extraHTTPHeaders);
+    sitemapUrls = await getSitemapsFromRobotsTxt(url, browser, userDataDirectory, extraHTTPHeaders);
+    if (sitemapUrls.length > 0) {
+      console.log(`Found ${sitemapUrls.length} sitemap(s) in robots.txt: ${sitemapUrls.join(', ')}`);
+      sitemapExist = true;
+    }
   } catch (error) {
     consoleLogger.error(error);
+  }
+
+  // Fall back to hardcoded path probing if robots.txt had no sitemaps
+  if (!sitemapExist) {
+    try {
+      sitemapUrl = await findSitemap(url, userDataDirectory, extraHTTPHeaders);
+      if (sitemapExist) {
+        sitemapUrls = [sitemapUrl];
+      }
+    } catch (error) {
+      consoleLogger.error(error);
+    }
   }
 
   if (!sitemapExist) {
@@ -124,33 +142,45 @@ const crawlIntelligentSitemap = async (
       followRobots,
       extraHTTPHeaders,
       safeMode,
-      scanDuration, // Use full duration since no sitemap
+      scanDuration,
     });
   }
 
-  console.log(`Sitemap found at ${sitemapUrl}`);
-  urlsCrawledFinal = await crawlSitemap({
-    sitemapUrl,
-    randomToken,
-    host,
-    viewportSettings,
-    maxRequestsPerCrawl,
-    browser,
-    userDataDirectory,
-    specifiedMaxConcurrency,
-    fileTypes,
-    blacklistedPatterns,
-    includeScreenshots,
-    extraHTTPHeaders,
-    strategy,
-    userUrl: url,
-    fromCrawlIntelligentSitemap,
-    userUrlInputFromIntelligent: url,
-    datasetFromIntelligent: dataset,
-    urlsCrawledFromIntelligent: urlsCrawled,
-    crawledFromLocalFile: false,
-    scanDuration,
-  });
+  // Process all discovered sitemaps sequentially, sharing dataset and urlsCrawled
+  for (const currentSitemapUrl of sitemapUrls) {
+    if (urlsCrawled.scanned.length >= maxRequestsPerCrawl) break;
+
+    const elapsed = Date.now() - startTime;
+    const remainingDuration = scanDuration > 0 ? Math.max(scanDuration - elapsed / 1000, 0) : scanDuration;
+    if (scanDuration > 0 && remainingDuration <= 0) {
+      durationExceeded = true;
+      break;
+    }
+
+    console.log(`Processing sitemap: ${currentSitemapUrl}`);
+    urlsCrawledFinal = await crawlSitemap({
+      sitemapUrl: currentSitemapUrl,
+      randomToken,
+      host,
+      viewportSettings,
+      maxRequestsPerCrawl,
+      browser,
+      userDataDirectory,
+      specifiedMaxConcurrency,
+      fileTypes,
+      blacklistedPatterns,
+      includeScreenshots,
+      extraHTTPHeaders,
+      strategy,
+      userUrl: url,
+      fromCrawlIntelligentSitemap,
+      userUrlInputFromIntelligent: url,
+      datasetFromIntelligent: dataset,
+      urlsCrawledFromIntelligent: urlsCrawled,
+      crawledFromLocalFile: false,
+      scanDuration: scanDuration > 0 ? remainingDuration : 0,
+    });
+  }
 
   const elapsed = Date.now() - startTime;
   const remainingScanDuration = Math.max(scanDuration - elapsed / 1000, 0); // in seconds

--- a/src/crawlers/crawlIntelligentSitemap.ts
+++ b/src/crawlers/crawlIntelligentSitemap.ts
@@ -183,11 +183,12 @@ const crawlIntelligentSitemap = async (
   }
 
   const elapsed = Date.now() - startTime;
-  const remainingScanDuration = Math.max(scanDuration - elapsed / 1000, 0); // in seconds
+  const remainingScanDuration = scanDuration > 0 ? Math.max(scanDuration - elapsed / 1000, 0) : 0;
+  const hasDurationRemaining = scanDuration === 0 || remainingScanDuration > 0;
 
-  if (urlsCrawledFinal.scanned.length < maxRequestsPerCrawl && remainingScanDuration > 0) {
+  if (urlsCrawled.scanned.length < maxRequestsPerCrawl && hasDurationRemaining) {
     console.log(
-      `Continuing crawl from root website. Remaining scan time: ${remainingScanDuration.toFixed(1)}s`,
+      `Continuing crawl from root website.${scanDuration > 0 ? ` Remaining scan time: ${remainingScanDuration.toFixed(1)}s` : ''}`,
     );
     urlsCrawledFinal = await crawlDomain({
       url,
@@ -207,10 +208,10 @@ const crawlIntelligentSitemap = async (
       safeMode,
       fromCrawlIntelligentSitemap,
       datasetFromIntelligent: dataset,
-      urlsCrawledFromIntelligent: urlsCrawledFinal,
+      urlsCrawledFromIntelligent: urlsCrawled,
       scanDuration: remainingScanDuration,
     });
-  } else if (remainingScanDuration <= 0) {
+  } else if (!hasDurationRemaining) {
     console.log(
       `Crawl duration exceeded before more pages could be found (limit: ${scanDuration}s).`,
     );
@@ -218,7 +219,7 @@ const crawlIntelligentSitemap = async (
   }
 
   guiInfoLog(guiInfoStatusTypes.COMPLETED, {});
-  return { urlsCrawled: urlsCrawledFinal, durationExceeded };
+  return { urlsCrawled, durationExceeded };
 };
 
 export default crawlIntelligentSitemap;

--- a/src/crawlers/crawlIntelligentSitemap.ts
+++ b/src/crawlers/crawlIntelligentSitemap.ts
@@ -142,6 +142,8 @@ const crawlIntelligentSitemap = async (
     blacklistedPatterns,
     includeScreenshots,
     extraHTTPHeaders,
+    strategy,
+    userUrl: url,
     fromCrawlIntelligentSitemap,
     userUrlInputFromIntelligent: url,
     datasetFromIntelligent: dataset,

--- a/src/crawlers/crawlSitemap.ts
+++ b/src/crawlers/crawlSitemap.ts
@@ -347,6 +347,24 @@ const crawlSitemap = async ({
 
             const results = await runAxeScript({ includeScreenshots, page, randomToken });
 
+            // Re-check page URL after axe scan — JS redirects may have fired during scan
+            try {
+              const postScanUrl = page.url();
+              if (postScanUrl && postScanUrl !== 'about:blank' && !isFollowStrategy(postScanUrl, request.url, 'same-hostname')) {
+                urlsCrawled.notScannedRedirects.push({
+                  fromUrl: request.url,
+                  toUrl: postScanUrl,
+                });
+                guiInfoLog(guiInfoStatusTypes.SKIPPED, {
+                  numScanned: urlsCrawled.scanned.length,
+                  urlScanned: request.url,
+                });
+                return;
+              }
+            } catch (_) {
+              // Page/context was destroyed during scan — handled by outer catch
+            }
+
             guiInfoLog(guiInfoStatusTypes.SCANNED, {
               numScanned: urlsCrawled.scanned.length,
               urlScanned: request.url,

--- a/src/crawlers/crawlSitemap.ts
+++ b/src/crawlers/crawlSitemap.ts
@@ -333,7 +333,7 @@ const crawlSitemap = async ({
               return;
             }
 
-            if (isRedirected && !isFollowStrategy(actualUrl, userUrl || request.url, strategy)) {
+            if (isRedirected && !isFollowStrategy(actualUrl, request.url, 'same-hostname')) {
               urlsCrawled.notScannedRedirects.push({
                 fromUrl: request.url,
                 toUrl: actualUrl,

--- a/src/crawlers/crawlSitemap.ts
+++ b/src/crawlers/crawlSitemap.ts
@@ -347,9 +347,20 @@ const crawlSitemap = async ({
 
             const results = await runAxeScript({ includeScreenshots, page, randomToken });
 
-            // Re-check page URL after axe scan — JS redirects may have fired during scan
+            // Detect JS redirects that fire during/after axe scan.
+            // Listen for navigation, then give a brief window for pending redirects to complete.
             try {
-              const postScanUrl = page.url();
+              let navigatedToUrl: string | null = null;
+              const onFrameNavigated = (frame: any) => {
+                if (frame === page.mainFrame()) {
+                  navigatedToUrl = frame.url();
+                }
+              };
+              page.on('framenavigated', onFrameNavigated);
+              await page.waitForTimeout(1000);
+              page.off('framenavigated', onFrameNavigated);
+
+              const postScanUrl = navigatedToUrl || page.url();
               if (postScanUrl && postScanUrl !== 'about:blank' && !isFollowStrategy(postScanUrl, request.url, 'same-hostname')) {
                 urlsCrawled.notScannedRedirects.push({
                   fromUrl: request.url,
@@ -362,7 +373,7 @@ const crawlSitemap = async ({
                 return;
               }
             } catch (_) {
-              // Page/context was destroyed during scan — handled by outer catch
+              // Page/context was destroyed during navigation — handled by outer catch
             }
 
             guiInfoLog(guiInfoStatusTypes.SCANNED, {

--- a/src/crawlers/crawlSitemap.ts
+++ b/src/crawlers/crawlSitemap.ts
@@ -1,4 +1,4 @@
-import crawlee, { LaunchContext, Request, RequestList, Dataset } from 'crawlee';
+import crawlee, { EnqueueStrategy, LaunchContext, Request, RequestList, Dataset } from 'crawlee';
 import fs from 'fs';
 import * as path from 'path';
 import fsp from 'fs/promises';
@@ -23,7 +23,7 @@ import {
   waitForPageLoaded,
   isFilePath,
 } from '../constants/common.js';
-import { areLinksEqual, isWhitelistedContentType, register } from '../utils.js';
+import { areLinksEqual, isFollowStrategy, isWhitelistedContentType, register } from '../utils.js';
 import {
   handlePdfDownload,
   runPdfScan,
@@ -46,6 +46,8 @@ const crawlSitemap = async ({
   blacklistedPatterns,
   includeScreenshots,
   extraHTTPHeaders,
+  strategy = EnqueueStrategy.All,
+  userUrl = '',
   scanDuration = 0,
   fromCrawlIntelligentSitemap = false,
   userUrlInputFromIntelligent = null,
@@ -65,6 +67,8 @@ const crawlSitemap = async ({
   blacklistedPatterns: string[];
   includeScreenshots: boolean;
   extraHTTPHeaders: Record<string, string>;
+  strategy?: EnqueueStrategy;
+  userUrl?: string;
   scanDuration?: number;
   fromCrawlIntelligentSitemap?: boolean;
   userUrlInputFromIntelligent?: string;
@@ -99,6 +103,8 @@ const crawlSitemap = async ({
     userUrlInputFromIntelligent,
     fromCrawlIntelligentSitemap,
     extraHTTPHeaders,
+    strategy,
+    userUrl || sitemapUrl,
   );
 
   sitemapUrl = encodeURI(sitemapUrl);
@@ -320,6 +326,18 @@ const crawlSitemap = async ({
                 httpStatusCode: 0,
               });
 
+              guiInfoLog(guiInfoStatusTypes.SKIPPED, {
+                numScanned: urlsCrawled.scanned.length,
+                urlScanned: request.url,
+              });
+              return;
+            }
+
+            if (isRedirected && !isFollowStrategy(actualUrl, userUrl || request.url, strategy)) {
+              urlsCrawled.notScannedRedirects.push({
+                fromUrl: request.url,
+                toUrl: actualUrl,
+              });
               guiInfoLog(guiInfoStatusTypes.SKIPPED, {
                 numScanned: urlsCrawled.scanned.length,
                 urlScanned: request.url,

--- a/src/mergeAxeResults.ts
+++ b/src/mergeAxeResults.ts
@@ -212,6 +212,8 @@ const writeHTML = async (
         await Promise.all([
           fs.promises.unlink(topFilePath),
           fs.promises.unlink(bottomFilePath),
+          fs.promises.unlink(lightScanItemsPayloadBase64FilePath),
+          fs.promises.unlink(lightScanItemsPayloadJsonFilePath),
         ]);
       } catch (err) {
         console.error('Error cleaning up temporary files:', err);

--- a/src/mergeAxeResults.ts
+++ b/src/mergeAxeResults.ts
@@ -212,8 +212,6 @@ const writeHTML = async (
         await Promise.all([
           fs.promises.unlink(topFilePath),
           fs.promises.unlink(bottomFilePath),
-          fs.promises.unlink(lightScanItemsPayloadBase64FilePath),
-          fs.promises.unlink(lightScanItemsPayloadJsonFilePath),
         ]);
       } catch (err) {
         console.error('Error cleaning up temporary files:', err);


### PR DESCRIPTION
## Summary

- Sitemap crawls now honour the `strategy` parameter, filtering URLs from the sitemap XML that don't match the user's URL based on strategy rules
- New strategy value `"ignore"` disables URL filtering (default for `-c sitemap` to preserve existing behaviour)
- Website, intelligent, and custom scans still require `same-domain` or `same-hostname`
- Fix pre-existing bug: pages that redirect to external domains during sitemap/domain crawls are now skipped instead of being scanned — including client-side JS redirects that fire during the axe scan
- Intelligent scans now discover sitemaps from robots.txt (supporting multiple `Sitemap:` directives per the spec), falling back to hardcoded path probing

## Context

The `strategy` parameter (`same-domain` / `same-hostname`) controls which discovered URLs are enqueued during crawling. Previously:

- `crawlDomain` fully honoured strategy (via crawlee's `enqueueLinks` and `isFollowStrategy` checks)
- `crawlSitemap` did **not** accept or use strategy -- it crawled every URL found in the sitemap XML regardless of hostname/domain
- `crawlIntelligentSitemap` passed strategy to `crawlDomain` (fallback + follow-up phases) but not to `crawlSitemap` (sitemap phase)
- Intelligent scan sitemap discovery only tried hardcoded paths (e.g. `/sitemap.xml`) — it did not check robots.txt for `Sitemap:` directives, missing sitemaps at non-standard locations or sites with multiple sitemaps
- If a page in the sitemap redirected to a completely different domain (via HTTP redirect), the redirected page was still scanned (axe was run on it)
- Pages performing **client-side JS redirects** (e.g. "Redirecting in 3 seconds") were scanned on the intermediate page, and if the redirect fired during the axe scan, results from the external domain could be recorded

## Changes

### 1. New `"ignore"` strategy option

- Added `'ignore'` to CLI strategy choices (`-s ignore`)
- Maps to `EnqueueStrategy.All` internally (no filtering)
- Defaults to `'ignore'` for `-c sitemap` scans (preserving previous no-filter behaviour)
- Rejected for website/intelligent/custom scans

### 2. Strategy filtering in sitemap URL collection

- `getLinksFromSitemap` now accepts `strategy` and `userUrl` parameters
- URLs in the sitemap XML that don't match the strategy (relative to the user-provided URL) are excluded before crawling begins
- Uses the existing `isFollowStrategy` utility for consistent behaviour with `crawlDomain`

### 3. Strategy passed through the full call chain

- `crawlSitemap` accepts and forwards strategy to `getLinksFromSitemap`
- `combine.ts` passes strategy for sitemap-only scans
- `crawlIntelligentSitemap` passes strategy for the sitemap phase of intelligent scans

### 4. Redirect-to-external-domain protection in `crawlSitemap`

- After page navigation, if the page redirected to a different hostname than the **original request URL**, it is skipped
- This check uses `isFollowStrategy(actualUrl, request.url, 'same-hostname')` — comparing against the listed sitemap URL, not the user-provided scan URL
- This applies **regardless of the top-level strategy setting** (even with `'ignore'`), ensuring that a URL listed as `siteA.com/page` that redirects to `siteC.com/other` is never scanned
- The redirect is recorded in `urlsCrawled.notScannedRedirects` for transparency
- This prevents scanning pages that belong to entirely different sites (e.g. login redirects, CDN pages, SSO flows)

### 5. Post-scan JS redirect detection in `crawlDomain` and `crawlSitemap`

- After `runAxeScript` completes, a `framenavigated` event listener is registered on the page's main frame, followed by a 1-second wait (`page.waitForTimeout(1000)`)
- This gives client-side JS redirects (e.g. "Redirecting in 3 seconds" timer pages) time to fire — by the time axe finishes, we're typically at 3s+ from page load, so an extra 1s puts us past most redirect timers
- If navigation to a different hostname is detected (either captured by the listener or via `page.url()` after the wait), the results are discarded and the URL is logged in `notScannedRedirects`
- Wrapped in try/catch to safely handle cases where the page/context was destroyed during navigation
- The 1-second wait runs concurrently across pages so adds minimal wall-clock time to the overall scan
- This catches the case where pre-scan checks pass (page is still on original hostname) but the redirect fires during or shortly after the axe evaluation

### 6. Robots.txt sitemap discovery in intelligent scans

- Intelligent scans now fetch robots.txt and extract all `Sitemap:` directives before trying hardcoded paths
- Supports multiple sitemaps per the robots.txt specification — all are processed sequentially with shared state (dataset + urlsCrawled)
- `Sitemap:` directives are global in the robots.txt spec (not scoped to any `User-agent` block), so parsing scans all lines regardless of block context
- Case-insensitive matching (`Sitemap:` / `sitemap:` / `SITEMAP:` all work)
- Falls back to hardcoded path probing (`/sitemap.xml`, `/sitemap_index.xml`, etc.) if robots.txt has no sitemap entries or is unavailable
- Each sitemap respects `maxRequestsPerCrawl` and `scanDuration` limits — processing stops early if either is exceeded
- New `getSitemapsFromRobotsTxt` utility in `common.ts` reuses the existing `getRobotsTxtViaPlaywright` fetcher
- Nested/index sitemaps are handled by the existing `getLinksFromSitemap` recursive logic (it already follows `<sitemapindex>` entries)

### 7. Fix intelligent scan domain crawl phase not running after sitemap phase

- When `scanDuration` is 0 (unlimited), the remaining duration calculation produced 0 (`Math.max(0 - elapsed, 0) = 0`), causing the domain crawl phase to be skipped entirely
- Additionally, `urlsCrawledFinal` held the return value of `crawlSitemap` (`{ urlsCrawled, durationExceeded }`) — accessing `.scanned` on it threw a TypeError, crashing the process before report generation
- Fixed by treating `scanDuration=0` as unlimited, and using the shared `urlsCrawled` variable directly (which is mutated in-place by `crawlSitemap` via `urlsCrawledFromIntelligent`)

### 8. CLI validation updates

- Strategy is now allowed for all scan types that can use it (website, custom, intelligent, sitemap)
- Two duplicate `.check()` blocks unified in logic
- `ignore` is validated to only be usable with sitemap scans

### 9. Local file sitemaps

- Local file sitemaps (`-c sitemap -u /path/to/sitemap.xml`) continue to enqueue all listed URLs regardless of domain
- This is because `-c sitemap` defaults to `'ignore'` (`EnqueueStrategy.All`), and `isFollowStrategy` returns `true` immediately for `'all'` without parsing or comparing URLs
- However, if a listed URL redirects to a **different hostname** than itself (e.g. `siteA.com/page` redirects to `siteC.com/other`), the redirected page is skipped — this protects against scanning unintended sites via redirect chains

## Files changed

| File | Change |
|------|--------|
| `src/constants/cliFunctions.ts` | Added `'ignore'` to strategy choices |
| `src/constants/common.ts` | `'ignore'` -> `EnqueueStrategy.All` mapping; added strategy + userUrl params to `getLinksFromSitemap` with `isFollowStrategy` filtering; new `getSitemapsFromRobotsTxt` utility |
| `src/cli.ts` | Default strategy to `'ignore'` for sitemap scans; validate `'ignore'` only for sitemap; allow strategy for all relevant scan types |
| `src/crawlers/crawlSitemap.ts` | Accept strategy + userUrl; pass to `getLinksFromSitemap`; skip redirected pages outside their own hostname; post-scan JS redirect detection |
| `src/crawlers/crawlDomain.ts` | Post-scan JS redirect detection after `runAxeScript` |
| `src/combine.ts` | Pass strategy + url to `crawlSitemap` |
| `src/crawlers/crawlIntelligentSitemap.ts` | Discover sitemaps from robots.txt first; process all found sitemaps sequentially; pass strategy + url to `crawlSitemap`; fix domain crawl phase skipped when scanDuration=0; fix TypeError on urlsCrawledFinal |

## Test plan

- [ ] `npm run build` compiles cleanly
- [ ] `-c sitemap -u <url>` defaults to no filtering (ignore) -- existing behaviour preserved
- [ ] `-c sitemap -u /path/to/local-sitemap.xml` scans all URLs in the file regardless of domain
- [ ] `-c sitemap -u <url> -s same-hostname` filters sitemap URLs to same hostname only
- [ ] `-c intelligent -u <url> -s same-hostname` filters URLs in both sitemap and domain crawl phases
- [ ] `-c website -s ignore` is rejected with an error
- [ ] Pages that redirect (HTTP) to a different hostname than their original URL are skipped and logged in `notScannedRedirects`
- [ ] Pages that redirect (client-side JS) during the axe scan are detected post-scan and results discarded
- [ ] Local file sitemap with multi-domain URLs: all are enqueued, but redirects leaving their own hostname are skipped
- [ ] `-c intelligent` discovers sitemaps from robots.txt when available (multiple `Sitemap:` directives supported)
- [ ] `-c intelligent` falls back to hardcoded path probing when robots.txt has no sitemap entries
- [ ] `-c intelligent` with no `-l` (scanDuration=0) proceeds to domain crawl after sitemap phase completes
- [ ] `-c intelligent` generates report successfully after both sitemap and domain crawl phases
