### PR TITLE
fix: normalize URLs for dedup to prevent scanning same page twice

### DIFF
--- a/src/crawlers/crawlDomain.ts
+++ b/src/crawlers/crawlDomain.ts
@@ -29,7 +29,7 @@ import {
   getUrlsFromRobotsTxt,
   waitForPageLoaded,
 } from '../constants/common.js';
-import { areLinksEqual, isFollowStrategy, register } from '../utils.js';
+import { areLinksEqual, isFollowStrategy, normUrl, register } from '../utils.js';
 import {
   handlePdfDownload,
   runPdfScan,
@@ -116,9 +116,9 @@ const crawlDomain = async ({
   const pdfDownloads: Promise<void>[] = [];
   const uuidToPdfMapping: Record<string, string> = {};
   const queuedUrlSet = new Set<string>();
-  const scannedUrlSet = new Set<string>(urlsCrawled.scanned.map(item => item.url));
+  const scannedUrlSet = new Set<string>(urlsCrawled.scanned.map(item => normUrl(item.url)));
   const scannedResolvedUrlSet = new Set<string>(
-    urlsCrawled.scanned.map(item => item.actualUrl || item.url),
+    urlsCrawled.scanned.map(item => normUrl(item.actualUrl || item.url)),
   );
   const isScanHtml = [FileTypes.All, FileTypes.HtmlOnly].includes(fileTypes as FileTypes);
   const isScanPdfs = [FileTypes.All, FileTypes.PdfOnly].includes(fileTypes as FileTypes);
@@ -166,7 +166,7 @@ const crawlDomain = async ({
     const selectedElementsString = cssQuerySelectors.join(', ');
 
     const isExcluded = (newPageUrl: string): boolean => {
-      const isAlreadyScanned: boolean = urlsCrawled.scanned.some(item => item.url === newPageUrl);
+      const isAlreadyScanned: boolean = scannedUrlSet.has(normUrl(newPageUrl));
       const isBlacklistedUrl: boolean = isBlacklisted(newPageUrl, blacklistedPatterns);
       const isNotFollowStrategy: boolean = !isFollowStrategy(newPageUrl, initialPageUrl, strategy);
       const isNotSupportedDocument: boolean = disallowedListOfPatterns.some(pattern =>
@@ -341,7 +341,7 @@ const crawlDomain = async ({
           } catch (e) {
             consoleLogger.error(e);
           }
-          if (scannedUrlSet.has(req.url)) {
+          if (scannedUrlSet.has(normUrl(req.url))) {
             req.skipNavigation = true;
           }
           if (isDisallowedInRobotsTxt(req.url)) return null;
@@ -537,7 +537,7 @@ const crawlDomain = async ({
           }
 
           // if URL has already been scanned
-          if (scannedUrlSet.has(request.url)) {
+          if (scannedUrlSet.has(normUrl(request.url))) {
             await enqueueProcess(page, enqueueLinks, browserContext);
             return;
           }
@@ -680,7 +680,7 @@ const crawlDomain = async ({
             }
 
             if (isRedirected) {
-              const isLoadedUrlInCrawledUrls = scannedResolvedUrlSet.has(actualUrl);
+              const isLoadedUrlInCrawledUrls = scannedResolvedUrlSet.has(normUrl(actualUrl));
 
               if (isLoadedUrlInCrawledUrls) {
                 urlsCrawled.notScannedRedirects.push({
@@ -702,8 +702,8 @@ const crawlDomain = async ({
                   pageTitle: results.pageTitle,
                   actualUrl, // i.e. actualUrl
                 });
-                scannedUrlSet.add(request.url);
-                scannedResolvedUrlSet.add(actualUrl);
+                scannedUrlSet.add(normUrl(request.url));
+                scannedResolvedUrlSet.add(normUrl(actualUrl));
 
                 urlsCrawled.scannedRedirects.push({
                   fromUrl: request.url,
@@ -725,8 +725,8 @@ const crawlDomain = async ({
                 actualUrl: request.url,
                 pageTitle: results.pageTitle,
               });
-              scannedUrlSet.add(request.url);
-              scannedResolvedUrlSet.add(request.url);
+              scannedUrlSet.add(normUrl(request.url));
+              scannedResolvedUrlSet.add(normUrl(request.url));
               await dataset.pushData(results);
             }
           } else {

--- a/src/crawlers/crawlSitemap.ts
+++ b/src/crawlers/crawlSitemap.ts
@@ -23,7 +23,7 @@ import {
   waitForPageLoaded,
   isFilePath,
 } from '../constants/common.js';
-import { areLinksEqual, isFollowStrategy, isWhitelistedContentType, register } from '../utils.js';
+import { areLinksEqual, isFollowStrategy, isWhitelistedContentType, normUrl, register } from '../utils.js';
 import {
   handlePdfDownload,
   runPdfScan,
@@ -305,7 +305,7 @@ const crawlSitemap = async ({
           if (isScanHtml && status < 300 && isWhitelistedContentType(contentType)) {
             const isRedirected = !areLinksEqual(page.url(), request.url);
             const isLoadedUrlInCrawledUrls = urlsCrawled.scanned.some(
-              item => (item.actualUrl || item.url) === page.url(),
+              item => normUrl(item.actualUrl || item.url) === normUrl(page.url()),
             );
 
             if (isRedirected && isLoadedUrlInCrawledUrls) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -5,6 +5,7 @@ import fs from 'fs-extra';
 import axe, { Rule } from 'axe-core';
 import { v4 as uuidv4 } from 'uuid';
 import { getDomain } from 'tldts';
+import { normalizeUrl } from '@apify/utilities';
 import constants, {
   BrowserTypes,
   destinationPath,
@@ -1077,6 +1078,8 @@ export const randomThreeDigitNumberString = () => {
   const threeDigitNumber = Math.floor(scaledDecimal) + 100;
   return String(threeDigitNumber);
 };
+
+export const normUrl = (u: string): string => (u ? normalizeUrl(u) || u : '');
 
 export const isFollowStrategy = (link1: string, link2: string, rule: string): boolean => {
   try {


### PR DESCRIPTION
URLs like https://example.com and https://example.com/ are the same page but were treated as different entries in the scannedUrlSet, causing duplicate scans (especially in intelligent crawls where the sitemap phase may list the URL without trailing slash and the domain crawl phase discovers it with a trailing slash).

Use @apify/utilities normalizeUrl (the same function crawlee uses internally) for consistent URL normalization in dedup sets. Exposed as normUrl helper in utils.ts.


- src/utils.ts: Added normUrl helper that wraps @apify/utilities normalizeUrl (safe for null/empty), exported for reuse
- src/crawlers/crawlDomain.ts: All scannedUrlSet and scannedResolvedUrlSet operations now use normUrl() for consistent dedup
- src/crawlers/crawlSitemap.ts: The isLoadedUrlInCrawledUrls check now compares normalized URLs

This PR adds... <!-- A brief description of what your PR does -->

<!-- This checklist is just a guideline.-->
<!-- If any of the following does not apply to your PR, please leave them unchecked and explain in the PR -->

- [ ] I've kept this PR as small as possible (~500 lines) by splitting it into PRs with manageable chunks of code
- [ ] I've requested reviews from 1 reviewer
- [ ] I've tested existing features (website scan, sitemap, custom flow) in both node index and cli
- [ ] I've synced this fork with GovTechSG repo
- [ ] I've added/updated unit tests
- [ ] I've added/updated any necessary dependencies in `package[-lock].json` `npm audit`, portable installation on GitHub Actions
