### PR TITLE
fix: await crawlee folder cleanup before zipping results

### DIFF
--- a/src/mergeAxeResults.ts
+++ b/src/mergeAxeResults.ts
@@ -996,14 +996,14 @@ const generateArtifacts = async (
     1,
   );
 
-  // Delay crawlee folder removal to allow lingering async storage operations to flush
-  setTimeout(async () => {
-    try {
-      await fs.promises.rm(path.join(storagePath, 'crawlee'), { recursive: true, force: true });
-    } catch (error) {
-      // Silently ignore — folder may already be gone or still locked
-    }
-  }, 5000);
+  // Brief delay to allow lingering async crawlee storage operations to flush
+  await new Promise(resolve => setTimeout(resolve, 3000));
+
+  try {
+    await fs.promises.rm(path.join(storagePath, 'crawlee'), { recursive: true, force: true });
+  } catch (error) {
+    // Silently ignore — folder may already be gone or still locked
+  }
 
   try {
     await fs.promises.rm(path.join(storagePath, 'pdfs'), { recursive: true, force: true });


### PR DESCRIPTION
The crawlee folder deletion was deferred via setTimeout (fire-and-forget) which meant the folder was still present when zipResults ran immediately after, including all crawlee internal JSON files in the output zip.

Replace with an awaited 3-second delay followed by synchronous deletion, ensuring the folder is removed before zipping starts.

This PR adds... <!-- A brief description of what your PR does -->

<!-- This checklist is just a guideline.-->
<!-- If any of the following does not apply to your PR, please leave them unchecked and explain in the PR -->

- [ ] I've kept this PR as small as possible (~500 lines) by splitting it into PRs with manageable chunks of code
- [ ] I've requested reviews from 1 reviewer
- [ ] I've tested existing features (website scan, sitemap, custom flow) in both node index and cli
- [ ] I've synced this fork with GovTechSG repo
- [ ] I've added/updated unit tests
- [ ] I've added/updated any necessary dependencies in `package[-lock].json` `npm audit`, portable installation on GitHub Actions
