### PR TITLE
Fix/local sitemap no pages scanned

### DIFF
--- a/src/constants/common.ts
+++ b/src/constants/common.ts
@@ -976,7 +976,7 @@ export const getLinksFromSitemap = async (
   const addToUrlList = (url: string) => {
     if (!url) return;
     if (isDisallowedInRobotsTxt(url)) return;
-    if (!isFollowStrategy(url, userUrl, strategy)) return;
+    if (!isFilePath(userUrl) && !isFollowStrategy(url, userUrl, strategy)) return;
 
     url = convertPathToLocalFile(url);
 

--- a/src/crawlers/crawlDomain.ts
+++ b/src/crawlers/crawlDomain.ts
@@ -172,7 +172,8 @@ const crawlDomain = async ({
       const isNotSupportedDocument: boolean = disallowedListOfPatterns.some(pattern =>
         newPageUrl.toLowerCase().startsWith(pattern),
       );
-      return isNotSupportedDocument || isAlreadyScanned || isBlacklistedUrl || isNotFollowStrategy;
+      const isRobotsDisallowed: boolean = isDisallowedInRobotsTxt(newPageUrl);
+      return isNotSupportedDocument || isAlreadyScanned || isBlacklistedUrl || isNotFollowStrategy || isRobotsDisallowed;
     };
     const setPageListeners = (pageListener: Page): void => {
       // event listener to handle new page popups upon button click
@@ -481,7 +482,7 @@ const crawlDomain = async ({
           }
 
           const isRedirected = !areLinksEqual(finalUrl, requestLabelUrl);
-          if (isRedirected) {
+          if (isRedirected && !isDisallowedInRobotsTxt(finalUrl)) {
             await enqueueUniqueRequest({ url: finalUrl, label: finalUrl });
           } else {
             request.skipNavigation = false;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1082,12 +1082,10 @@ export const randomThreeDigitNumberString = () => {
 export const normUrl = (u: string): string => (u ? normalizeUrl(u) || u : '');
 
 export const isFollowStrategy = (link1: string, link2: string, rule: string): boolean => {
+  if (rule === 'all') return true;
   try {
     const parsedLink1 = new URL(link1);
     const parsedLink2 = new URL(link2);
-    if (rule === 'all') {
-      return true;
-    }
     if (rule === 'same-origin') {
       return parsedLink1.origin === parsedLink2.origin;
     }


### PR DESCRIPTION
## Problem

Two bugs were found affecting scans that use a local sitemap file (`-u /path/to/sitemap.xml`) and scans with `--followRobots yes`.

---

### Bug 1 — Local sitemap scans produce zero pages

When a local file path is passed as the scan target (e.g. `-u /app/sitemaps/foo.xml`), `crawlSitemap` falls back to using the raw file path as `userUrl`. Inside `getLinksFromSitemap`, every URL extracted from the sitemap goes through `isFollowStrategy(sitemapUrl, '/app/sitemaps/foo.xml', strategy)`. That function calls `new URL('/app/sitemaps/foo.xml')` which throws because a bare file path is not a valid URL. The `catch` block returns `false` for every URL, so nothing is added to the crawl queue.

This was reproduced in production logs showing `"This is a XML format sitemap."` immediately followed by `"No pages were scanned."` for a 1000-URL sitemap.

**Root cause chain:**

```
crawlLocalFile  →  crawlSitemap (no userUrl passed, defaults to '')
                →  getLinksFromSitemap(userUrl = '' || '/app/sitemaps/foo.xml')
                →  addToUrlList: isFollowStrategy(httpsUrl, '/app/sitemaps/...', 'all')
                →  new URL('/app/sitemaps/...') throws
                →  catch returns false  →  URL rejected  →  0 pages scanned
```

Note: even with `strategy = 'all'`, the early-return was placed *after* the URL parsing that throws, so it was never reached.

**Fixes (`src/utils.ts`, `src/constants/common.ts`):**

- Move the `rule === 'all'` short-circuit before URL parsing in `isFollowStrategy` — the most common strategy no longer parses URLs at all
- Skip the strategy check in `addToUrlList` when `userUrl` is a local file path (`isFilePath`), since origin/hostname comparison is meaningless against a file path

---

### Bug 2 — robots.txt disallow rules not enforced for JS-driven URLs

With `--followRobots yes`, disallowed URLs found via `<a>` tags were correctly blocked at enqueue time (via `transformRequestFunction`). However, URLs discovered through three other paths were not checked at enqueue and were **fetched by the browser** before the page-handler safety net could filter them:

| Discovery path | Code location | robots.txt checked at enqueue? |
|---|---|---|
| `<a>` tags via `enqueueLinks` | `crawlDomain.ts:333` | ✅ Yes (`transformRequestFunction`) |
| JS popups (`window.open`) | `crawlDomain.ts:183` | ❌ No |
| Frame navigations | `crawlDomain.ts:211` | ❌ No |
| Interactive element clicks | `crawlDomain.ts:294` | ❌ No |
| Redirect destinations | `crawlDomain.ts:485` | ❌ No |

The last four all went through `enqueueUniqueRequest` or `isExcluded` with no robots.txt check, so the browser would navigate to disallowed URLs (making real HTTP requests) even though they were ultimately not scanned.

**Fixes (`src/crawlers/crawlDomain.ts`):**

- Add `isDisallowedInRobotsTxt` to `isExcluded` — popup, framenavigated, and click-discovered URLs are blocked before being queued and never fetched
- Guard the redirect enqueue at line 485 with the same check

---

## Changes

| File | Change |
|---|---|
| `src/utils.ts` | Move `rule === 'all'` early-return before URL parsing in `isFollowStrategy` |
| `src/constants/common.ts` | Skip strategy check in `addToUrlList` when `userUrl` is a local file path |
| `src/crawlers/crawlDomain.ts` | Add `isDisallowedInRobotsTxt` to `isExcluded`; guard redirect enqueue |

## Testing

- Verified with production logs: scan command `node ./oobee/dist/cli.js -u /app/sitemaps/foo.xml` against a 1000-URL sitemap previously returned "No pages were scanned" — fixed by Bug 1 changes
- `isDisallowedInRobotsTxt` returns `false` (no-op) when `followRobots` is disabled (`constants.robotsTxtUrls === null`), so Bug 2 changes have zero impact when the flag is off
