### PR TITLE
fix: correctly block exact paths and query-string patterns from robots.txt

### DIFF
--- a/src/constants/common.ts
+++ b/src/constants/common.ts
@@ -806,7 +806,11 @@ export const getUrlsFromRobotsTxt = async (
   const disallowedUrls = [];
   const allowedUrls = [];
 
-  const sanitisePattern = (pattern: string): string => {
+  // Returns 1–2 minimatch glob patterns for a single robots.txt path pattern.
+  // Two patterns are returned for bare paths (no trailing wildcard) so that
+  // both the exact URL and all child paths are blocked, matching robots.txt
+  // prefix semantics.
+  const sanitisePattern = (pattern: string): string[] => {
     const directoryRegex = /^\/(?:[^?#/]+\/)*[^?#]*$/;
     const subdirWildcardRegex = /\/\*\//g;
     const filePathRegex = /^\/(?:[^\/]+\/)*[^\/]+\.[a-zA-Z0-9]{1,6}$/;
@@ -814,16 +818,30 @@ export const getUrlsFromRobotsTxt = async (
     if (subdirWildcardRegex.test(pattern)) {
       pattern = pattern.replace(subdirWildcardRegex, '/**/');
     }
+
+    // Query-string patterns (e.g. /faq?faqItem= or /faq/?faq&faqItem=):
+    // '?' is the query separator in robots.txt but a single-char wildcard in
+    // minimatch. Escape it to a literal match and append '*' so any query
+    // value after the stated prefix is also blocked.
+    if (pattern.includes('?')) {
+      return [domain + pattern.replace('?', '\\?') + '*'];
+    }
+
     if (pattern.match(directoryRegex) && !pattern.match(filePathRegex)) {
       if (pattern.endsWith('*')) {
-        pattern = pattern.concat('*');
+        // e.g. /ebook/* → /ebook/** (already covers all children)
+        return [domain + pattern.concat('*')];
       } else {
-        if (!pattern.endsWith('/')) pattern = pattern.concat('/');
-        pattern = pattern.concat('**');
+        // Bare path (e.g. /subscription/unsubscribe): robots.txt blocks the
+        // exact URL *and* every descendant. minimatch's '/**' glob does not
+        // match the bare path itself (no trailing slash), so we emit both the
+        // exact-path pattern and a children glob.
+        const base = domain + pattern;
+        const children = domain + (pattern.endsWith('/') ? pattern : pattern + '/') + '**';
+        return [base, children];
       }
     }
-    const final = domain.concat(pattern);
-    return final;
+    return [domain + pattern];
   };
 
   for (const line of lines) {
@@ -834,14 +852,12 @@ export const getUrlsFromRobotsTxt = async (
     } else if (shouldCapture && line.toLowerCase().startsWith('disallow:')) {
       let disallowed = line.substring('disallow: '.length).trim();
       if (disallowed) {
-        disallowed = sanitisePattern(disallowed);
-        disallowedUrls.push(disallowed);
+        disallowedUrls.push(...sanitisePattern(disallowed));
       }
     } else if (shouldCapture && line.toLowerCase().startsWith('allow:')) {
       let allowed = line.substring('allow: '.length).trim();
       if (allowed) {
-        allowed = sanitisePattern(allowed);
-        allowedUrls.push(allowed);
+        allowedUrls.push(...sanitisePattern(allowed));
       }
     }
   }


### PR DESCRIPTION
Two bugs in sanitisePattern/getUrlsFromRobotsTxt:

1. Bare paths (e.g. /subscription/unsubscribe) were converted to a single '/**' glob which does not match the exact URL without a trailing slash. Now emits both the exact-path pattern and a children glob so the page itself and all descendants are blocked per robots.txt prefix semantics.

2. Query-string patterns (e.g. /faq?faqItem= or /faq/?faq&faqItem=) were passed to minimatch unchanged, where '?' is a single-char wildcard rather than a query-string separator.  The '?' is now escaped to '\?' for a literal match and '*' is appended to block any query value after the prefix.

sanitisePattern return type changed from string to string[]; call sites updated to spread the result into disallowedUrls / allowedUrls.

This PR adds... <!-- A brief description of what your PR does -->

<!-- This checklist is just a guideline.-->
<!-- If any of the following does not apply to your PR, please leave them unchecked and explain in the PR -->

- [ ] I've kept this PR as small as possible (~500 lines) by splitting it into PRs with manageable chunks of code
- [ ] I've requested reviews from 1 reviewer
- [ ] I've tested existing features (website scan, sitemap, custom flow) in both node index and cli
- [ ] I've synced this fork with GovTechSG repo
- [ ] I've added/updated unit tests
- [ ] I've added/updated any necessary dependencies in `package[-lock].json` `npm audit`, portable installation on GitHub Actions
