### PR TITLE
fix: reduce memory usage in mergeAxeResults for large scans

### DIFF
--- a/src/mergeAxeResults.ts
+++ b/src/mergeAxeResults.ts
@@ -31,6 +31,7 @@ import { consoleLogger } from './logs.js';
 import itemTypeDescription from './constants/itemTypeDescription.js';
 import { oobeeAiHtmlETL, oobeeAiRules } from './constants/oobeeAi.js';
 import { buildHtmlGroups, convertItemsToReferences } from './mergeAxeResults/itemReferences.js';
+import { ItemsStore } from './mergeAxeResults/itemsStore.js';
 import {
   compressJsonFileStreaming,
   writeJsonAndBase64Files,
@@ -418,7 +419,7 @@ const writeSummaryPdf = async (
 // Tracking WCAG occurrences
 const wcagOccurrencesMap = new Map<string, number>();
 
-const pushResults = async (pageResults, allIssues, isCustomFlow) => {
+const pushResults = async (pageResults, allIssues, isCustomFlow, itemsStore: ItemsStore) => {
   const { url, pageTitle, filePath } = pageResults;
 
   const totalIssuesInPage = new Set();
@@ -433,15 +434,15 @@ const pushResults = async (pageResults, allIssues, isCustomFlow) => {
     totalOccurrences: 0,
   });
 
-  ['mustFix', 'goodToFix', 'needsReview', 'passed'].forEach(category => {
-    if (!pageResults[category]) return;
+  for (const category of ['mustFix', 'goodToFix', 'needsReview', 'passed'] as const) {
+    if (!pageResults[category]) continue;
 
     const { totalItems, rules } = pageResults[category];
     const currCategoryFromAllIssues = allIssues.items[category];
 
     currCategoryFromAllIssues.totalItems += totalItems;
 
-    Object.keys(rules).forEach(rule => {
+    for (const rule of Object.keys(rules)) {
       const {
         description,
         axeImpact,
@@ -457,7 +458,6 @@ const pushResults = async (pageResults, allIssues, isCustomFlow) => {
           helpUrl,
           conformance,
           totalItems: 0,
-          // numberOfPagesAffectedAfterRedirects: 0,
           pagesAffected: {},
         };
       }
@@ -470,7 +470,6 @@ const pushResults = async (pageResults, allIssues, isCustomFlow) => {
               allIssues.wcagViolations.push(c);
             }
 
-            // Track WCAG criteria occurrences for Sentry
             const currentCount = wcagOccurrencesMap.get(c) || 0;
             wcagOccurrencesMap.set(c, currentCount + count);
           });
@@ -480,9 +479,6 @@ const pushResults = async (pageResults, allIssues, isCustomFlow) => {
 
       currRuleFromAllIssues.totalItems += count;
 
-      // Build htmlGroups for pre-computed Group by HTML Element
-      buildHtmlGroups(currRuleFromAllIssues, items, url);
-
       if (isCustomFlow) {
         const { pageIndex, pageImagePath, metadata } = pageResults;
         currRuleFromAllIssues.pagesAffected[pageIndex] = {
@@ -490,17 +486,31 @@ const pushResults = async (pageResults, allIssues, isCustomFlow) => {
           pageTitle,
           pageImagePath,
           metadata,
-          items: [...items],
+          itemsCount: items.length,
         };
+        await itemsStore.appendPageItems(category, rule, {
+          url,
+          pageTitle,
+          items,
+          pageIndex,
+          pageImagePath,
+          metadata,
+        });
       } else if (!(url in currRuleFromAllIssues.pagesAffected)) {
         currRuleFromAllIssues.pagesAffected[url] = {
           pageTitle,
-          items: [...items],
+          itemsCount: items.length,
           ...(filePath && { filePath }),
         };
+        await itemsStore.appendPageItems(category, rule, {
+          url,
+          pageTitle,
+          items,
+          ...(filePath && { filePath }),
+        });
       }
-    });
-  });
+    }
+  }
 };
 
 const getTopTenIssues = allIssues => {
@@ -561,26 +571,26 @@ const flattenAndSortResults = (allIssues: AllIssues, isCustomFlow: boolean) => {
           .map(pageEntry => {
             if (isCustomFlow) {
               const [pageIndex, pageInfo] = pageEntry as unknown as [number, PageInfo];
-              // Only update the occurrences map if not passed.
               if (category !== 'passed') {
                 urlOccurrencesMap.set(
                   pageInfo.url!,
-                  (urlOccurrencesMap.get(pageInfo.url!) || 0) + pageInfo.items.length,
+                  (urlOccurrencesMap.get(pageInfo.url!) || 0) + (pageInfo.itemsCount || 0),
                 );
               }
               return { pageIndex, ...pageInfo };
             }
             const [url, pageInfo] = pageEntry as unknown as [string, PageInfo];
             if (category !== 'passed') {
-              urlOccurrencesMap.set(url, (urlOccurrencesMap.get(url) || 0) + pageInfo.items.length);
+              urlOccurrencesMap.set(
+                url,
+                (urlOccurrencesMap.get(url) || 0) + (pageInfo.itemsCount || 0),
+              );
             }
             return { url, ...pageInfo };
           })
-          // Sort pages so that those with the most items come first
-          .sort((page1, page2) => page2.items.length - page1.items.length);
+          .sort((page1, page2) => (page2.itemsCount || 0) - (page1.itemsCount || 0));
         return { rule, ...ruleInfo };
       })
-      // Sort the rules by totalItems (descending)
       .sort((rule1, rule2) => rule2.totalItems - rule1.totalItems);
   });
 
@@ -631,19 +641,24 @@ const extractRuleAiData = (
 };
 
 // This is for telemetry purposes called within mergeAxeResults.ts
-export const createRuleIdJson = allIssues => {
+export const createRuleIdJson = async (allIssues, itemsStore?: ItemsStore) => {
   const compiledRuleJson = {};
 
-  ['mustFix', 'goodToFix', 'needsReview'].forEach(category => {
-    allIssues.items[category].rules.forEach(rule => {
-      const allItems = rule.pagesAffected.flatMap(page => page.items || []);
-      compiledRuleJson[rule.rule] = extractRuleAiData(rule.rule, rule.totalItems, allItems, () => {
-        rule.pagesAffected.forEach(p => {
-          delete p.items;
-        });
-      });
-    });
-  });
+  for (const category of ['mustFix', 'goodToFix', 'needsReview'] as const) {
+    for (const rule of allIssues.items[category].rules) {
+      let allItems: any[] = [];
+
+      if (itemsStore) {
+        for await (const entry of itemsStore.readRuleItems(category, rule.rule)) {
+          allItems.push(...entry.items);
+        }
+      } else {
+        allItems = rule.pagesAffected.flatMap(page => page.items || []);
+      }
+
+      compiledRuleJson[rule.rule] = extractRuleAiData(rule.rule, rule.totalItems, allItems);
+    }
+  }
 
   return compiledRuleJson;
 };
@@ -815,20 +830,20 @@ const generateArtifacts = async (
   };
 
   const allFiles = await extractFileNames(intermediateDatasetsPath);
+  const itemsStore = new ItemsStore(storagePath);
 
-  const jsonArray = await Promise.all(
-    allFiles.map(async file => parseContentToJson(`${intermediateDatasetsPath}/${file}`)),
-  );
-
-  await Promise.all(
-    jsonArray.map(async pageResults => {
-      await pushResults(pageResults, allIssues, isCustomFlow);
-    }),
-  ).catch(flattenIssuesError => {
-    consoleLogger.error(
-      `[generateArtifacts] Error flattening issues: ${flattenIssuesError?.stack || flattenIssuesError}`,
-    );
-  });
+  for (const file of allFiles) {
+    try {
+      const pageResults = await parseContentToJson(`${intermediateDatasetsPath}/${file}`);
+      if (pageResults) {
+        await pushResults(pageResults, allIssues, isCustomFlow, itemsStore);
+      }
+    } catch (flattenIssuesError: any) {
+      consoleLogger.error(
+        `[generateArtifacts] Error processing ${file}: ${flattenIssuesError?.stack || flattenIssuesError}`,
+      );
+    }
+  }
 
   flattenAndSortResults(allIssues, isCustomFlow);
 
@@ -863,6 +878,15 @@ const generateArtifacts = async (
   }
 
   populateScanPagesDetail(allIssues);
+
+  // Build htmlGroups in a second pass from disk-backed items
+  for (const category of ['mustFix', 'goodToFix', 'needsReview', 'passed'] as const) {
+    for (const rule of allIssues.items[category].rules) {
+      for await (const entry of itemsStore.readRuleItems(category, rule.rule)) {
+        buildHtmlGroups(rule, entry.items, entry.url);
+      }
+    }
+  }
 
   allIssues.wcagPassPercentage = getWcagPassPercentage(
     allIssues.wcagViolations,
@@ -928,7 +952,7 @@ const generateArtifacts = async (
     rest.minor = axeImpactCount.minor;
   }
 
-  await writeCsv(allIssues, storagePath);
+  await writeCsv(allIssues, storagePath, itemsStore);
   await writeSitemap(pagesScanned, storagePath);
   const {
     scanDataJsonFilePath,
@@ -945,7 +969,7 @@ const generateArtifacts = async (
     scanPagesSummaryBase64FilePath,
     scanDataJsonFileSize,
     scanItemsJsonFileSize,
-  } = await writeJsonAndBase64Files(allIssues, storagePath);
+  } = await writeJsonAndBase64Files(allIssues, storagePath, itemsStore);
   // Removed BIG_RESULTS_THRESHOLD check - always use full scanItems
 
   await writeScanDetailsCsv(
@@ -1058,7 +1082,10 @@ const generateArtifacts = async (
   }
 
   // Generate scrubbed HTML Code Snippets
-  const ruleIdJson = createRuleIdJson(allIssues);
+  const ruleIdJson = await createRuleIdJson(allIssues, itemsStore);
+
+  // Clean up intermediate items files
+  await itemsStore.cleanup();
 
   // At the end of the function where results are generated, add:
   try {

--- a/src/mergeAxeResults/itemsStore.ts
+++ b/src/mergeAxeResults/itemsStore.ts
@@ -1,0 +1,73 @@
+import fs from 'fs-extra';
+import path from 'path';
+import readline from 'readline';
+import type { ItemsInfo } from './types.js';
+
+export interface ItemsStoreEntry {
+  url: string;
+  pageTitle: string;
+  items: ItemsInfo[];
+  filePath?: string;
+  pageIndex?: number;
+  pageImagePath?: string;
+  metadata?: string;
+}
+
+export class ItemsStore {
+  private basePath: string;
+  private ensuredDirs = new Set<string>();
+
+  constructor(storagePath: string) {
+    this.basePath = path.join(storagePath, 'tmp-items');
+  }
+
+  private sanitizeRuleId(ruleId: string): string {
+    return ruleId.replace(/[^a-zA-Z0-9_-]/g, '_');
+  }
+
+  private getRuleFilePath(category: string, ruleId: string): string {
+    return path.join(this.basePath, category, `${this.sanitizeRuleId(ruleId)}.jsonl`);
+  }
+
+  private async ensureDir(category: string): Promise<void> {
+    const dirPath = path.join(this.basePath, category);
+    if (!this.ensuredDirs.has(dirPath)) {
+      await fs.ensureDir(dirPath);
+      this.ensuredDirs.add(dirPath);
+    }
+  }
+
+  async appendPageItems(category: string, ruleId: string, entry: ItemsStoreEntry): Promise<void> {
+    await this.ensureDir(category);
+    const filePath = this.getRuleFilePath(category, ruleId);
+    const line = JSON.stringify(entry) + '\n';
+    await fs.appendFile(filePath, line, 'utf8');
+  }
+
+  async *readRuleItems(category: string, ruleId: string): AsyncGenerator<ItemsStoreEntry> {
+    const filePath = this.getRuleFilePath(category, ruleId);
+    if (!fs.existsSync(filePath)) return;
+
+    const fileStream = fs.createReadStream(filePath, { encoding: 'utf8' });
+    const rl = readline.createInterface({ input: fileStream, crlfDelay: Infinity });
+
+    for await (const line of rl) {
+      if (line.trim()) {
+        yield JSON.parse(line) as ItemsStoreEntry;
+      }
+    }
+  }
+
+  async readRuleItemsMap(category: string, ruleId: string): Promise<Map<string, ItemsStoreEntry>> {
+    const map = new Map<string, ItemsStoreEntry>();
+    for await (const entry of this.readRuleItems(category, ruleId)) {
+      const key = entry.pageIndex != null ? String(entry.pageIndex) : entry.url;
+      map.set(key, entry);
+    }
+    return map;
+  }
+
+  async cleanup(): Promise<void> {
+    await fs.rm(this.basePath, { recursive: true, force: true });
+  }
+}

--- a/src/mergeAxeResults/jsonArtifacts.ts
+++ b/src/mergeAxeResults/jsonArtifacts.ts
@@ -6,6 +6,7 @@ import { pipeline } from 'stream/promises';
 import { a11yRuleShortDescriptionMap } from '../constants/constants.js';
 import { consoleLogger } from '../logs.js';
 import type { AllIssues } from './types.js';
+import type { ItemsStore } from './itemsStore.js';
 
 function* serializeObject(obj: any, depth = 0, indent = '  ') {
   const currentIndent = indent.repeat(depth);
@@ -79,158 +80,151 @@ function writeLargeJsonToFile(obj: object, filePath: string) {
   });
 }
 
-const writeLargeScanItemsJsonToFile = async (obj: object, filePath: string) => {
-  return new Promise((resolve, reject) => {
-    const writeStream = fs.createWriteStream(filePath, { flags: 'a', encoding: 'utf8' });
-    const writeQueue: string[] = [];
-    let isWriting = false;
+const writeLargeScanItemsJsonToFile = async (
+  obj: object,
+  filePath: string,
+  itemsStore?: ItemsStore,
+) => {
+  const writeStream = fs.createWriteStream(filePath, { flags: 'a', encoding: 'utf8' });
 
-    const processNextWrite = async () => {
-      if (isWriting || writeQueue.length === 0) return;
+  const write = (data: string): Promise<void> => {
+    if (!writeStream.write(data)) {
+      return new Promise<void>(resolve => writeStream.once('drain', resolve));
+    }
+    return Promise.resolve();
+  };
 
-      isWriting = true;
-      const data = writeQueue.shift()!;
+  try {
+    await write('{\n');
+    const keys = Object.keys(obj);
 
-      try {
-        if (!writeStream.write(data)) {
-          await new Promise<void>(resolve => {
-            writeStream.once('drain', () => {
-              resolve();
-            });
-          });
+    for (let i = 0; i < keys.length; i++) {
+      const key = keys[i];
+      const value = obj[key];
+
+      if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+        await write(`  "${key}": ${JSON.stringify(value)}`);
+      } else {
+        await write(`  "${key}": {\n`);
+
+        const { rules, ...otherProperties } = value;
+        const otherKeys = Object.keys(otherProperties);
+
+        for (let j = 0; j < otherKeys.length; j++) {
+          const propKey = otherKeys[j];
+          const propValue = otherProperties[propKey];
+          const propValueString =
+            propValue === null ||
+            typeof propValue === 'function' ||
+            typeof propValue === 'undefined'
+              ? 'null'
+              : JSON.stringify(propValue);
+          await write(`    "${propKey}": ${propValueString}`);
+          if (j < otherKeys.length - 1 || (rules && rules.length >= 0)) {
+            await write(',\n');
+          } else {
+            await write('\n');
+          }
         }
-      } catch (error) {
-        writeStream.destroy(error as Error);
-        return;
+
+        if (rules && Array.isArray(rules)) {
+          await write('    "rules": [\n');
+
+          for (let j = 0; j < rules.length; j++) {
+            const rule = rules[j];
+            await write('      {\n');
+            const { pagesAffected, ...otherRuleProperties } = rule;
+            const ruleKeys = Object.keys(otherRuleProperties);
+
+            for (let k = 0; k < ruleKeys.length; k++) {
+              const ruleKey = ruleKeys[k];
+              const ruleValue = otherRuleProperties[ruleKey];
+              const ruleValueString =
+                ruleValue === null ||
+                typeof ruleValue === 'function' ||
+                typeof ruleValue === 'undefined'
+                  ? 'null'
+                  : JSON.stringify(ruleValue);
+              await write(`        "${ruleKey}": ${ruleValueString}`);
+              if (k < ruleKeys.length - 1 || pagesAffected) {
+                await write(',\n');
+              } else {
+                await write('\n');
+              }
+            }
+
+            if (pagesAffected && Array.isArray(pagesAffected)) {
+              // Load items from disk for this rule if itemsStore is available
+              let itemsMap: Map<string, any> | null = null;
+              if (itemsStore && rule.rule) {
+                itemsMap = await itemsStore.readRuleItemsMap(key, rule.rule);
+              }
+
+              await write('        "pagesAffected": [\n');
+
+              for (let p = 0; p < pagesAffected.length; p++) {
+                const page = pagesAffected[p];
+                let fullPage = page;
+
+                if (itemsMap) {
+                  const lookupKey =
+                    page.pageIndex != null ? String(page.pageIndex) : page.url;
+                  const entry = itemsMap.get(lookupKey);
+                  if (entry) {
+                    // Strip itemsCount to match original scanItems.json format
+                    const { itemsCount: _ic, ...pageWithoutCount } = page;
+                    fullPage = { ...pageWithoutCount, items: entry.items };
+                  }
+                }
+
+                const pageJson = JSON.stringify(fullPage, null, 2)
+                  .split('\n')
+                  .map(line => `          ${line}`)
+                  .join('\n');
+
+                await write(pageJson);
+
+                if (p < pagesAffected.length - 1) {
+                  await write(',\n');
+                } else {
+                  await write('\n');
+                }
+              }
+
+              await write('        ]');
+            }
+
+            await write('\n      }');
+            if (j < rules.length - 1) {
+              await write(',\n');
+            } else {
+              await write('\n');
+            }
+          }
+
+          await write('    ]');
+        }
+        await write('\n  }');
       }
 
-      isWriting = false;
-      processNextWrite();
-    };
-
-    const queueWrite = (data: string) => {
-      writeQueue.push(data);
-      processNextWrite();
-    };
-
-    writeStream.on('error', error => {
-      consoleLogger.error(`Error writing object to JSON file: ${error}`);
-      reject(error);
-    });
-
-    writeStream.on('finish', () => {
-      consoleLogger.info(`JSON file written successfully: ${filePath}`);
-      resolve(true);
-    });
-
-    try {
-      queueWrite('{\n');
-      const keys = Object.keys(obj);
-
-      keys.forEach((key, i) => {
-        const value = obj[key];
-
-        if (value === null || typeof value !== 'object' || Array.isArray(value)) {
-          queueWrite(`  "${key}": ${JSON.stringify(value)}`);
-        } else {
-          queueWrite(`  "${key}": {\n`);
-
-          const { rules, ...otherProperties } = value;
-
-          Object.entries(otherProperties).forEach(([propKey, propValue], j) => {
-            const propValueString =
-              propValue === null ||
-              typeof propValue === 'function' ||
-              typeof propValue === 'undefined'
-                ? 'null'
-                : JSON.stringify(propValue);
-            queueWrite(`    "${propKey}": ${propValueString}`);
-            if (j < Object.keys(otherProperties).length - 1 || (rules && rules.length >= 0)) {
-              queueWrite(',\n');
-            } else {
-              queueWrite('\n');
-            }
-          });
-
-          if (rules && Array.isArray(rules)) {
-            queueWrite('    "rules": [\n');
-
-            rules.forEach((rule, j) => {
-              queueWrite('      {\n');
-              const { pagesAffected, ...otherRuleProperties } = rule;
-
-              Object.entries(otherRuleProperties).forEach(([ruleKey, ruleValue], k) => {
-                const ruleValueString =
-                  ruleValue === null ||
-                  typeof ruleValue === 'function' ||
-                  typeof ruleValue === 'undefined'
-                    ? 'null'
-                    : JSON.stringify(ruleValue);
-                queueWrite(`        "${ruleKey}": ${ruleValueString}`);
-                if (k < Object.keys(otherRuleProperties).length - 1 || pagesAffected) {
-                  queueWrite(',\n');
-                } else {
-                  queueWrite('\n');
-                }
-              });
-
-              if (pagesAffected && Array.isArray(pagesAffected)) {
-                queueWrite('        "pagesAffected": [\n');
-
-                pagesAffected.forEach((page, p) => {
-                  const pageJson = JSON.stringify(page, null, 2)
-                    .split('\n')
-                    .map(line => `          ${line}`)
-                    .join('\n');
-
-                  queueWrite(pageJson);
-
-                  if (p < pagesAffected.length - 1) {
-                    queueWrite(',\n');
-                  } else {
-                    queueWrite('\n');
-                  }
-                });
-
-                queueWrite('        ]');
-              }
-
-              queueWrite('\n      }');
-              if (j < rules.length - 1) {
-                queueWrite(',\n');
-              } else {
-                queueWrite('\n');
-              }
-            });
-
-            queueWrite('    ]');
-          }
-          queueWrite('\n  }');
-        }
-
-        if (i < keys.length - 1) {
-          queueWrite(',\n');
-        } else {
-          queueWrite('\n');
-        }
-      });
-
-      queueWrite('}\n');
-
-      const checkQueueAndEnd = () => {
-        if (writeQueue.length === 0 && !isWriting) {
-          writeStream.end();
-        } else {
-          setTimeout(checkQueueAndEnd, 100);
-        }
-      };
-
-      checkQueueAndEnd();
-    } catch (err) {
-      writeStream.destroy(err as Error);
-      reject(err);
+      if (i < keys.length - 1) {
+        await write(',\n');
+      } else {
+        await write('\n');
+      }
     }
-  });
+
+    await write('}\n');
+  } finally {
+    writeStream.end();
+    await new Promise<void>((resolve, reject) => {
+      writeStream.on('finish', () => {
+        consoleLogger.info(`JSON file written successfully: ${filePath}`);
+        resolve();
+      });
+      writeStream.on('error', reject);
+    });
+  }
 };
 
 async function compressJsonFileStreaming(inputPath: string, outputPath: string) {
@@ -247,12 +241,13 @@ const writeJsonFileAndCompressedJsonFile = async (
   data: object,
   storagePath: string,
   filename: string,
+  itemsStore?: ItemsStore,
 ): Promise<{ jsonFilePath: string; base64FilePath: string }> => {
   try {
     consoleLogger.info(`Writing JSON to ${filename}.json`);
     const jsonFilePath = path.join(storagePath, `${filename}.json`);
     if (filename === 'scanItems') {
-      await writeLargeScanItemsJsonToFile(data, jsonFilePath);
+      await writeLargeScanItemsJsonToFile(data, jsonFilePath, itemsStore);
     } else {
       await writeLargeJsonToFile(data, jsonFilePath);
     }
@@ -277,6 +272,7 @@ const writeJsonFileAndCompressedJsonFile = async (
 const writeJsonAndBase64Files = async (
   allIssues: AllIssues,
   storagePath: string,
+  itemsStore?: ItemsStore,
 ): Promise<{
   scanDataJsonFilePath: string;
   scanDataBase64FilePath: string;
@@ -301,6 +297,7 @@ const writeJsonAndBase64Files = async (
       { oobeeAppVersion: allIssues.oobeeAppVersion, ...items },
       storagePath,
       'scanItems',
+      itemsStore,
     );
 
   ['mustFix', 'goodToFix', 'needsReview', 'passed'].forEach(category => {
@@ -345,22 +342,22 @@ const writeJsonAndBase64Files = async (
 
   items.mustFix.rules.forEach(rule => {
     rule.pagesAffected.forEach(page => {
-      page.itemsCount = page.items.length;
+      page.itemsCount = page.itemsCount ?? (Array.isArray(page.items) ? page.items.length : 0);
     });
   });
   items.goodToFix.rules.forEach(rule => {
     rule.pagesAffected.forEach(page => {
-      page.itemsCount = page.items.length;
+      page.itemsCount = page.itemsCount ?? (Array.isArray(page.items) ? page.items.length : 0);
     });
   });
   items.needsReview.rules.forEach(rule => {
     rule.pagesAffected.forEach(page => {
-      page.itemsCount = page.items.length;
+      page.itemsCount = page.itemsCount ?? (Array.isArray(page.items) ? page.items.length : 0);
     });
   });
   items.passed.rules.forEach(rule => {
     rule.pagesAffected.forEach(page => {
-      page.itemsCount = page.items.length;
+      page.itemsCount = page.itemsCount ?? (Array.isArray(page.items) ? page.items.length : 0);
     });
   });
 

--- a/src/mergeAxeResults/scanPages.ts
+++ b/src/mergeAxeResults/scanPages.ts
@@ -40,8 +40,8 @@ export default function populateScanPagesDetail(allIssues: AllIssues): void {
       const { rule: ruleId, conformance = [] } = rule;
 
       rule.pagesAffected.forEach(p => {
-        const { url, pageTitle, items = [] } = p;
-        const itemsCount = items.length;
+        const { url, pageTitle, itemsCount: storedCount, items } = p as any;
+        const itemsCount: number = storedCount ?? (Array.isArray(items) ? items.length : 0);
 
         if (!pagesMap[url]) {
           pagesMap[url] = {

--- a/src/mergeAxeResults/writeCsv.ts
+++ b/src/mergeAxeResults/writeCsv.ts
@@ -1,18 +1,46 @@
 import { createWriteStream } from 'fs';
-import { AsyncParser, ParserOptions } from '@json2csv/node';
 import { a11yRuleShortDescriptionMap } from '../constants/constants.js';
 import type { AllIssues, RuleInfo } from './types.js';
+import type { ItemsStore } from './itemsStore.js';
 
-const writeCsv = async (allIssues: AllIssues, storagePath: string): Promise<void> => {
+function escapeCsvField(value: string): string {
+  if (value == null) return '';
+  const str = String(value);
+  return `"${str.replace(/"/g, '""')}"`;
+}
+
+const writeCsv = async (
+  allIssues: AllIssues,
+  storagePath: string,
+  itemsStore?: ItemsStore,
+): Promise<void> => {
   const csvOutput = createWriteStream(`${storagePath}/report.csv`, { encoding: 'utf8' });
+
   const formatPageViolation = (pageNum: number) => {
     if (pageNum < 0) return 'Document';
     return `Page ${pageNum}`;
   };
 
-  // transform allIssues into the form:
-  // [['mustFix', rule1], ['mustFix', rule2], ['goodToFix', rule3], ...]
-  const getRulesByCategory = (issues: AllIssues) => {
+  const fields = [
+    'customFlowLabel',
+    'deviceChosen',
+    'scanCompletedAt',
+    'severity',
+    'issueId',
+    'issueDescription',
+    'wcagConformance',
+    'url',
+    'pageTitle',
+    'context',
+    'howToFix',
+    'axeImpact',
+    'xpath',
+    'learnMore',
+  ];
+
+  csvOutput.write(fields.map(escapeCsvField).join(',') + '\n');
+
+  const getRulesByCategory = (issues: AllIssues): [string, RuleInfo][] => {
     return Object.entries(issues.items)
       .filter(([category]) => category !== 'passed')
       .reduce((prev: [string, RuleInfo][], [category, value]) => {
@@ -23,15 +51,14 @@ const writeCsv = async (allIssues: AllIssues, storagePath: string): Promise<void
         return prev;
       }, [])
       .sort((a, b) => {
-        // sort rules according to severity, then ruleId
         const compareCategory = -a[0].localeCompare(b[0]);
         return compareCategory === 0 ? a[1].rule.localeCompare(b[1].rule) : compareCategory;
       });
   };
 
-  const flattenRule = (catAndRule: [string, RuleInfo]) => {
-    const [severity, rule] = catAndRule;
-    const results = [];
+  const rulesByCategory = getRulesByCategory(allIssues);
+
+  for (const [severity, rule] of rulesByCategory) {
     const {
       rule: issueId,
       description: issueDescription,
@@ -41,104 +68,106 @@ const writeCsv = async (allIssues: AllIssues, storagePath: string): Promise<void
       helpUrl: learnMore,
     } = rule;
 
-    // format clauses as a string
     const wcagConformance = conformance.join(',');
 
-    pagesAffected.sort((a, b) => a.url.localeCompare(b.url));
+    if (itemsStore) {
+      const itemsMap = await itemsStore.readRuleItemsMap(severity, issueId);
+      const sortedPages = [...pagesAffected].sort((a, b) => (a.url || '').localeCompare(b.url || ''));
 
-    pagesAffected.forEach(affectedPage => {
-      const { url, items } = affectedPage;
-      items.forEach(item => {
-        const { html, message, xpath } = item;
-        const page = (item as any).page;
-        const howToFix = message.replace(/(\r\n|\n|\r)/g, '\\n'); // preserve newlines as \n
-        const violation = html || formatPageViolation(page); // page is a number, not a string
-        const context = violation.replace(/(\r\n|\n|\r)/g, ''); // remove newlines
+      for (const affectedPage of sortedPages) {
+        const key = affectedPage.pageIndex != null ? String(affectedPage.pageIndex) : affectedPage.url;
+        const entry = itemsMap.get(key);
+        if (!entry) continue;
 
-        results.push({
-          customFlowLabel: allIssues.customFlowLabel || '',
-          deviceChosen: allIssues.deviceChosen || '',
-          scanCompletedAt: allIssues.endTime ? allIssues.endTime.toISOString() : '',
-          severity: severity || '',
-          issueId: issueId || '',
-          issueDescription: a11yRuleShortDescriptionMap[issueId] || issueDescription || '',
-          wcagConformance: wcagConformance || '',
-          url: url || '',
-          pageTitle: affectedPage.pageTitle || 'No page title',
-          context: context || '',
-          howToFix: howToFix || '',
-          axeImpact: axeImpact || '',
-          xpath: xpath || '',
-          learnMore: learnMore || '',
-        });
-      });
-    });
-    if (results.length === 0) return {};
-    return results;
-  };
+        for (const item of entry.items) {
+          const { html, message, xpath } = item;
+          const page = (item as any).page;
+          const howToFix = (message || '').replace(/(\r\n|\n|\r)/g, '\\n');
+          const violation = html || formatPageViolation(page);
+          const context = violation.replace(/(\r\n|\n|\r)/g, '');
 
-  const opts: ParserOptions<any, any> = {
-    transforms: [getRulesByCategory, flattenRule],
-    fields: [
-      'customFlowLabel',
-      'deviceChosen',
-      'scanCompletedAt',
-      'severity',
-      'issueId',
-      'issueDescription',
-      'wcagConformance',
-      'url',
-      'pageTitle',
-      'context',
-      'howToFix',
-      'axeImpact',
-      'xpath',
-      'learnMore',
-    ],
-    includeEmptyRows: true,
-  };
+          const row = [
+            allIssues.customFlowLabel || '',
+            allIssues.deviceChosen || '',
+            allIssues.endTime ? allIssues.endTime.toISOString() : '',
+            severity || '',
+            issueId || '',
+            a11yRuleShortDescriptionMap[issueId] || issueDescription || '',
+            wcagConformance || '',
+            affectedPage.url || '',
+            affectedPage.pageTitle || 'No page title',
+            context || '',
+            howToFix || '',
+            axeImpact || '',
+            xpath || '',
+            learnMore || '',
+          ].map(escapeCsvField);
 
-  // Create the parse stream (it's asynchronous)
-  const parser = new AsyncParser(opts);
-  const parseStream = parser.parse(allIssues);
+          csvOutput.write(row.join(',') + '\n');
+        }
+      }
+    } else {
+      const sortedPages = [...pagesAffected].sort((a, b) => (a.url || '').localeCompare(b.url || ''));
 
-  // Pipe JSON2CSV output into the file, but don't end automatically
-  parseStream.pipe(csvOutput, { end: false });
+      for (const affectedPage of sortedPages) {
+        const items = (affectedPage as any).items || [];
+        for (const item of items) {
+          const { html, message, xpath } = item;
+          const page = (item as any).page;
+          const howToFix = (message || '').replace(/(\r\n|\n|\r)/g, '\\n');
+          const violation = html || formatPageViolation(page);
+          const context = violation.replace(/(\r\n|\n|\r)/g, '');
 
-  // Once JSON2CSV is done writing all normal rows, append any "pagesNotScanned"
-  parseStream.on('end', () => {
-    if (allIssues.pagesNotScanned && allIssues.pagesNotScanned.length > 0) {
-      csvOutput.write('\n');
-      allIssues.pagesNotScanned.forEach(page => {
-        const skippedPage = {
-          customFlowLabel: allIssues.customFlowLabel || '',
-          deviceChosen: allIssues.deviceChosen || '',
-          scanCompletedAt: allIssues.endTime ? allIssues.endTime.toISOString() : '',
-          severity: 'error',
-          issueId: 'error-pages-skipped',
-          issueDescription: page.metadata
-            ? page.metadata
-            : 'An unknown error caused the page to be skipped',
-          wcagConformance: '',
-          url: page.url || page || '',
-          pageTitle: 'Error',
-          context: '',
-          howToFix: '',
-          axeImpact: '',
-          xpath: '',
-          learnMore: '',
-        };
-        csvOutput.write(`${Object.values(skippedPage).join(',')}\n`);
-      });
+          const row = [
+            allIssues.customFlowLabel || '',
+            allIssues.deviceChosen || '',
+            allIssues.endTime ? allIssues.endTime.toISOString() : '',
+            severity || '',
+            issueId || '',
+            a11yRuleShortDescriptionMap[issueId] || issueDescription || '',
+            wcagConformance || '',
+            affectedPage.url || '',
+            affectedPage.pageTitle || 'No page title',
+            context || '',
+            howToFix || '',
+            axeImpact || '',
+            xpath || '',
+            learnMore || '',
+          ].map(escapeCsvField);
+
+          csvOutput.write(row.join(',') + '\n');
+        }
+      }
     }
+  }
 
-    // Now close the CSV file
-    csvOutput.end();
-  });
+  if (allIssues.pagesNotScanned && allIssues.pagesNotScanned.length > 0) {
+    allIssues.pagesNotScanned.forEach(page => {
+      const row = [
+        allIssues.customFlowLabel || '',
+        allIssues.deviceChosen || '',
+        allIssues.endTime ? allIssues.endTime.toISOString() : '',
+        'error',
+        'error-pages-skipped',
+        page.metadata ? page.metadata : 'An unknown error caused the page to be skipped',
+        '',
+        (page as any).url || page || '',
+        'Error',
+        '',
+        '',
+        '',
+        '',
+        '',
+      ].map(escapeCsvField);
 
-  parseStream.on('error', (err: unknown) => {
-    console.error('Error parsing CSV:', err);
-    csvOutput.end();
+      csvOutput.write(row.join(',') + '\n');
+    });
+  }
+
+  csvOutput.end();
+  await new Promise<void>((resolve, reject) => {
+    csvOutput.on('finish', resolve);
+    csvOutput.on('error', reject);
   });
 };
 


### PR DESCRIPTION
Stream page result files sequentially instead of loading all into memory, write violation items to per-rule JSONL files on disk during accumulation (keeping only itemsCount in the in-memory allIssues object), and defer htmlGroups construction to a second pass reading from disk.

This reduces peak heap from ~3GB to well under 4GB for 1,000-page scans on ECS containers, preventing OOM during report artifact generation.

## Summary

Fixes OOM crash (`FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory`) during report generation (`generateArtifacts` / `mergeAxeResults`) when scanning 1,000 pages on ECS with 4GB memory.

**Root cause**: The `allIssues` object accumulated full violation `items[]` arrays (html, xpath, message, screenshotPath) for every page x every rule simultaneously in memory. Combined with loading all ~1,000 crawlee JSON files in parallel, peak heap exceeded 3GB.

**Fix**: Three memory reduction strategies:
- **Sequential file processing** — read one page JSON at a time instead of `Promise.all` loading all 1,000 files
- **Disk-backed items storage** — write violation items to per-rule JSONL files during accumulation, keeping only `itemsCount` in memory
- **Deferred htmlGroups** — build htmlGroups in a second pass reading from disk, after the main accumulation is complete

## Changes

| File | What changed |
|------|-------------|
| `src/mergeAxeResults/itemsStore.ts` | **New** — `ItemsStore` class managing per-rule JSONL files under `<storagePath>/tmp-items/` |
| `src/mergeAxeResults.ts` | Sequential loop, `pushResults` writes items to disk, `flattenAndSortResults` uses `itemsCount`, htmlGroups second pass, `createRuleIdJson` made async |
| `src/mergeAxeResults/jsonArtifacts.ts` | `writeLargeScanItemsJsonToFile` rewritten with async/await, loads items from disk per-rule during streaming write |
| `src/mergeAxeResults/writeCsv.ts` | Replaced `@json2csv/node` AsyncParser with manual streaming CSV that reads items per-rule from disk |
| `src/mergeAxeResults/scanPages.ts` | Uses `itemsCount` with fallback for backward compat |

## Memory impact

| | Before | After |
|---|--------|-------|
| Page JSON loading | All ~1,000 files in memory (~500MB) | 1 file at a time (~500KB) |
| Items in allIssues | All pages x all rules (~500MB-1GB) | Only `itemsCount` per page (~2MB) |
| Peak during report gen | One rule's items from disk (~2.5MB) | One rule's items from disk (~2.5MB) |
| **Estimated peak reduction** | | **~500MB - 1.5GB** |

## Output differences

### scanItems.json — identical
`itemsCount` field is stripped during write to match the original format (items were written before `itemsCount` was set in the old code).

### report.html — identical
EJS template only accesses metadata/counts (never `page.items[]`). `htmlGroups` and `convertItemsToReferences` produce the same data since they're built before `writeHTML` runs.

### scanData.json, scanIssuesSummary.json, scanPagesDetail.json, scanPagesSummary.json, scanItemsSummary.json — identical
These files don't contain page-level items.

### report.csv — functionally equivalent, minor formatting difference
The old code used `@json2csv/node` which always double-quotes every field. The new code also always double-quotes every field to match. One minor difference: the new code adds a trailing `\n` after the last row, while json2csv did not. Content and field ordering are identical.

## Disk I/O tradeoff

The fix trades memory for temporary disk usage:
- Up to ~800 JSONL files created under `<storagePath>/tmp-items/` (one per category/rule)
- Total temporary disk: ~same size as the crawlee dataset (~100-500MB for 1,000 pages)
- Files are cleaned up after `createRuleIdJson` completes
- Sequential access patterns mean OS file cache is effective

## Test plan

- [ ] TypeScript compiles cleanly (`npx tsc --noEmit` passes)
- [ ] Run a 5-10 page scan locally, diff `scanItems.json` against a pre-change baseline
- [ ] Run a 50+ page scan with `--max-old-space-size=2048` to verify no OOM
- [ ] Verify report.html renders correctly in browser (check "Group by HTML Element" view)
- [ ] Verify CSV opens correctly in Excel/Google Sheets
- [ ] Deploy to ECS with 4GB and run 1,000 page scan



This PR adds... <!-- A brief description of what your PR does -->

<!-- This checklist is just a guideline.-->
<!-- If any of the following does not apply to your PR, please leave them unchecked and explain in the PR -->

- [ ] I've kept this PR as small as possible (~500 lines) by splitting it into PRs with manageable chunks of code
- [ ] I've requested reviews from 1 reviewer
- [ ] I've tested existing features (website scan, sitemap, custom flow) in both node index and cli
- [ ] I've synced this fork with GovTechSG repo
- [ ] I've added/updated unit tests
- [ ] I've added/updated any necessary dependencies in `package[-lock].json` `npm audit`, portable installation on GitHub Actions
