### PR TITLE
ci: generate and commit oobee-client-scanner.js in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,6 +22,17 @@ jobs:
       - run: npm run build
         continue-on-error: false
 
+      - name: Generate oobee-client-scanner.js
+        run: node dist/generateOobeeClientScanner.js
+
+      - name: Commit generated client scanner
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add oobee-client-scanner.js
+          git diff --cached --quiet || git commit -m "chore: regenerate oobee-client-scanner.js"
+          git push origin HEAD:${{ github.ref_name }}
+
       - name: Create and push git tags
         run: |
           VERSION=$(node -p "require('./package.json').version")


### PR DESCRIPTION
Run dist/generateOobeeClientScanner.js after build and commit the generated bundle back to the repo before tagging and publishing.

This PR adds... <!-- A brief description of what your PR does -->

<!-- This checklist is just a guideline.-->
<!-- If any of the following does not apply to your PR, please leave them unchecked and explain in the PR -->

- [ ] I've kept this PR as small as possible (~500 lines) by splitting it into PRs with manageable chunks of code
- [ ] I've requested reviews from 1 reviewer
- [ ] I've tested existing features (website scan, sitemap, custom flow) in both node index and cli
- [ ] I've synced this fork with GovTechSG repo
- [ ] I've added/updated unit tests
- [ ] I've added/updated any necessary dependencies in `package[-lock].json` `npm audit`, portable installation on GitHub Actions
