### PR TITLE
fix: use Crawlee dataset.drop() for graceful storage cleanup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -226,7 +226,7 @@ When making changes, validate these areas which have well-established edge cases
 
 ### Crawlee Lifecycle & Cleanup
 - Crawlee's async lock-file operations (`.json.lock` mkdir) can fire after the crawl finishes. On Windows, this triggers uncaughtException EPERM during report generation. A scoped exception handler suppresses these. The cleanup delay is 5s on Windows, 3s on others.
-- The crawlee dataset folder must be deleted BEFORE zipping results. The deletion uses an awaited delay (not fire-and-forget setTimeout) to let lingering Crawlee I/O flush.
+- The crawlee dataset folder and `tmp-items` (intermediate JSONL store) must be deleted BEFORE zipping results. `zipResults` must be the last step in `generateArtifacts()` — any cleanup or processing that removes temp files from `storagePath` must happen earlier. The dataset deletion uses an awaited delay (not fire-and-forget setTimeout) to let lingering Crawlee I/O flush.
 - Errors must only be recorded in `failedRequestHandler` (after all retries exhausted), not in the `requestHandler` catch block. Crawlee retries up to 3 times, so recording in the catch block creates duplicates and false positives for URLs that succeed on retry.
 
 ### URL & Redirect Handling

--- a/src/mergeAxeResults.ts
+++ b/src/mergeAxeResults.ts
@@ -5,6 +5,7 @@ import printMessage from 'print-message';
 import path from 'path';
 import ejs from 'ejs';
 import { fileURLToPath } from 'url';
+import { Dataset, RequestQueue, Configuration } from 'crawlee';
 import constants, {
   BrowserTypes,
   ScannerTypes,
@@ -1063,36 +1064,34 @@ const generateArtifacts = async (
     1,
   );
 
-  // Suppress uncaught EPERM errors from lingering Crawlee async lock-file operations
-  // (Windows holds mandatory file locks; Crawlee may still attempt mkdir on .json.lock
-  // files after the crawl has finished). Without this, Node crashes with uncaughtException.
-  const crawleeEpermHandler = (err: Error & { code?: string }) => {
-    if (err.code === 'EPERM' && err.message?.includes('crawlee')) {
-      consoleLogger.info(`Suppressed lingering Crawlee storage error: ${err.message}`);
-      return;
-    }
-    // Re-throw non-crawlee EPERM errors so they aren't silently swallowed
-    throw err;
-  };
-  process.on('uncaughtException', crawleeEpermHandler);
-  process.on('unhandledRejection', crawleeEpermHandler);
+  // Flush pending background storage operations (metadata writes, lock-file ops)
+  const storageClient = Configuration.getStorageClient();
+  if (storageClient.teardown) {
+    await storageClient.teardown();
+  }
 
-  // Brief delay to allow lingering async crawlee storage operations to flush
-  await new Promise(resolve => setTimeout(resolve, process.platform === 'win32' ? 5000 : 3000));
+  // Gracefully drop Dataset and RequestQueue — releases locks and removes files
+  const crawleeDir = path.join(storagePath, 'crawlee');
+  try {
+    const dataset = await Dataset.open(crawleeDir);
+    await dataset.drop();
+  } catch (error) {
+    consoleLogger.info(`Dataset drop: ${error.message}`);
+  }
 
+  try {
+    const requestQueue = await RequestQueue.open(crawleeDir);
+    await requestQueue.drop();
+  } catch (error) {
+    consoleLogger.info(`RequestQueue drop: ${error.message}`);
+  }
+
+  // Fallback rm for any leftover files not managed by Crawlee's storage API
   const crawleePath = path.join(storagePath, 'crawlee');
   try {
     await fs.promises.rm(crawleePath, { recursive: true, force: true });
-  } catch (error) {
-    // On Windows, retry once after a delay if the folder is still locked
-    if (process.platform === 'win32') {
-      await new Promise(resolve => setTimeout(resolve, 3000));
-      try {
-        await fs.promises.rm(crawleePath, { recursive: true, force: true });
-      } catch {
-        // Best-effort cleanup — leave the folder; report generation continues
-      }
-    }
+  } catch {
+    // Best-effort; storage was already dropped via API
   }
 
   try {
@@ -1177,9 +1176,6 @@ const generateArtifacts = async (
 
   if (process.env.RUNNING_FROM_PH_GUI || process.env.OOBEE_VERBOSE)
     console.log('Report generated successfully');
-
-  process.removeListener('uncaughtException', crawleeEpermHandler);
-  process.removeListener('unhandledRejection', crawleeEpermHandler);
 
   return ruleIdJson;
 };

--- a/src/mergeAxeResults.ts
+++ b/src/mergeAxeResults.ts
@@ -1100,6 +1100,31 @@ const generateArtifacts = async (
     consoleLogger.warn(`Unable to force remove pdfs folder: ${error.message}`);
   }
 
+  // Generate scrubbed HTML Code Snippets
+  const ruleIdJson = await createRuleIdJson(allIssues, itemsStore);
+
+  // Clean up intermediate items files before zipping
+  await itemsStore.cleanup();
+
+  try {
+    await sendWcagBreakdownToSentry(
+      oobeeAppVersion,
+      wcagOccurrencesMap,
+      ruleIdJson,
+      {
+        entryUrl: urlScanned,
+        scanType,
+        browser: scanDetails.deviceChosen,
+        email: scanDetails.nameEmail?.email,
+        name: scanDetails.nameEmail?.name,
+      },
+      allIssues,
+      pagesScanned.length,
+    );
+  } catch (error) {
+    console.error('Error sending WCAG data to Sentry:', error);
+  }
+
   // Take option if set
   if (typeof zip === 'string') {
     constants.cliZipFileName = zip;
@@ -1144,34 +1169,6 @@ const generateArtifacts = async (
     printMessage(messageToDisplay);
   } catch (error) {
     printMessage([`Error in zipping results: ${error}`]);
-  }
-
-  // Generate scrubbed HTML Code Snippets
-  const ruleIdJson = await createRuleIdJson(allIssues, itemsStore);
-
-  // Clean up intermediate items files
-  await itemsStore.cleanup();
-
-  // At the end of the function where results are generated, add:
-  try {
-    // Always send WCAG breakdown to Sentry, even if no violations were found
-    // This ensures that all criteria are reported, including those with 0 occurrences
-    await sendWcagBreakdownToSentry(
-      oobeeAppVersion,
-      wcagOccurrencesMap,
-      ruleIdJson,
-      {
-        entryUrl: urlScanned,
-        scanType,
-        browser: scanDetails.deviceChosen,
-        email: scanDetails.nameEmail?.email,
-        name: scanDetails.nameEmail?.name,
-      },
-      allIssues,
-      pagesScanned.length,
-    );
-  } catch (error) {
-    console.error('Error sending WCAG data to Sentry:', error);
   }
 
   if (process.env.RUNNING_FROM_PH_GUI || process.env.OOBEE_VERBOSE)

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -6,6 +6,7 @@ import axe, { Rule } from 'axe-core';
 import { v4 as uuidv4 } from 'uuid';
 import { getDomain } from 'tldts';
 import { normalizeUrl } from '@apify/utilities';
+import { Dataset, RequestQueue, Configuration } from 'crawlee';
 import constants, {
   BrowserTypes,
   destinationPath,
@@ -390,6 +391,19 @@ export const cleanUp = async (randomToken?: string, isError: boolean = false): P
   if (randomToken !== undefined) {
     const storagePath = getStoragePath(randomToken);
 
+    try {
+      const storageClient = Configuration.getStorageClient();
+      if (storageClient.teardown) {
+        await storageClient.teardown();
+      }
+      const crawleeDir = path.join(storagePath, 'crawlee');
+      const dataset = await Dataset.open(crawleeDir);
+      await dataset.drop();
+      const requestQueue = await RequestQueue.open(crawleeDir);
+      await requestQueue.drop();
+    } catch (error) {
+      consoleLogger.info(`Crawlee storage drop in cleanUp: ${error.message}`);
+    }
     try {
       fs.rmSync(path.join(storagePath, 'crawlee'), { recursive: true, force: true });
     } catch (error) {


### PR DESCRIPTION
## Summary
- Replace platform-specific EPERM workaround in `generateArtifacts` with Crawlee's native `dataset.drop()` and `requestQueue.drop()` APIs
- Call `Configuration.getStorageClient().teardown()` to flush pending background writes before dropping storage
- Eliminate the 3-5 second delay and Windows retry logic that was needed to work around file locks

## Test plan
- [ ] Run a full scan on macOS/Linux — verify crawlee folder is cleanly removed with no warnings
- [ ] Run on Windows — verify no EPERM errors or Node crashes
- [ ] Verify scan results (HTML report, CSV, JSON) are generated correctly
- [ ] Test error path: kill scan mid-way, verify `cleanUp()` doesn't hang
- [ ] Run existing test suite: `npm test`
