### PR TITLE
fix: remove duplicate/false-positive error entries caused by request retries

### DIFF
--- a/src/crawlers/crawlDomain.ts
+++ b/src/crawlers/crawlDomain.ts
@@ -777,27 +777,20 @@ const crawlDomain = async ({
               });
             }
           } catch {
-            // Do nothing since the error will be pushed
+            // Recovery failed; Crawlee will retry the request automatically
           }
 
-          // when max pages have been scanned, scan will abort and all relevant pages still opened will close instantly.
-          // a browser close error will then be flagged. Since this is an intended behaviour, this error will be excluded.
-          if (!isAbortingScanNow) {
-            guiInfoLog(guiInfoStatusTypes.ERROR, {
-              numScanned: urlsCrawled.scanned.length,
-              urlScanned: request.url,
-            });
-
-            urlsCrawled.error.push({
-              url: request.url,
-              pageTitle: request.url,
-              actualUrl: request.url,
-              metadata: STATUS_CODE_METADATA[2],
-            });
-          }
+          // Do not push to urlsCrawled.error here — Crawlee will retry the request
+          // (up to maxRequestRetries, default 3). If all retries are exhausted,
+          // failedRequestHandler will record the error. Pushing here causes
+          // duplicates and false positives for URLs that succeed on retry.
         }
       },
       failedRequestHandler: async ({ request, response }) => {
+        if (isAbortingScanNow) {
+          return;
+        }
+
         guiInfoLog(guiInfoStatusTypes.ERROR, {
           numScanned: urlsCrawled.scanned.length,
           urlScanned: request.url,

--- a/src/crawlers/crawlSitemap.ts
+++ b/src/crawlers/crawlSitemap.ts
@@ -420,20 +420,10 @@ const crawlSitemap = async ({
             }
           }
         } catch (e) {
-          if (!isAbortingScan) {
-            guiInfoLog(guiInfoStatusTypes.ERROR, {
-              numScanned: urlsCrawled.scanned.length,
-              urlScanned: request.url,
-            });
-
-            urlsCrawled.error.push({
-              url: request.url,
-              pageTitle: request.url,
-              actualUrl: request.url,
-              metadata: STATUS_CODE_METADATA[2],
-              httpStatusCode: 0,
-            });
-          }
+          // Do not push to urlsCrawled.error here — Crawlee will retry the request
+          // (up to maxRequestRetries, default 3). If all retries are exhausted,
+          // failedRequestHandler will record the error. Pushing here causes
+          // duplicates and false positives for URLs that succeed on retry.
         }
       },
       failedRequestHandler: async ({ request, response, error }) => {


### PR DESCRIPTION
## Summary
- Remove `urlsCrawled.error.push()` from `requestHandler` catch blocks in both `crawlDomain.ts` and `crawlSitemap.ts`
- Errors are now only recorded in `failedRequestHandler`, which fires exclusively after all retries (default 3) are exhausted
- Add `isAbortingScanNow` guard to `failedRequestHandler` in `crawlDomain.ts` to avoid recording spurious errors during intentional scan abort

## Problem
When a URL failed during crawling, the error was immediately pushed to `urlsCrawled.error` in the `requestHandler` catch block — on **every** failed attempt. Since Crawlee retries requests up to 3 times by default (`retryOnBlocked: true`), this caused:
1. **Duplicate entries** — the same URL appeared in the error list multiple times (once per failed attempt)
2. **False positives** — URLs that succeeded on retry (attempt 2 or 3) still had error entries from earlier failed attempts, appearing in reports as errors despite being successfully scanned

## Fix
Rely on Crawlee's built-in retry mechanism and only record errors in `failedRequestHandler`, which is called once after all retries are exhausted. The `failedRequestHandler` also provides more accurate status codes (actual HTTP response status when available vs always reporting a generic "Web Crawler Errored").

## Test plan
- [ ] Run a crawl against a site with intermittent access issues and verify no duplicate URLs in the error report
- [ ] Verify URLs that succeed on retry do not appear in the error list
- [ ] Verify URLs that fail all retries still appear exactly once in the error list with correct status codes
- [ ] Verify aborting a scan mid-crawl does not produce spurious error entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)
