### PR TITLE
fix: resolve sitemap detection and content fetch failures in headless/Docker environments

### DIFF
--- a/src/combine.ts
+++ b/src/combine.ts
@@ -6,7 +6,7 @@ import crawlLocalFile from './crawlers/crawlLocalFile.js';
 import crawlIntelligentSitemap from './crawlers/crawlIntelligentSitemap.js';
 import generateArtifacts from './mergeAxeResults.js';
 import { getHost, createAndUpdateResultsFolders, cleanUpAndExit, getStoragePath } from './utils.js';
-import { ScannerTypes, UrlsCrawled } from './constants/constants.js';
+import constants, { ScannerTypes, UrlsCrawled } from './constants/constants.js';
 import { getBlackListedPatterns, submitForm } from './constants/common.js';
 import { consoleLogger, silentLogger } from './logs.js';
 import runCustom from './crawlers/runCustom.js';
@@ -72,6 +72,7 @@ const combineRun = async (details: Data, deviceToScan: string) => {
 
   process.env.CRAWLEE_LOG_LEVEL = 'ERROR';
   process.env.CRAWLEE_STORAGE_DIR = randomToken;
+  constants.sitemapFetchedLinks = null;
 
   if (process.env.CRAWLEE_SYSTEM_INFO_V2 === undefined) {
     // Set the environment variable to enable system info v2

--- a/src/combine.ts
+++ b/src/combine.ts
@@ -274,6 +274,7 @@ const combineRun = async (details: Data, deviceToScan: string) => {
         scanDetails,
         zip,
         generateJsonFiles,
+        browser,
       );
       const [name, email] = nameEmail.split(':');
 

--- a/src/constants/common.ts
+++ b/src/constants/common.ts
@@ -977,7 +977,7 @@ export const isDisallowedInRobotsTxt = (url: string): boolean => {
 
 export const getLinksFromSitemap = async (
   sitemapUrl: string,
-  maxLinksCount: number,
+  _maxLinksCount: number,
   browser: string,
   userDataDirectory: string,
   userUrlInput: string,
@@ -1237,10 +1237,10 @@ export const getLinksFromSitemap = async (
     consoleLogger.error(e);
   }
 
-  // Build Request objects only for the URLs that will actually be crawled
+  // Build Request objects for all discovered URLs; the crawler itself enforces
+  // maxRequestsPerCrawl by counting only successfully scanned pages.
   const requestList: Request[] = [];
   for (const url of allUrls) {
-    if (requestList.length >= maxLinksCount) break;
     try {
       const request = new Request({ url });
       if (isUrlPdf(url)) {

--- a/src/constants/common.ts
+++ b/src/constants/common.ts
@@ -888,6 +888,7 @@ const getRobotsTxtViaPlaywright = async (
       browserContext = await constants.launcher.launchPersistentContext(robotsDataDir, {
         ...getPlaywrightLaunchOptions(browser),
         ...(extraHTTPHeaders && { extraHTTPHeaders }),
+        ...(process.env.OOBEE_USER_AGENT && { userAgent: process.env.OOBEE_USER_AGENT }),
       });
       register(browserContext);
     } else {
@@ -895,9 +896,10 @@ const getRobotsTxtViaPlaywright = async (
       const launchOptions = getPlaywrightLaunchOptions(browser);
       browserInstance = await constants.launcher.launch(launchOptions);
       register(browserInstance as unknown as { close: () => Promise<void> });
-      
+
       browserContext = await browserInstance.newContext({
         ...(extraHTTPHeaders && { extraHTTPHeaders }),
+        ...(process.env.OOBEE_USER_AGENT && { userAgent: process.env.OOBEE_USER_AGENT }),
       });
     }
 

--- a/src/constants/common.ts
+++ b/src/constants/common.ts
@@ -1260,9 +1260,10 @@ export const getLinksFromSitemap = async (
     fetchedLinks,
   }));
 
+  const prev = constants.sitemapFetchedLinks;
   constants.sitemapFetchedLinks = {
-    totalLinksFetchedFromSitemaps: requestList.length,
-    fetchedSitemaps,
+    totalLinksFetchedFromSitemaps: (prev?.totalLinksFetchedFromSitemaps ?? 0) + requestList.length,
+    fetchedSitemaps: [...(prev?.fetchedSitemaps ?? []), ...fetchedSitemaps],
   };
 
   if (requestList.length > 0) {

--- a/src/constants/common.ts
+++ b/src/constants/common.ts
@@ -988,9 +988,7 @@ export const getLinksFromSitemap = async (
 ) => {
   const scannedSitemaps = new Set<string>();
   const sitemapLinkCounts: Record<string, number> = {};
-  const urls: Record<string, Request> = {}; // dictionary of requests to urls to be scanned
-
-  const isLimitReached = () => Object.keys(urls).length >= maxLinksCount;
+  const allUrls = new Set<string>(); // all discovered URLs (lightweight strings)
 
   const addToUrlList = (url: string) => {
     if (!url) return;
@@ -998,17 +996,7 @@ export const getLinksFromSitemap = async (
     if (!isFilePath(userUrl) && !isFollowStrategy(url, userUrl, strategy)) return;
 
     url = convertPathToLocalFile(url);
-
-    let request;
-    try {
-      request = new Request({ url });
-    } catch (e) {
-      console.log('Error creating request', e);
-    }
-    if (isUrlPdf(url)) {
-      request.skipNavigation = true;
-    }
-    urls[url] = request;
+    allUrls.add(url);
   };
 
   const calculateCloseness = (sitemapUrl: string) => {
@@ -1061,16 +1049,15 @@ export const getLinksFromSitemap = async (
       });
     }
 
-    // Add the sorted URLs to the main URL list
-    for (const { url } of urlList.slice(0, maxLinksCount)) {
+    // Add all URLs to the discovered list (limit applied later at return time)
+    for (const { url } of urlList) {
       addToUrlList(url);
     }
   };
 
   const processNonStandardSitemap = (data: string) => {
     const urlsFromData = crawlee
-      .extractUrls({ string: data, urlRegExp: new RegExp('^(http|https):/{2}.+$', 'gmi') })
-      .slice(0, maxLinksCount);
+      .extractUrls({ string: data, urlRegExp: new RegExp('^(http|https):/{2}.+$', 'gmi') });
     urlsFromData.forEach(url => {
       addToUrlList(url);
     });
@@ -1207,16 +1194,13 @@ export const getLinksFromSitemap = async (
       sitemapType = constants.xmlSitemapTypes.unknown;
     }
 
-    const countBefore = Object.keys(urls).length;
+    const countBefore = allUrls.size;
 
     switch (sitemapType) {
       case constants.xmlSitemapTypes.xmlIndex:
         consoleLogger.info(`This is a XML format sitemap index.`);
         for (const childSitemapUrl of $('loc')) {
           const childSitemapUrlText = $(childSitemapUrl).text();
-          if (isLimitReached()) {
-            break;
-          }
           if (childSitemapUrlText.endsWith('.xml') || childSitemapUrlText.endsWith('.txt')) {
             await fetchUrls(childSitemapUrlText, extraHTTPHeaders); // Recursive call for nested sitemaps
           } else {
@@ -1241,7 +1225,7 @@ export const getLinksFromSitemap = async (
         processNonStandardSitemap(data);
     }
 
-    const linksFromThisSitemap = Object.keys(urls).length - countBefore;
+    const linksFromThisSitemap = allUrls.size - countBefore;
     if (linksFromThisSitemap > 0) {
       sitemapLinkCounts[url] = (sitemapLinkCounts[url] || 0) + linksFromThisSitemap;
     }
@@ -1253,8 +1237,22 @@ export const getLinksFromSitemap = async (
     consoleLogger.error(e);
   }
 
-  const requestList = Object.values(urls);
+  // Build Request objects only for the URLs that will actually be crawled
+  const requestList: Request[] = [];
+  for (const url of allUrls) {
+    if (requestList.length >= maxLinksCount) break;
+    try {
+      const request = new Request({ url });
+      if (isUrlPdf(url)) {
+        request.skipNavigation = true;
+      }
+      requestList.push(request);
+    } catch (e) {
+      consoleLogger.info(`Error creating request for ${url}: ${e}`);
+    }
+  }
 
+  const totalLinksDiscovered = allUrls.size;
   const fetchedSitemaps = Object.entries(sitemapLinkCounts).map(([url, fetchedLinks]) => ({
     url,
     fetchedLinks,
@@ -1262,16 +1260,16 @@ export const getLinksFromSitemap = async (
 
   const prev = constants.sitemapFetchedLinks;
   constants.sitemapFetchedLinks = {
-    totalLinksFetchedFromSitemaps: (prev?.totalLinksFetchedFromSitemaps ?? 0) + requestList.length,
+    totalLinksFetchedFromSitemaps: (prev?.totalLinksFetchedFromSitemaps ?? 0) + totalLinksDiscovered,
     fetchedSitemaps: [...(prev?.fetchedSitemaps ?? []), ...fetchedSitemaps],
   };
 
-  if (requestList.length > 0) {
+  if (totalLinksDiscovered > 0) {
     const breakdown = fetchedSitemaps
       .map(({ url, fetchedLinks }) => `${url} (${fetchedLinks})`)
       .join(', ');
     consoleLogger.info(
-      `There are a total of ${requestList.length} links found across ${breakdown}.`,
+      `There are a total of ${totalLinksDiscovered} links found across ${breakdown}.`,
     );
   }
 

--- a/src/constants/common.ts
+++ b/src/constants/common.ts
@@ -987,6 +987,7 @@ export const getLinksFromSitemap = async (
   userUrl: string = userUrlInput,
 ) => {
   const scannedSitemaps = new Set<string>();
+  const sitemapLinkCounts: Record<string, number> = {};
   const urls: Record<string, Request> = {}; // dictionary of requests to urls to be scanned
 
   const isLimitReached = () => Object.keys(urls).length >= maxLinksCount;
@@ -1206,6 +1207,8 @@ export const getLinksFromSitemap = async (
       sitemapType = constants.xmlSitemapTypes.unknown;
     }
 
+    const countBefore = Object.keys(urls).length;
+
     switch (sitemapType) {
       case constants.xmlSitemapTypes.xmlIndex:
         consoleLogger.info(`This is a XML format sitemap index.`);
@@ -1237,6 +1240,11 @@ export const getLinksFromSitemap = async (
         consoleLogger.info(`This is an unrecognised XML sitemap format.`);
         processNonStandardSitemap(data);
     }
+
+    const linksFromThisSitemap = Object.keys(urls).length - countBefore;
+    if (linksFromThisSitemap > 0) {
+      sitemapLinkCounts[url] = (sitemapLinkCounts[url] || 0) + linksFromThisSitemap;
+    }
   };
 
   try {
@@ -1246,6 +1254,15 @@ export const getLinksFromSitemap = async (
   }
 
   const requestList = Object.values(urls);
+
+  if (requestList.length > 0) {
+    const breakdown = Object.entries(sitemapLinkCounts)
+      .map(([sitemapUrl, count]) => `${sitemapUrl} (${count})`)
+      .join(', ');
+    consoleLogger.info(
+      `There are a total of ${requestList.length} links found across ${breakdown}.`,
+    );
+  }
 
   return requestList;
 };

--- a/src/constants/common.ts
+++ b/src/constants/common.ts
@@ -1120,6 +1120,7 @@ export const getLinksFromSitemap = async (
               // Bug in Chrome which causes browser pool crash when userDataDirectory is set in non-headless mode
               ...(process.env.CRAWLEE_HEADLESS === '1' && { userDataDir: userDataDirectory }),
               ...(extraHTTPHeaders && { extraHTTPHeaders }),
+              ...(process.env.OOBEE_USER_AGENT && { userAgent: process.env.OOBEE_USER_AGENT }),
             },
           );
 
@@ -1129,9 +1130,10 @@ export const getLinksFromSitemap = async (
           const launchOptions = getPlaywrightLaunchOptions(browser);
           browserInstance = await constants.launcher.launch(launchOptions);
           register(browserInstance as unknown as { close: () => Promise<void> });
-          
+
           browserContext = await browserInstance.newContext({
             ...(extraHTTPHeaders && { extraHTTPHeaders }),
+            ...(process.env.OOBEE_USER_AGENT && { userAgent: process.env.OOBEE_USER_AGENT }),
           });
         }
 

--- a/src/constants/common.ts
+++ b/src/constants/common.ts
@@ -1255,9 +1255,19 @@ export const getLinksFromSitemap = async (
 
   const requestList = Object.values(urls);
 
+  const fetchedSitemaps = Object.entries(sitemapLinkCounts).map(([url, fetchedLinks]) => ({
+    url,
+    fetchedLinks,
+  }));
+
+  constants.sitemapFetchedLinks = {
+    totalLinksFetchedFromSitemaps: requestList.length,
+    fetchedSitemaps,
+  };
+
   if (requestList.length > 0) {
-    const breakdown = Object.entries(sitemapLinkCounts)
-      .map(([sitemapUrl, count]) => `${sitemapUrl} (${count})`)
+    const breakdown = fetchedSitemaps
+      .map(({ url, fetchedLinks }) => `${url} (${fetchedLinks})`)
       .join(', ');
     consoleLogger.info(
       `There are a total of ${requestList.length} links found across ${breakdown}.`,

--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -946,6 +946,7 @@ export default {
   a11yRuleShortDescriptionMap,
   disabilityBadgesMap,
   robotsTxtUrls: null,
+  sitemapFetchedLinks: null as { totalLinksFetchedFromSitemaps: number; fetchedSitemaps: { url: string; fetchedLinks: number }[] } | null,
   userDataDirectory: null, // This will be set later in the code
   randomToken: null, // This will be set later in the code
   // Track all active Crawlee / Playwright resources for cleanup

--- a/src/crawlers/crawlIntelligentSitemap.ts
+++ b/src/crawlers/crawlIntelligentSitemap.ts
@@ -7,7 +7,7 @@ import { consoleLogger, guiInfoLog } from '../logs.js';
 import crawlDomain from './crawlDomain.js';
 import crawlSitemap from './crawlSitemap.js';
 import { ViewportSettingsClass } from '../combine.js';
-import { getPlaywrightLaunchOptions, getSitemapsFromRobotsTxt } from '../constants/common.js';
+import { getPlaywrightLaunchOptions, getSitemapsFromRobotsTxt, initModifiedUserAgent } from '../constants/common.js';
 import { register } from '../utils.js';
 
 const crawlIntelligentSitemap = async (
@@ -40,6 +40,10 @@ const crawlIntelligentSitemap = async (
 
   ({ dataset } = await createCrawleeSubFolders(randomToken));
 
+  // Initialise modified User-Agent early so sitemap discovery requests
+  // don't expose "HeadlessChrome" (which triggers bot-blocking on some sites).
+  await initModifiedUserAgent(browser);
+
   function getHomeUrl(parsedUrl: string) {
     const urlObject = new URL(parsedUrl);
     return `${urlObject.protocol}//${urlObject.hostname}${urlObject.port ? `:${urlObject.port}` : ''}`;
@@ -62,6 +66,7 @@ const crawlIntelligentSitemap = async (
       context = await constants.launcher.launchPersistentContext(effectiveUserDataDirectory, {
         ...launchOptions,
         ...(extraHTTPHeaders && { extraHTTPHeaders }),
+        ...(process.env.OOBEE_USER_AGENT && { userAgent: process.env.OOBEE_USER_AGENT }),
       });
       register(context);
     } else {
@@ -70,6 +75,7 @@ const crawlIntelligentSitemap = async (
       register(browserInstance as unknown as { close: () => Promise<void> });
       context = await browserInstance.newContext({
         ...(extraHTTPHeaders && { extraHTTPHeaders }),
+        ...(process.env.OOBEE_USER_AGENT && { userAgent: process.env.OOBEE_USER_AGENT }),
       });
     }
 
@@ -93,7 +99,7 @@ const crawlIntelligentSitemap = async (
   const checkUrlExists = async (page: Page, parsedUrl: string) => {
     try {
       const response = await page.goto(parsedUrl);
-      return response.ok();
+      return response?.ok() ?? false;
     } catch (e) {
       consoleLogger.error(e);
       return false;

--- a/src/mergeAxeResults.ts
+++ b/src/mergeAxeResults.ts
@@ -761,6 +761,8 @@ const generateArtifacts = async (
     endTime: scanDetails.endTime ? scanDetails.endTime : new Date(),
     urlScanned,
     scanType,
+    totalLinksFetchedFromSitemaps: constants.sitemapFetchedLinks?.totalLinksFetchedFromSitemaps ?? 0,
+    fetchedSitemaps: constants.sitemapFetchedLinks?.fetchedSitemaps ?? [],
     deviceChosen: scanDetails.deviceChosen || 'Desktop',
     formatAboutStartTime,
     isCustomFlow,

--- a/src/mergeAxeResults.ts
+++ b/src/mergeAxeResults.ts
@@ -741,6 +741,7 @@ const generateArtifacts = async (
   },
   zip: string = undefined, // optional
   generateJsonFiles = false,
+  preferredBrowser?: string,
 ) => {
   consoleLogger.info('Generating report artifacts');
 
@@ -1005,7 +1006,11 @@ const generateArtifacts = async (
     ]);
   }
 
-  const browserChannel = getBrowserToRun(randomToken, BrowserTypes.CHROME, false).browserToRun;
+  const browserChannel = getBrowserToRun(
+    randomToken,
+    (preferredBrowser as BrowserTypes) || BrowserTypes.CHROME,
+    false,
+  ).browserToRun;
 
   // Should consider refactor constants.userDataDirectory to be a parameter in future
   await retryFunction(

--- a/src/npmIndex.ts
+++ b/src/npmIndex.ts
@@ -363,6 +363,7 @@ export const init = async ({
   const { mustFix: mustFixThreshold, goodToFix: goodToFixThreshold } = thresholds;
 
   process.env.CRAWLEE_STORAGE_DIR = randomToken;
+  constants.sitemapFetchedLinks = null;
 
   const scanDetails = {
     startTime: new Date(),


### PR DESCRIPTION
## Summary

- Fix intelligent crawl failing to detect and fetch sitemaps in Docker/Linux (headless) due to `HeadlessChrome` User-Agent being blocked by WAFs (e.g. www.moh.gov.sg)
- Fix sitemap link discovery truncating at the page crawl limit (e.g. 10) instead of parsing and enqueuing all URLs from the sitemap
- Fix errored pages consuming the scan budget — all sitemap URLs are now enqueued and the crawler stops only when enough pages are *successfully* scanned
- Fix summary.pdf generation using inconsistent browser (hardcoded Chrome) instead of the user's preferred browser
- Add sitemap fetch diagnostics: console log with per-sitemap link breakdown and new `totalLinksFetchedFromSitemaps` / `fetchedSitemaps` fields in `scanData.json`

## Problem

### 1. HeadlessChrome UA blocked by bot-protection

In Docker/Linux environments, the intelligent crawl's sitemap discovery and content fetching phases launched Playwright browser contexts with the raw default User-Agent containing `HeadlessChrome`. Sites with bot-protection (Cloudflare, Akamai, etc.) block this UA, causing:

1. `robots.txt` fetch to fail or return a challenge page
2. Even when `robots.txt` succeeds, the actual sitemap XML content fetch gets blocked — resulting in 0 URLs extracted and the crawl falling through to domain crawl with the misleading log: "Continuing crawl from root website"

On macOS this worked because the browser ran in headful mode with a normal Chrome UA.

### 2. Sitemap link discovery truncated at crawl limit

`getLinksFromSitemap` was gating URL discovery with `isLimitReached()` which checked against `maxLinksCount` (= `maxRequestsPerCrawl`). If a user set max pages to 10, only 10 URLs were ever *discovered* from a sitemap with thousands of pages. This meant:
- The console log reported "10 links found" when the sitemap actually contained thousands
- `scanData.json` reported only the truncated count
- No visibility into whether the sitemap itself was large or small
- If those 10 pages errored out, remaining valid pages were never attempted

### 3. PDF browser inconsistency

`summary.pdf` generation always hardcoded `BrowserTypes.CHROME` regardless of the user's configured preferred browser, leading to inconsistent fallback chains across platforms (e.g. webkit on macOS without Chrome).

## Changes

### User-Agent fixes
- Call `initModifiedUserAgent()` early in `crawlIntelligentSitemap` before sitemap discovery
- Pass `OOBEE_USER_AGENT` to browser contexts in:
  - `findSitemap()` (sitemap path probing)
  - `getRobotsTxtViaPlaywright()` (robots.txt fetching)
  - `getLinksFromSitemap()` → `getDataUsingPlaywright()` (sitemap XML content fetching)
- Fix null-safety on `response.ok()` in `checkUrlExists`

### Sitemap link discovery and enqueue fix
- Collect all discovered URLs as lightweight strings in a `Set<string>` (no early truncation)
- Enqueue **all** discovered URLs as `Request` objects — the crawler already sets `maxRequestsPerCrawl: Infinity` internally and stops when `urlsCrawled.scanned.length` (successful scans only) reaches the user's limit
- This means errored pages no longer consume the scan budget; the crawler keeps trying remaining URLs until enough succeed
- Report the true total discovered count in logs and `scanData.json`
- Accumulate sitemap fetch data across multiple `crawlSitemap` calls (for intelligent crawl with multiple sitemaps from robots.txt)
- Reset `constants.sitemapFetchedLinks` at scan start to prevent stale data

### PDF generation browser consistency
- Add `preferredBrowser` parameter to `generateArtifacts()`
- Pass the user's actual browser choice from `combine.ts` (CLI flow)
- npm API path retains Chrome-first default

### Sitemap diagnostics
- Log per-sitemap link counts after parsing: `"There are a total of X links found across url1 (Y), url2 (Z)."`
- Add `totalLinksFetchedFromSitemaps` and `fetchedSitemaps` array to `scanData.json` output

## Test plan

- [ ] Run intelligent crawl against www.moh.gov.sg in Docker (headless Chromium) — verify sitemap URLs are extracted instead of falling through to domain crawl
- [ ] Run intelligent crawl on macOS (headful) — verify no regression, sitemap still discovered
- [ ] Verify a sitemap with thousands of URLs reports the full count (e.g. "3000 links found") even with maxPages=10
- [ ] Verify `scanData.json` contains `totalLinksFetchedFromSitemaps` and `fetchedSitemaps` fields with full counts
- [ ] Verify console logs show the per-sitemap breakdown message
- [ ] Run a non-sitemap scan — verify `totalLinksFetchedFromSitemaps: 0` and `fetchedSitemaps: []`
- [ ] Set preferred browser to `chromium` and verify `summary.pdf` is generated using Chromium (not webkit fallback on macOS)
- [ ] Test with a sitemap index (multiple child sitemaps) — verify all child sitemaps are enumerated in `fetchedSitemaps`
- [ ] Test with a local file sitemap (`./sitemap.xml`) — verify links are parsed and reported correctly
- [ ] Test with a sitemap of N+M pages (maxPages=N), where first N pages error — verify remaining M pages are still attempted and successfully scanned
