### PR TITLE
fix: normalize www prefix in hostname comparisons and add adaptive crawl rate control

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -224,6 +224,7 @@ When making changes, validate these areas which have well-established edge cases
 
 ### URL & Redirect Handling
 - `https://example.com` and `https://example.com/` must be treated as the same page. Use `normUrl()` (wrapping `@apify/utilities normalizeUrl`) for all dedup sets.
+- `www.example.com` and `example.com` must be treated as the same host for follow-strategy checks. Sitemaps commonly list child URLs without the `www.` prefix even when the parent sitemap is served from the `www.` subdomain. `isFollowStrategy()` in `src/utils.ts` strips the `www.` prefix before comparing hostnames.
 - Pages may redirect to external domains. The crawler detects this both pre-scan (via `response.url()` after goto) and post-scan (via `page.url()` after axe completes, since JS redirects can fire during scan). Results are discarded if the page leaves its queued hostname.
 - In custom flow, the entry URL should remain the user-provided URL, not the final redirected URL.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -224,7 +224,7 @@ When making changes, validate these areas which have well-established edge cases
 
 ### URL & Redirect Handling
 - `https://example.com` and `https://example.com/` must be treated as the same page. Use `normUrl()` (wrapping `@apify/utilities normalizeUrl`) for all dedup sets.
-- `www.example.com` and `example.com` must be treated as the same host for follow-strategy checks. Sitemaps commonly list child URLs without the `www.` prefix even when the parent sitemap is served from the `www.` subdomain. `isFollowStrategy()` in `src/utils.ts` strips the `www.` prefix before comparing hostnames.
+- `www.example.com` and `example.com` must be treated as the same host. Never compare hostnames with `===` directly — use `isSameHostname()` from `src/utils.ts`, which strips the `www.` prefix. This applies to follow-strategy checks, click-discovery gating, and any other hostname comparison. Sitemaps commonly list child URLs without the `www.` prefix; browsers redirect between www/non-www variants freely.
 - Pages may redirect to external domains. The crawler detects this both pre-scan (via `response.url()` after goto) and post-scan (via `page.url()` after axe completes, since JS redirects can fire during scan). Results are discarded if the page leaves its queued hostname.
 - In custom flow, the entry URL should remain the user-provided URL, not the final redirected URL.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -246,14 +246,15 @@ When making changes, validate these areas which have well-established edge cases
 - The `-s` (strategy) flag must be passed through to `crawlSitemap` and `getLinksFromSitemap`. For sitemap-only scans the default is `'ignore'` (all URLs); for domain/intelligent crawls it's `'same-domain'`.
 - `scanDuration=0` means unlimited. Code that calculates `remainingDuration` must treat 0 as "no limit", not as "0 seconds remaining".
 
-### Rate Limiting & Circuit Breaker
+### Rate Limiting, Adaptive Concurrency & CrawlRateController
 - Sites with WAFs (Cloudflare, Akamai, etc.) will start returning 403/503 after a certain number of concurrent requests — typically 200-300 pages in rapid succession.
-- Both `crawlSitemap` and `crawlDomain` have a consecutive-failure circuit breaker: if 100 consecutive requests fail with HTTP 4xx/5xx, the crawl aborts gracefully and proceeds to report generation with whatever pages were successfully scanned.
-- The threshold is configurable via `OOBEE_CONSECUTIVE_MAX_RETRIES` env var (default 100).
-- Only HTTP 4xx/5xx responses count toward the threshold — timeouts and network errors do not.
-- The counter resets to 0 on each successful page scan.
-- In intelligent crawl, each phase (sitemap then domain) has its own counter — transitioning from sitemap to domain crawl starts fresh.
-- Without this circuit breaker, a rate-limited crawl with thousands of enqueued URLs would run indefinitely (each URL retried 10× by Crawlee), never hit the success threshold, and never generate a report.
+- Both crawlers use a shared `CrawlRateController` class (`src/crawlers/crawlRateController.ts`) that provides:
+  1. **Strict maxPages**: Atomic slot claiming (`claimSlot()`) prevents race conditions with concurrent handlers overshooting the page limit.
+  2. **Circuit breaker**: After 100 consecutive HTTP 4xx/5xx failures (configurable via `OOBEE_CONSECUTIVE_MAX_RETRIES`), the crawl aborts gracefully.
+  3. **Adaptive concurrency**: On each 4xx/5xx failure, concurrency is halved (floor 1). After every 20 consecutive successes, concurrency recovers by +1 toward the original value. This automatically finds the site's rate limit threshold without manual tuning.
+- Only HTTP 4xx/5xx responses trigger rate adaptation and count toward the circuit breaker — timeouts and network errors do not.
+- In intelligent crawl, each phase (sitemap then domain) creates its own `CrawlRateController` instance — transitioning from sitemap to domain crawl starts fresh.
+- Without the circuit breaker, a rate-limited crawl with thousands of enqueued URLs would run indefinitely, never hit the success threshold, and never generate a report.
 - When enqueuing all sitemap URLs (which we do for accurate `totalLinksFetchedFromSitemaps` reporting), always ensure either a scan duration (`-d`) or the circuit breaker is in place as a safety net.
 
 ### Axe & Custom Checks

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -246,6 +246,16 @@ When making changes, validate these areas which have well-established edge cases
 - The `-s` (strategy) flag must be passed through to `crawlSitemap` and `getLinksFromSitemap`. For sitemap-only scans the default is `'ignore'` (all URLs); for domain/intelligent crawls it's `'same-domain'`.
 - `scanDuration=0` means unlimited. Code that calculates `remainingDuration` must treat 0 as "no limit", not as "0 seconds remaining".
 
+### Rate Limiting & Circuit Breaker
+- Sites with WAFs (Cloudflare, Akamai, etc.) will start returning 403/503 after a certain number of concurrent requests — typically 200-300 pages in rapid succession.
+- Both `crawlSitemap` and `crawlDomain` have a consecutive-failure circuit breaker: if 100 consecutive requests fail with HTTP 4xx/5xx, the crawl aborts gracefully and proceeds to report generation with whatever pages were successfully scanned.
+- The threshold is configurable via `OOBEE_CONSECUTIVE_MAX_RETRIES` env var (default 100).
+- Only HTTP 4xx/5xx responses count toward the threshold — timeouts and network errors do not.
+- The counter resets to 0 on each successful page scan.
+- In intelligent crawl, each phase (sitemap then domain) has its own counter — transitioning from sitemap to domain crawl starts fresh.
+- Without this circuit breaker, a rate-limited crawl with thousands of enqueued URLs would run indefinitely (each URL retried 10× by Crawlee), never hit the success threshold, and never generate a report.
+- When enqueuing all sitemap URLs (which we do for accurate `totalLinksFetchedFromSitemaps` reporting), always ensure either a scan duration (`-d`) or the circuit breaker is in place as a safety net.
+
 ### Axe & Custom Checks
 - When axe reports color-contrast violations but cannot determine the actual colors, skip augmenting the message with contrast context (avoids crashes on null/undefined color values).
 - Violation messages are enriched with live DOM context (element text, computed styles, dimensions) via `page.evaluate()` during scan. Handle cases where elements are no longer in DOM at evaluation time.

--- a/src/crawlers/crawlDomain.ts
+++ b/src/crawlers/crawlDomain.ts
@@ -29,7 +29,7 @@ import {
   getUrlsFromRobotsTxt,
   waitForPageLoaded,
 } from '../constants/common.js';
-import { areLinksEqual, isFollowStrategy, normUrl, register } from '../utils.js';
+import { areLinksEqual, isFollowStrategy, isSameHostname, normUrl, register } from '../utils.js';
 import {
   handlePdfDownload,
   runPdfScan,
@@ -364,9 +364,7 @@ const crawlDomain = async ({
         // same-domain strategy) still contribute their <a> links above, but
         // clicking every interactive element on them is too slow and starves
         // the crawler of time to discover pages on the primary hostname.
-        const currentHostname = new URL(page.url()).hostname;
-        const seedHostname = new URL(url).hostname;
-        if (currentHostname === seedHostname) {
+        if (isSameHostname(new URL(page.url()).hostname, new URL(url).hostname)) {
           // Try catch is necessary as clicking links is best effort, it may result in new pages that cause browser load or navigation errors that PlaywrightCrawler does not handle
           try {
             await customEnqueueLinksByClickingElements(page, browserContext);
@@ -843,7 +841,7 @@ const crawlDomain = async ({
         .map(item => item.actualUrl || item.url)
         .filter(pageUrl => {
           try {
-            return new URL(pageUrl).hostname === seedHostname && !clickPassVisited.has(pageUrl);
+            return isSameHostname(new URL(pageUrl).hostname, seedHostname) && !clickPassVisited.has(pageUrl);
           } catch {
             return false;
           }

--- a/src/crawlers/crawlDomain.ts
+++ b/src/crawlers/crawlDomain.ts
@@ -380,6 +380,8 @@ const crawlDomain = async ({
   };
 
   let isAbortingScanNow = false;
+  let consecutiveFailures = 0;
+  const maxConsecutiveFailures = Number(process.env.OOBEE_CONSECUTIVE_MAX_RETRIES) || 100;
 
   const crawler = register(
     new crawlee.PlaywrightCrawler({
@@ -701,6 +703,7 @@ const crawlDomain = async ({
                   pageTitle: results.pageTitle,
                   actualUrl, // i.e. actualUrl
                 });
+                consecutiveFailures = 0;
                 scannedUrlSet.add(normUrl(request.url));
                 scannedResolvedUrlSet.add(normUrl(actualUrl));
 
@@ -724,6 +727,7 @@ const crawlDomain = async ({
                 actualUrl: request.url,
                 pageTitle: results.pageTitle,
               });
+              consecutiveFailures = 0;
               scannedUrlSet.add(normUrl(request.url));
               scannedResolvedUrlSet.add(normUrl(request.url));
               await dataset.pushData(results);
@@ -789,12 +793,24 @@ const crawlDomain = async ({
           return;
         }
 
+        const status = response?.status();
+        if (typeof status === 'number' && status >= 400) {
+          consecutiveFailures++;
+          if (consecutiveFailures >= maxConsecutiveFailures) {
+            console.log(
+              `Aborting crawl: ${maxConsecutiveFailures} consecutive HTTP ${status >= 500 ? '5xx' : '4xx'} failures detected (site may be rate-limiting). Successfully scanned ${urlsCrawled.scanned.length} pages.`,
+            );
+            isAbortingScanNow = true;
+            crawler.autoscaledPool?.abort();
+            return;
+          }
+        }
+
         guiInfoLog(guiInfoStatusTypes.ERROR, {
           numScanned: urlsCrawled.scanned.length,
           urlScanned: request.url,
         });
 
-        const status = response?.status();
         const metadata =
           typeof status === 'number'
             ? STATUS_CODE_METADATA[status] || STATUS_CODE_METADATA[599]

--- a/src/crawlers/crawlDomain.ts
+++ b/src/crawlers/crawlDomain.ts
@@ -798,7 +798,7 @@ const crawlDomain = async ({
 
         const status = response?.status();
         if (rateController.onFailure(status, crawler.autoscaledPool)) {
-          console.log(
+          consoleLogger.info(
             `Aborting crawl: consecutive HTTP failures threshold reached (site may be rate-limiting). Successfully scanned ${urlsCrawled.scanned.length} pages.`,
           );
           isAbortingScanNow = true;

--- a/src/crawlers/crawlDomain.ts
+++ b/src/crawlers/crawlDomain.ts
@@ -1,4 +1,5 @@
 import crawlee, { EnqueueStrategy } from 'crawlee';
+import { CrawlRateController } from './crawlRateController.js';
 import type { BrowserContext, ElementHandle, Frame, Page } from 'playwright';
 import type { PlaywrightCrawlingContext, RequestOptions } from 'crawlee';
 import * as path from 'path';
@@ -380,8 +381,10 @@ const crawlDomain = async ({
   };
 
   let isAbortingScanNow = false;
-  let consecutiveFailures = 0;
-  const maxConsecutiveFailures = Number(process.env.OOBEE_CONSECUTIVE_MAX_RETRIES) || 100;
+  const rateController = new CrawlRateController(
+    maxRequestsPerCrawl,
+    specifiedMaxConcurrency || constants.maxConcurrency,
+  );
 
   const crawler = register(
     new crawlee.PlaywrightCrawler({
@@ -527,7 +530,7 @@ const crawlDomain = async ({
           const hasExceededDuration =
             scanDuration > 0 && Date.now() - crawlStartTime > scanDuration * 1000;
 
-          if (urlsCrawled.scanned.length >= maxRequestsPerCrawl || hasExceededDuration) {
+          if (!rateController.claimSlot() || hasExceededDuration) {
             if (hasExceededDuration) {
               console.log(`Crawl duration of ${scanDuration}s exceeded. Aborting website crawl.`);
               durationExceeded = true;
@@ -703,7 +706,7 @@ const crawlDomain = async ({
                   pageTitle: results.pageTitle,
                   actualUrl, // i.e. actualUrl
                 });
-                consecutiveFailures = 0;
+                rateController.onSuccess(crawler.autoscaledPool);
                 scannedUrlSet.add(normUrl(request.url));
                 scannedResolvedUrlSet.add(normUrl(actualUrl));
 
@@ -727,7 +730,7 @@ const crawlDomain = async ({
                 actualUrl: request.url,
                 pageTitle: results.pageTitle,
               });
-              consecutiveFailures = 0;
+              rateController.onSuccess(crawler.autoscaledPool);
               scannedUrlSet.add(normUrl(request.url));
               scannedResolvedUrlSet.add(normUrl(request.url));
               await dataset.pushData(results);
@@ -794,16 +797,13 @@ const crawlDomain = async ({
         }
 
         const status = response?.status();
-        if (typeof status === 'number' && status >= 400) {
-          consecutiveFailures++;
-          if (consecutiveFailures >= maxConsecutiveFailures) {
-            console.log(
-              `Aborting crawl: ${maxConsecutiveFailures} consecutive HTTP ${status >= 500 ? '5xx' : '4xx'} failures detected (site may be rate-limiting). Successfully scanned ${urlsCrawled.scanned.length} pages.`,
-            );
-            isAbortingScanNow = true;
-            crawler.autoscaledPool?.abort();
-            return;
-          }
+        if (rateController.onFailure(status, crawler.autoscaledPool)) {
+          console.log(
+            `Aborting crawl: consecutive HTTP failures threshold reached (site may be rate-limiting). Successfully scanned ${urlsCrawled.scanned.length} pages.`,
+          );
+          isAbortingScanNow = true;
+          crawler.autoscaledPool?.abort();
+          return;
         }
 
         guiInfoLog(guiInfoStatusTypes.ERROR, {

--- a/src/crawlers/crawlIntelligentSitemap.ts
+++ b/src/crawlers/crawlIntelligentSitemap.ts
@@ -111,7 +111,7 @@ const crawlIntelligentSitemap = async (
   try {
     sitemapUrls = await getSitemapsFromRobotsTxt(url, browser, userDataDirectory, extraHTTPHeaders);
     if (sitemapUrls.length > 0) {
-      console.log(`Found ${sitemapUrls.length} sitemap(s) in robots.txt: ${sitemapUrls.join(', ')}`);
+      consoleLogger.info(`Found ${sitemapUrls.length} sitemap(s) in robots.txt: ${sitemapUrls.join(', ')}`);
       sitemapExist = true;
     }
   } catch (error) {
@@ -131,7 +131,7 @@ const crawlIntelligentSitemap = async (
   }
 
   if (!sitemapExist) {
-    console.log('Unable to find sitemap. Commencing website crawl instead.');
+    consoleLogger.info('Unable to find sitemap. Commencing website crawl instead.');
     return await crawlDomain({
       url,
       randomToken,
@@ -163,7 +163,7 @@ const crawlIntelligentSitemap = async (
       break;
     }
 
-    console.log(`Processing sitemap: ${currentSitemapUrl}`);
+    consoleLogger.info(`Processing sitemap: ${currentSitemapUrl}`);
     urlsCrawledFinal = await crawlSitemap({
       sitemapUrl: currentSitemapUrl,
       randomToken,
@@ -193,7 +193,7 @@ const crawlIntelligentSitemap = async (
   const hasDurationRemaining = scanDuration === 0 || remainingScanDuration > 0;
 
   if (urlsCrawled.scanned.length < maxRequestsPerCrawl && hasDurationRemaining) {
-    console.log(
+    consoleLogger.info(
       `Continuing crawl from root website.${scanDuration > 0 ? ` Remaining scan time: ${remainingScanDuration.toFixed(1)}s` : ''}`,
     );
     urlsCrawledFinal = await crawlDomain({
@@ -218,7 +218,7 @@ const crawlIntelligentSitemap = async (
       scanDuration: remainingScanDuration,
     });
   } else if (!hasDurationRemaining) {
-    console.log(
+    consoleLogger.info(
       `Crawl duration exceeded before more pages could be found (limit: ${scanDuration}s).`,
     );
     durationExceeded = true;

--- a/src/crawlers/crawlRateController.ts
+++ b/src/crawlers/crawlRateController.ts
@@ -1,0 +1,54 @@
+import { consoleLogger } from '../logs.js';
+
+export class CrawlRateController {
+  private remainingSlots: number;
+  private consecutiveFailures = 0;
+  private consecutiveSuccesses = 0;
+  private readonly maxConsecutiveFailures: number;
+  private readonly originalMaxConcurrency: number;
+  private static readonly RECOVERY_INTERVAL = 20;
+
+  constructor(maxRequestsPerCrawl: number, maxConcurrency: number) {
+    this.remainingSlots = maxRequestsPerCrawl;
+    this.maxConsecutiveFailures = Number(process.env.OOBEE_CONSECUTIVE_MAX_RETRIES) || 100;
+    this.originalMaxConcurrency = maxConcurrency;
+  }
+
+  claimSlot(): boolean {
+    return --this.remainingSlots >= 0;
+  }
+
+  onSuccess(pool?: { maxConcurrency: number }): void {
+    this.consecutiveFailures = 0;
+    this.consecutiveSuccesses++;
+
+    if (pool && this.consecutiveSuccesses % CrawlRateController.RECOVERY_INTERVAL === 0) {
+      if (pool.maxConcurrency < this.originalMaxConcurrency) {
+        pool.maxConcurrency = Math.min(pool.maxConcurrency + 1, this.originalMaxConcurrency);
+        consoleLogger.info(`Recovering concurrency to ${pool.maxConcurrency}`);
+      }
+    }
+  }
+
+  onFailure(httpStatus: number | undefined, pool?: { maxConcurrency: number }): boolean {
+    if (typeof httpStatus !== 'number' || httpStatus < 400) {
+      return false;
+    }
+
+    this.consecutiveSuccesses = 0;
+    this.consecutiveFailures++;
+
+    if (pool && pool.maxConcurrency > 1) {
+      pool.maxConcurrency = Math.max(1, Math.floor(pool.maxConcurrency / 2));
+      consoleLogger.info(
+        `Rate limited (HTTP ${httpStatus}) — reducing concurrency to ${pool.maxConcurrency}`,
+      );
+    }
+
+    if (this.consecutiveFailures >= this.maxConsecutiveFailures) {
+      return true;
+    }
+
+    return false;
+  }
+}

--- a/src/crawlers/crawlSitemap.ts
+++ b/src/crawlers/crawlSitemap.ts
@@ -1,4 +1,5 @@
 import crawlee, { EnqueueStrategy, LaunchContext, Request, RequestList, Dataset } from 'crawlee';
+import { CrawlRateController } from './crawlRateController.js';
 import fs from 'fs';
 import * as path from 'path';
 import fsp from 'fs/promises';
@@ -81,8 +82,10 @@ const crawlSitemap = async ({
   let urlsCrawled: UrlsCrawled;
   let durationExceeded = false;
   let isAbortingScan = false;
-  let consecutiveFailures = 0;
-  const maxConsecutiveFailures = Number(process.env.OOBEE_CONSECUTIVE_MAX_RETRIES) || 100;
+  const rateController = new CrawlRateController(
+    maxRequestsPerCrawl,
+    specifiedMaxConcurrency || constants.maxConcurrency,
+  );
 
   if (fromCrawlIntelligentSitemap) {
     dataset = datasetFromIntelligent;
@@ -261,13 +264,13 @@ const crawlSitemap = async ({
           const hasExceededDuration =
             scanDuration > 0 && Date.now() - crawlStartTime > scanDuration * 1000;
 
-          if (urlsCrawled.scanned.length >= maxRequestsPerCrawl || hasExceededDuration) {
+          if (!rateController.claimSlot() || hasExceededDuration) {
             isAbortingScan = true;
             if (hasExceededDuration) {
               console.log(`Crawl duration of ${scanDuration}s exceeded. Aborting sitemap crawl.`);
               durationExceeded = true;
             }
-            crawler.autoscaledPool.abort(); // stops new requests
+            crawler.autoscaledPool.abort();
             return;
           }
 
@@ -388,7 +391,7 @@ const crawlSitemap = async ({
               pageTitle: results.pageTitle,
               actualUrl, // i.e. actualUrl
             });
-            consecutiveFailures = 0;
+            rateController.onSuccess(crawler.autoscaledPool);
 
             urlsCrawled.scannedRedirects.push({
               fromUrl: request.url,
@@ -435,16 +438,13 @@ const crawlSitemap = async ({
         }
 
         const status = response?.status();
-        if (typeof status === 'number' && status >= 400) {
-          consecutiveFailures++;
-          if (consecutiveFailures >= maxConsecutiveFailures) {
-            console.log(
-              `Aborting crawl: ${maxConsecutiveFailures} consecutive HTTP ${status >= 500 ? '5xx' : '4xx'} failures detected (site may be rate-limiting). Successfully scanned ${urlsCrawled.scanned.length} pages.`,
-            );
-            isAbortingScan = true;
-            crawler.autoscaledPool?.abort();
-            return;
-          }
+        if (rateController.onFailure(status, crawler.autoscaledPool)) {
+          console.log(
+            `Aborting crawl: consecutive HTTP failures threshold reached (site may be rate-limiting). Successfully scanned ${urlsCrawled.scanned.length} pages.`,
+          );
+          isAbortingScan = true;
+          crawler.autoscaledPool?.abort();
+          return;
         }
 
         guiInfoLog(guiInfoStatusTypes.ERROR, {

--- a/src/crawlers/crawlSitemap.ts
+++ b/src/crawlers/crawlSitemap.ts
@@ -31,7 +31,7 @@ import {
   mapPdfScanResults,
   doPdfScreenshots,
 } from './pdfScanFunc.js';
-import { guiInfoLog } from '../logs.js';
+import { consoleLogger, guiInfoLog } from '../logs.js';
 import { ViewportSettingsClass } from '../combine.js';
 
 const crawlSitemap = async ({
@@ -439,7 +439,7 @@ const crawlSitemap = async ({
 
         const status = response?.status();
         if (rateController.onFailure(status, crawler.autoscaledPool)) {
-          console.log(
+          consoleLogger.info(
             `Aborting crawl: consecutive HTTP failures threshold reached (site may be rate-limiting). Successfully scanned ${urlsCrawled.scanned.length} pages.`,
           );
           isAbortingScan = true;

--- a/src/crawlers/crawlSitemap.ts
+++ b/src/crawlers/crawlSitemap.ts
@@ -81,6 +81,8 @@ const crawlSitemap = async ({
   let urlsCrawled: UrlsCrawled;
   let durationExceeded = false;
   let isAbortingScan = false;
+  let consecutiveFailures = 0;
+  const maxConsecutiveFailures = Number(process.env.OOBEE_CONSECUTIVE_MAX_RETRIES) || 100;
 
   if (fromCrawlIntelligentSitemap) {
     dataset = datasetFromIntelligent;
@@ -386,6 +388,7 @@ const crawlSitemap = async ({
               pageTitle: results.pageTitle,
               actualUrl, // i.e. actualUrl
             });
+            consecutiveFailures = 0;
 
             urlsCrawled.scannedRedirects.push({
               fromUrl: request.url,
@@ -431,12 +434,24 @@ const crawlSitemap = async ({
           return;
         }
 
+        const status = response?.status();
+        if (typeof status === 'number' && status >= 400) {
+          consecutiveFailures++;
+          if (consecutiveFailures >= maxConsecutiveFailures) {
+            console.log(
+              `Aborting crawl: ${maxConsecutiveFailures} consecutive HTTP ${status >= 500 ? '5xx' : '4xx'} failures detected (site may be rate-limiting). Successfully scanned ${urlsCrawled.scanned.length} pages.`,
+            );
+            isAbortingScan = true;
+            crawler.autoscaledPool?.abort();
+            return;
+          }
+        }
+
         guiInfoLog(guiInfoStatusTypes.ERROR, {
           numScanned: urlsCrawled.scanned.length,
           urlScanned: request.url,
         });
 
-        const status = response?.status();
         const metadata =
           typeof status === 'number'
             ? STATUS_CODE_METADATA[status] || STATUS_CODE_METADATA[599]

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1081,15 +1081,19 @@ export const randomThreeDigitNumberString = () => {
 
 export const normUrl = (u: string): string => (u ? normalizeUrl(u) || u : '');
 
+export const stripWwwPrefix = (hostname: string): string => hostname.replace(/^www\./, '');
+
+export const isSameHostname = (hostname1: string, hostname2: string): boolean =>
+  stripWwwPrefix(hostname1) === stripWwwPrefix(hostname2);
+
 export const isFollowStrategy = (link1: string, link2: string, rule: string): boolean => {
   if (rule === 'all') return true;
   try {
     const parsedLink1 = new URL(link1);
     const parsedLink2 = new URL(link2);
-    const stripWww = (hostname: string) => hostname.replace(/^www\./, '');
     if (rule === 'same-origin') {
       return parsedLink1.protocol === parsedLink2.protocol &&
-        stripWww(parsedLink1.hostname) === stripWww(parsedLink2.hostname) &&
+        isSameHostname(parsedLink1.hostname, parsedLink2.hostname) &&
         parsedLink1.port === parsedLink2.port;
     }
     if (rule === 'same-domain') {
@@ -1098,7 +1102,7 @@ export const isFollowStrategy = (link1: string, link2: string, rule: string): bo
       return link1Domain.toLowerCase() === link2Domain.toLowerCase();
     }
     // default: same-hostname
-    return stripWww(parsedLink1.hostname) === stripWww(parsedLink2.hostname);
+    return isSameHostname(parsedLink1.hostname, parsedLink2.hostname);
   } catch {
     return false;
   }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1086,8 +1086,11 @@ export const isFollowStrategy = (link1: string, link2: string, rule: string): bo
   try {
     const parsedLink1 = new URL(link1);
     const parsedLink2 = new URL(link2);
+    const stripWww = (hostname: string) => hostname.replace(/^www\./, '');
     if (rule === 'same-origin') {
-      return parsedLink1.origin === parsedLink2.origin;
+      return parsedLink1.protocol === parsedLink2.protocol &&
+        stripWww(parsedLink1.hostname) === stripWww(parsedLink2.hostname) &&
+        parsedLink1.port === parsedLink2.port;
     }
     if (rule === 'same-domain') {
       const link1Domain = getDomain(parsedLink1.hostname, { allowPrivateDomains: true }) || parsedLink1.hostname;
@@ -1095,7 +1098,7 @@ export const isFollowStrategy = (link1: string, link2: string, rule: string): bo
       return link1Domain.toLowerCase() === link2Domain.toLowerCase();
     }
     // default: same-hostname
-    return parsedLink1.hostname === parsedLink2.hostname;
+    return stripWww(parsedLink1.hostname) === stripWww(parsedLink2.hostname);
   } catch {
     return false;
   }


### PR DESCRIPTION
## Summary

- Fix intelligent crawl skipping all sitemap-discovered URLs when the sitemap lists child URLs without the `www.` prefix (e.g., `mom.gov.sg/passes-and-permits.xml` vs entry URL `www.mom.gov.sg`)
- Fix click-discovery being skipped when the seed URL and redirected page URL differ only by www prefix (e.g., user enters `mom.gov.sg` but browser lands on `www.mom.gov.sg`)
- Add `CrawlRateController` — a shared class providing strict maxPages enforcement, adaptive concurrency, and a consecutive-failure circuit breaker
- Extract shared `isSameHostname` / `stripWwwPrefix` utilities to avoid repeating normalization logic
- Document changes in AGENTS.md

## Problem

### 1. www prefix mismatch

Multiple hostname comparisons across the crawl pipeline used strict equality, causing failures when the `www.` prefix differs between seed URL and discovered/loaded URLs:

**Sitemap URL filtering (`isFollowStrategy` in `src/utils.ts`)**

When scanning `www.mom.gov.sg`, the sitemap at `https://www.mom.gov.sg/sitemap.xml` lists child sitemaps under `https://mom.gov.sg/...` (without www). The strict comparison rejected all child sitemap URLs, causing intelligent crawl to fall back to "Continuing crawl from root website."

**Click-discovery gating (`crawlDomain.ts:367`)**

If user enters `mom.gov.sg` but the browser redirects to `www.mom.gov.sg`, the hostname comparison (`page.url()` hostname vs seed hostname) fails, skipping the expensive click-based link discovery on every page.

**Additional click-pass filtering (`crawlDomain.ts:832`)**

Same issue — the post-crawl click-discovery pass filters scanned pages by seed hostname, finding no matches when hostnames differ by www prefix.

### 2. Rate limiting causes infinite crawl or maxPages overshoot

When a site's WAF starts returning 403s (e.g. MOH after ~265 pages at concurrency 10):
- The crawler kept hammering at full concurrency, wasting time on retries
- With all 11,052 sitemap URLs enqueued and no scan duration limit, the process ran indefinitely without generating a report
- With concurrency 10, the `urlsCrawled.scanned.length >= maxRequestsPerCrawl` check raced — multiple handlers passed simultaneously, overshooting by up to `maxConcurrency - 1` pages (e.g. 1002 instead of 1000)

## Fix

### www normalization

Export `stripWwwPrefix` and `isSameHostname` from `src/utils.ts`:

```typescript
export const stripWwwPrefix = (hostname: string): string => hostname.replace(/^www\./, '');

export const isSameHostname = (hostname1: string, hostname2: string): boolean =>
  stripWwwPrefix(hostname1) === stripWwwPrefix(hostname2);
```

Applied in:
- `isFollowStrategy()` — `same-hostname` and `same-origin` strategies
- `crawlDomain` click-discovery gate
- `crawlDomain` additional click-pass page filter

The `same-domain` strategy already worked correctly (uses `getDomain()` which ignores subdomains).

### CrawlRateController (`src/crawlers/crawlRateController.ts`)

A shared class used by both `crawlSitemap` and `crawlDomain` providing:

1. **Strict maxPages** — `claimSlot()` atomically decrements a counter. Since JS is single-threaded, no concurrent handler can overshoot. Replaces the racy `urlsCrawled.scanned.length >= maxRequestsPerCrawl` check.

2. **Adaptive concurrency** — `onFailure()` halves the pool's `maxConcurrency` on each 4xx/5xx (floor 1). `onSuccess()` recovers +1 every 20 consecutive successes. The crawl automatically settles at the site's actual rate-limit threshold without manual `-t` tuning.

3. **Circuit breaker** — after 100 consecutive HTTP 4xx/5xx failures (configurable via `OOBEE_CONSECUTIVE_MAX_RETRIES`), aborts the crawl gracefully and proceeds to report generation.

## Test plan

- [ ] Scan `www.mom.gov.sg` with intelligent crawl — verify child sitemap URLs (under `mom.gov.sg`) are loaded
- [ ] Scan `mom.gov.sg` (without www) — verify pages at `www.mom.gov.sg` are not rejected by click-discovery or follow-strategy
- [ ] Verify `same-hostname` treats `www.x.com` and `x.com` as equivalent (bidirectional)
- [ ] Verify genuinely different subdomains are still rejected (e.g., `cdn.example.com` vs `www.example.com`)
- [ ] Verify `same-domain` still works unchanged (already uses `getDomain()`)
- [ ] Scan a rate-limiting site (MOH, 1000 pages) — verify exactly 1000 pages scanned (no overshoot)
- [ ] Verify adaptive concurrency messages appear in logs when 403s start
- [ ] Verify circuit breaker aborts and generates report if site blocks completely
- [ ] Scan a non-rate-limited site — verify no concurrency reduction messages and normal operation
