### PR TITLE
feat: download pages scanned as sitemap.txt from about modal

### DIFF
--- a/src/static/ejs/partials/scripts/header/aboutScanModal/AboutScanModal.ejs
+++ b/src/static/ejs/partials/scripts/header/aboutScanModal/AboutScanModal.ejs
@@ -48,4 +48,23 @@
 
   document.getElementById('pagesScannedModalLabel').innerHTML = title;
   document.getElementById('pagesScannedModalToggleTxt').innerHTML = title;
+
+  const crawlToggleBtn = document.querySelector('[aria-controls="view-crawl"]');
+  if (crawlToggleBtn) {
+    crawlToggleBtn.addEventListener('click', function () {
+      const pages = scanData.pagesScanned;
+      if (!pages || pages.length === 0) return;
+
+      const content = pages.map(page => page.url).join('\n');
+      const blob = new Blob([content], { type: 'text/plain;charset=utf-8;' });
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement('a');
+      link.href = url;
+      link.download = 'sitemap.txt';
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+      URL.revokeObjectURL(url);
+    });
+  }
 </script>


### PR DESCRIPTION
Clicking the crawl summary link (e.g. "Intelligent crawl (1000 pages)") in the about modal now triggers a browser download of sitemap.txt containing one scanned URL per line.

This PR adds... <!-- A brief description of what your PR does -->

<!-- This checklist is just a guideline.-->
<!-- If any of the following does not apply to your PR, please leave them unchecked and explain in the PR -->

- [ ] I've kept this PR as small as possible (~500 lines) by splitting it into PRs with manageable chunks of code
- [ ] I've requested reviews from 1 reviewer
- [ ] I've tested existing features (website scan, sitemap, custom flow) in both node index and cli
- [ ] I've synced this fork with GovTechSG repo
- [ ] I've added/updated unit tests
- [ ] I've added/updated any necessary dependencies in `package[-lock].json` `npm audit`, portable installation on GitHub Actions
