### PR TITLE
fix: claim scan slots at success time to prevent maxPages undershoot

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,7 @@
 # Oobee Developer Guide
 
+> **Keep this file up to date.** When you make changes that affect architecture, crawl behavior, environment variables, or testing considerations described here, update the relevant section in the same commit.
+
 Oobee is a web accessibility scanner that crawls websites and runs axe-core + custom checks against each page, producing HTML/PDF/CSV/JSON reports.
 
 ## Architecture Overview
@@ -249,9 +251,10 @@ When making changes, validate these areas which have well-established edge cases
 ### Rate Limiting, Adaptive Concurrency & CrawlRateController
 - Sites with WAFs (Cloudflare, Akamai, etc.) will start returning 403/503 after a certain number of concurrent requests — typically 200-300 pages in rapid succession.
 - Both crawlers use a shared `CrawlRateController` class (`src/crawlers/crawlRateController.ts`) that provides:
-  1. **Strict maxPages**: Atomic slot claiming (`claimSlot()`) prevents race conditions with concurrent handlers overshooting the page limit.
+  1. **Strict maxPages**: `claimSlot()` is called at the moment of success (synchronously right before `urlsCrawled.scanned.push()`), not at the top of the request handler. `abort()` is called only after claiming the last slot (`isLimitReached()` becomes true post-claim). Never abort from the top of the handler — doing so kills in-flight pages that other handlers are scanning, causing undershoot.
   2. **Circuit breaker**: After 100 consecutive HTTP 4xx/5xx failures (configurable via `OOBEE_CONSECUTIVE_MAX_RETRIES`), the crawl aborts gracefully.
   3. **Adaptive concurrency**: On each 4xx/5xx failure, concurrency is halved (floor 1). After every 20 consecutive successes, concurrency recovers by +1 toward the original value. This automatically finds the site's rate limit threshold without manual tuning.
+- **Critical placement of `claimSlot()` and `abort()`**: `claimSlot()` must be synchronously right before `push()` — never at the top of the handler. `abort()` must be called only after the last slot is claimed — never from an early-exit check. Pages can be discarded mid-handler (redirect, dedup, robots.txt block), and aborting prematurely kills in-flight handlers that would have succeeded.
 - Only HTTP 4xx/5xx responses trigger rate adaptation and count toward the circuit breaker — timeouts and network errors do not.
 - In intelligent crawl, each phase (sitemap then domain) creates its own `CrawlRateController` instance — transitioning from sitemap to domain crawl starts fresh.
 - Without the circuit breaker, a rate-limited crawl with thousands of enqueued URLs would run indefinitely, never hit the success threshold, and never generate a report.

--- a/src/crawlers/crawlDomain.ts
+++ b/src/crawlers/crawlDomain.ts
@@ -530,11 +530,9 @@ const crawlDomain = async ({
           const hasExceededDuration =
             scanDuration > 0 && Date.now() - crawlStartTime > scanDuration * 1000;
 
-          if (!rateController.claimSlot() || hasExceededDuration) {
-            if (hasExceededDuration) {
-              console.log(`Crawl duration of ${scanDuration}s exceeded. Aborting website crawl.`);
-              durationExceeded = true;
-            }
+          if (hasExceededDuration) {
+            console.log(`Crawl duration of ${scanDuration}s exceeded. Aborting website crawl.`);
+            durationExceeded = true;
             isAbortingScanNow = true;
             activeCrawler.autoscaledPool.abort();
             return;
@@ -694,8 +692,7 @@ const crawlDomain = async ({
                 return;
               }
 
-              // One more check if scanned pages have reached limit due to multi-instances of handler running
-              if (urlsCrawled.scanned.length < maxRequestsPerCrawl) {
+              if (rateController.claimSlot()) {
                 guiInfoLog(guiInfoStatusTypes.SCANNED, {
                   numScanned: urlsCrawled.scanned.length,
                   urlScanned: request.url,
@@ -707,6 +704,10 @@ const crawlDomain = async ({
                   actualUrl, // i.e. actualUrl
                 });
                 rateController.onSuccess(crawler.autoscaledPool);
+                if (rateController.isLimitReached()) {
+                  isAbortingScanNow = true;
+                  activeCrawler.autoscaledPool.abort();
+                }
                 scannedUrlSet.add(normUrl(request.url));
                 scannedResolvedUrlSet.add(normUrl(actualUrl));
 
@@ -719,8 +720,7 @@ const crawlDomain = async ({
                 results.actualUrl = actualUrl;
                 await dataset.pushData(results);
               }
-            } else if (urlsCrawled.scanned.length < maxRequestsPerCrawl) {
-              // One more check if scanned pages have reached limit due to multi-instances of handler running
+            } else if (rateController.claimSlot()) {
               guiInfoLog(guiInfoStatusTypes.SCANNED, {
                 numScanned: urlsCrawled.scanned.length,
                 urlScanned: request.url,
@@ -731,6 +731,10 @@ const crawlDomain = async ({
                 pageTitle: results.pageTitle,
               });
               rateController.onSuccess(crawler.autoscaledPool);
+              if (rateController.isLimitReached()) {
+                isAbortingScanNow = true;
+                activeCrawler.autoscaledPool.abort();
+              }
               scannedUrlSet.add(normUrl(request.url));
               scannedResolvedUrlSet.add(normUrl(request.url));
               await dataset.pushData(results);

--- a/src/crawlers/crawlRateController.ts
+++ b/src/crawlers/crawlRateController.ts
@@ -1,7 +1,8 @@
 import { consoleLogger } from '../logs.js';
 
 export class CrawlRateController {
-  private remainingSlots: number;
+  private scannedCount = 0;
+  private readonly maxPages: number;
   private consecutiveFailures = 0;
   private consecutiveSuccesses = 0;
   private readonly maxConsecutiveFailures: number;
@@ -9,13 +10,17 @@ export class CrawlRateController {
   private static readonly RECOVERY_INTERVAL = 20;
 
   constructor(maxRequestsPerCrawl: number, maxConcurrency: number) {
-    this.remainingSlots = maxRequestsPerCrawl;
+    this.maxPages = maxRequestsPerCrawl;
     this.maxConsecutiveFailures = Number(process.env.OOBEE_CONSECUTIVE_MAX_RETRIES) || 100;
     this.originalMaxConcurrency = maxConcurrency;
   }
 
   claimSlot(): boolean {
-    return --this.remainingSlots >= 0;
+    if (this.scannedCount >= this.maxPages) {
+      return false;
+    }
+    this.scannedCount++;
+    return true;
   }
 
   onSuccess(pool?: { maxConcurrency: number }): void {
@@ -50,5 +55,9 @@ export class CrawlRateController {
     }
 
     return false;
+  }
+
+  isLimitReached(): boolean {
+    return this.scannedCount >= this.maxPages;
   }
 }

--- a/src/crawlers/crawlSitemap.ts
+++ b/src/crawlers/crawlSitemap.ts
@@ -264,12 +264,10 @@ const crawlSitemap = async ({
           const hasExceededDuration =
             scanDuration > 0 && Date.now() - crawlStartTime > scanDuration * 1000;
 
-          if (!rateController.claimSlot() || hasExceededDuration) {
+          if (hasExceededDuration) {
+            consoleLogger.info(`Crawl duration of ${scanDuration}s exceeded. Aborting sitemap crawl.`);
+            durationExceeded = true;
             isAbortingScan = true;
-            if (hasExceededDuration) {
-              console.log(`Crawl duration of ${scanDuration}s exceeded. Aborting sitemap crawl.`);
-              durationExceeded = true;
-            }
             crawler.autoscaledPool.abort();
             return;
           }
@@ -381,27 +379,33 @@ const crawlSitemap = async ({
               // Page/context was destroyed during navigation — handled by outer catch
             }
 
-            guiInfoLog(guiInfoStatusTypes.SCANNED, {
-              numScanned: urlsCrawled.scanned.length,
-              urlScanned: request.url,
-            });
+            if (rateController.claimSlot()) {
+              guiInfoLog(guiInfoStatusTypes.SCANNED, {
+                numScanned: urlsCrawled.scanned.length,
+                urlScanned: request.url,
+              });
 
-            urlsCrawled.scanned.push({
-              url: request.url,
-              pageTitle: results.pageTitle,
-              actualUrl, // i.e. actualUrl
-            });
-            rateController.onSuccess(crawler.autoscaledPool);
+              urlsCrawled.scanned.push({
+                url: request.url,
+                pageTitle: results.pageTitle,
+                actualUrl, // i.e. actualUrl
+              });
+              rateController.onSuccess(crawler.autoscaledPool);
+              if (rateController.isLimitReached()) {
+                isAbortingScan = true;
+                crawler.autoscaledPool.abort();
+              }
 
-            urlsCrawled.scannedRedirects.push({
-              fromUrl: request.url,
-              toUrl: actualUrl,
-            });
+              urlsCrawled.scannedRedirects.push({
+                fromUrl: request.url,
+                toUrl: actualUrl,
+              });
 
-            results.url = request.url;
-            results.actualUrl = actualUrl;
+              results.url = request.url;
+              results.actualUrl = actualUrl;
 
-            await dataset.pushData(results);
+              await dataset.pushData(results);
+            }
           } else {
             guiInfoLog(guiInfoStatusTypes.SKIPPED, {
               numScanned: urlsCrawled.scanned.length,


### PR DESCRIPTION
## Summary

Fix `CrawlRateController` claiming slots at the wrong point in the handler lifecycle, causing fewer pages scanned than requested (e.g. 8 instead of 10).

## Problem

`claimSlot()` was called at the top of the request handler and `abort()` was triggered from an `isLimitReached()` early-exit check. This caused two issues:

1. **Undershoot from wasted slots**: Pages discarded after the handler started (redirect to external domain, dedup, robots.txt block) consumed a slot without producing a scanned page.
2. **Undershoot from premature abort**: `abort()` at the top of the handler killed the browser pool, closing pages that other in-flight handlers were still scanning. Those handlers got "Target page, context or browser has been closed" errors and never reached `claimSlot()`.

## Fix

- Move `claimSlot()` to the moment of success — synchronously right before `urlsCrawled.scanned.push()`. No slot is wasted on discarded pages.
- Remove the `isLimitReached()` → `abort()` path from the top of the handler. Instead, call `abort()` only after claiming the **last** slot (when `isLimitReached()` becomes true post-claim). In-flight handlers finish naturally without their pages being killed.
- Duration-exceeded abort remains at the top (hard timeout is still immediate).

## Test plan

- [ ] `npm run cli -- -u https://www.tech.gov.sg -p 10 -c 2` → exactly 10 pages scanned
- [ ] Run with higher concurrency (`-t 10`) → still exactly maxPages, no overshoot or undershoot
- [ ] Run against rate-limiting site (MOH) → adaptive concurrency still works, circuit breaker still fires
- [ ] Run with scan duration limit (`-d 60`) → still aborts immediately when time exceeded
