### PR TITLE
fix: filter false-positive aria-hidden-focus violations from carousel timing races

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -260,6 +260,7 @@ When making changes, validate these areas which have well-established edge cases
 ### Axe & Custom Checks
 - When axe reports color-contrast violations but cannot determine the actual colors, skip augmenting the message with contrast context (avoids crashes on null/undefined color values).
 - Violation messages are enriched with live DOM context (element text, computed styles, dimensions) via `page.evaluate()` during scan. Handle cases where elements are no longer in DOM at evaluation time.
+- `aria-hidden-focus` violations are re-verified against the live DOM after axe completes, to handle race conditions with JS that sets `tabindex="-1"` after `aria-hidden="true"` (common in carousel/slider libraries). The re-verification yields to the event loop before re-checking, allowing pending timers to fire. If all focusable descendants now have `tabindex < 0`, the violation is filtered out as a false positive.
 
 ## Report Output Structure
 

--- a/src/crawlers/commonCrawlerFunc.ts
+++ b/src/crawlers/commonCrawlerFunc.ts
@@ -1019,7 +1019,42 @@ export const runAxeScript = async ({
           .run(selectors, {
             resultTypes: defaultResultTypes,
           })
-          .then(results => {
+          .then(async results => {
+            // Re-verify aria-hidden-focus violations against the live DOM to
+            // handle race conditions with JS that sets tabindex="-1" after
+            // aria-hidden (common in carousel/slider libraries like slick)
+            const ariaHiddenViolation = results.violations.find(
+              v => v.id === 'aria-hidden-focus',
+            );
+            if (ariaHiddenViolation) {
+              await new Promise(resolve => setTimeout(resolve, 0));
+              ariaHiddenViolation.nodes = ariaHiddenViolation.nodes.filter(node => {
+                const selector = node.target && node.target[0];
+                if (typeof selector !== 'string') return true;
+                try {
+                  const el = document.querySelector(selector);
+                  if (!el) return true;
+                  const focusables = el.querySelectorAll(
+                    'a[href], area[href], button:not([disabled]), input:not([disabled]):not([type="hidden"]), select:not([disabled]), textarea:not([disabled]), [tabindex]',
+                  );
+                  if (focusables.length === 0) return false;
+                  return Array.from(focusables).some(child => {
+                    const tabindex = child.getAttribute('tabindex');
+                    if (tabindex === null) return true;
+                    const parsed = parseInt(tabindex, 10);
+                    return isNaN(parsed) || parsed >= 0;
+                  });
+                } catch {
+                  return true;
+                }
+              });
+              if (ariaHiddenViolation.nodes.length === 0) {
+                results.violations = results.violations.filter(
+                  v => v.id !== 'aria-hidden-focus',
+                );
+              }
+            }
+
             if (disableOobee) {
               return results;
             }

--- a/src/generateOobeeClientScanner.ts
+++ b/src/generateOobeeClientScanner.ts
@@ -461,6 +461,37 @@ const scanApiScript = (
       // Run axe-core + oobee custom checks
       var scanResult = await window.runA11yScan(elementsToScan, '');
 
+      // Re-verify aria-hidden-focus violations against the live DOM to handle
+      // race conditions with JS that sets tabindex="-1" after aria-hidden
+      var axeViolations = scanResult.axeScanResults.violations || [];
+      var ariaHiddenViolation = axeViolations.find(function(v) { return v.id === 'aria-hidden-focus'; });
+      if (ariaHiddenViolation) {
+        await new Promise(function(resolve) { setTimeout(resolve, 0); });
+        ariaHiddenViolation.nodes = ariaHiddenViolation.nodes.filter(function(node) {
+          var selector = node.target && node.target[0];
+          if (typeof selector !== 'string') return true;
+          try {
+            var el = document.querySelector(selector);
+            if (!el) return true;
+            var focusables = el.querySelectorAll(
+              'a[href], area[href], button:not([disabled]), input:not([disabled]):not([type="hidden"]), select:not([disabled]), textarea:not([disabled]), [tabindex]'
+            );
+            if (focusables.length === 0) return false;
+            return Array.from(focusables).some(function(child) {
+              var tabindex = child.getAttribute('tabindex');
+              if (tabindex === null) return true;
+              var parsed = parseInt(tabindex, 10);
+              return isNaN(parsed) || parsed >= 0;
+            });
+          } catch (e) { return true; }
+        });
+        if (ariaHiddenViolation.nodes.length === 0) {
+          scanResult.axeScanResults.violations = axeViolations.filter(function(v) {
+            return v.id !== 'aria-hidden-focus';
+          });
+        }
+      }
+
       // Convert raw axe results into oobee category structure
       var filtered = _oobeeFilterAxeResults(scanResult.axeScanResults, scanResult.pageTitle);
 


### PR DESCRIPTION
## Summary

- Carousel/slider libraries (e.g. slick-slider) set `aria-hidden="true"` on inactive slides then apply `tabindex="-1"` to child focusable elements ~1 second later. The axe scan can capture the DOM between these two operations, producing a false-positive `aria-hidden-focus` violation.
- Added a post-scan re-verification step (in both the Playwright server-side scanner and the client-side browser scanner) that yields to the event loop and re-checks the live DOM. If all focusable descendants now have `tabindex < 0`, the violation is filtered out.
- Updated AGENTS.md to document this behaviour.

## Changes

| File | Change |
|------|--------|
| `src/crawlers/commonCrawlerFunc.ts` | Post-axe re-verification of `aria-hidden-focus` violations in the Playwright scan pipeline |
| `src/generateOobeeClientScanner.ts` | Same re-verification logic for the standalone client-side scanner bundle |
| `AGENTS.md` | Document the new behaviour under "Axe & Custom Checks" |

## How it works

1. After `axe.run()` resolves, check if any `aria-hidden-focus` violations exist.
2. If yes, yield to the browser event loop (`setTimeout(0)`) — this allows any pending JS timers (like the carousel's `tabindex="-1"` setter) to fire.
3. For each violated node, re-query the live DOM via its CSS selector.
4. If all focusable descendants (`a[href]`, `button`, `input`, etc.) now have a negative `tabindex`, remove the node from the violation.
5. If no nodes remain, remove the entire rule from violations.
6. On any error during re-verification, the original violation is kept (fail-safe).

## Test plan

- [ ] `npx tsc --noEmit` passes (verified)
- [ ] `npm run build` succeeds (verified)
- [ ] Scan a page with a slick-slider carousel (inactive slides have `aria-hidden="true"`, child links get `tabindex="-1"` via JS) — confirm no `aria-hidden-focus` violation is reported
- [ ] Scan a page with a genuine `aria-hidden-focus` issue (focusable element inside `aria-hidden` with no `tabindex="-1"` fix) — confirm the violation IS still reported
- [ ] Run the client-side scanner (`window.oobee.scan()`) on a carousel page — confirm same false-positive filtering

This PR adds... <!-- A brief description of what your PR does -->

<!-- This checklist is just a guideline.-->
<!-- If any of the following does not apply to your PR, please leave them unchecked and explain in the PR -->

- [ ] I've kept this PR as small as possible (~500 lines) by splitting it into PRs with manageable chunks of code
- [ ] I've requested reviews from 1 reviewer
- [ ] I've tested existing features (website scan, sitemap, custom flow) in both node index and cli
- [ ] I've synced this fork with GovTechSG repo
- [ ] I've added/updated unit tests
- [ ] I've added/updated any necessary dependencies in `package[-lock].json` `npm audit`, portable installation on GitHub Actions
