### PR TITLE
fix: pass modified user-agent to Crawlee browser contexts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,7 +87,7 @@ Contexts that need `userAgent: process.env.OOBEE_USER_AGENT`:
 - `findSitemap()` in `crawlIntelligentSitemap.ts` — sitemap path probing
 - `getDataUsingPlaywright()` in `getLinksFromSitemap()` — sitemap XML content fetching
 - `checkUrl()` — main URL validation context (already handled)
-- Crawlee crawler contexts in `crawlDomain`/`crawlSitemap` handle UA via Crawlee's browser pool
+- Crawlee `PlaywrightCrawler` in `crawlDomain`/`crawlSitemap` — passed via `userAgent` in `preLaunchHooks` `launchOptions`
 
 ### Headless vs Headful
 

--- a/src/constants/common.ts
+++ b/src/constants/common.ts
@@ -2027,6 +2027,11 @@ export const getPlaywrightLaunchOptions = (browser?: string): LaunchOptions => {
       !(browser === BrowserTypes.CHROME && arg === '--edge-skip-compat-layer-relaunch'),
   );
 
+  // Anti-bot-detection: hide navigator.webdriver and automation signals
+  if (!finalArgs.includes('--disable-blink-features=AutomationControlled')) {
+    finalArgs.push('--disable-blink-features=AutomationControlled');
+  }
+
   // Headless flags (unchanged)
   if (process.env.CRAWLEE_HEADLESS === '1') {
     if (!finalArgs.includes('--mute-audio')) finalArgs.push('--mute-audio');
@@ -2050,8 +2055,8 @@ export const getPlaywrightLaunchOptions = (browser?: string): LaunchOptions => {
 
   const options: LaunchOptions = {
     ignoreDefaultArgs: shouldIgnoreMuteAudio
-      ? ['--use-mock-keychain', '--mute-audio']
-      : ['--use-mock-keychain'],
+      ? ['--use-mock-keychain', '--mute-audio', '--enable-automation']
+      : ['--use-mock-keychain', '--enable-automation'],
     args: finalArgs,
     headless: process.env.CRAWLEE_HEADLESS === '1',
     ...(channel && { channel }),

--- a/src/constants/common.ts
+++ b/src/constants/common.ts
@@ -2055,8 +2055,8 @@ export const getPlaywrightLaunchOptions = (browser?: string): LaunchOptions => {
 
   const options: LaunchOptions = {
     ignoreDefaultArgs: shouldIgnoreMuteAudio
-      ? ['--use-mock-keychain', '--mute-audio', '--enable-automation']
-      : ['--use-mock-keychain', '--enable-automation'],
+      ? ['--use-mock-keychain', '--mute-audio']
+      : ['--use-mock-keychain'],
     args: finalArgs,
     headless: process.env.CRAWLEE_HEADLESS === '1',
     ...(channel && { channel }),

--- a/src/crawlers/crawlDomain.ts
+++ b/src/crawlers/crawlDomain.ts
@@ -399,6 +399,8 @@ const crawlDomain = async ({
         preLaunchHooks: [
           async (_pageId, launchContext) => {
             await fsp.mkdir(userDataDirectory, { recursive: true });
+            // Remove stale SingletonLock left by prior Oobee browser instances
+            await fsp.rm(path.join(userDataDirectory, 'SingletonLock'), { force: true });
 
             // eslint-disable-next-line no-param-reassign
             launchContext.launchOptions = {

--- a/src/crawlers/crawlDomain.ts
+++ b/src/crawlers/crawlDomain.ts
@@ -422,6 +422,7 @@ const crawlDomain = async ({
               ...launchContext.launchOptions,
               ignoreHTTPSErrors: true,
               ...playwrightDeviceDetailsObject,
+              ...(process.env.OOBEE_USER_AGENT && { userAgent: process.env.OOBEE_USER_AGENT }),
               ...(process.env.OOBEE_DISABLE_BROWSER_DOWNLOAD && { acceptDownloads: false }),
               ...(extraHTTPHeaders && { extraHTTPHeaders }),
             };

--- a/src/crawlers/crawlDomain.ts
+++ b/src/crawlers/crawlDomain.ts
@@ -391,32 +391,15 @@ const crawlDomain = async ({
       launchContext: {
         launcher: constants.launcher,
         launchOptions: getPlaywrightLaunchOptions(browser),
-        // Bug in Chrome which causes browser pool crash when userDataDirectory is set in non-headless mode
-        ...(process.env.CRAWLEE_HEADLESS === '1' && { userDataDir: userDataDirectory }),
+        userDataDir: userDataDirectory,
       },
       retryOnBlocked: true,
       browserPoolOptions: {
         useFingerprints: false,
         preLaunchHooks: [
           async (_pageId, launchContext) => {
-            const baseDir = userDataDirectory; // e.g., /Users/young/.../Chrome/oobee-...
+            await fsp.mkdir(userDataDirectory, { recursive: true });
 
-            // Ensure base exists
-            await fsp.mkdir(baseDir, { recursive: true });
-
-            // Create a unique subdir per browser
-            const subProfileDir = path.join(
-              baseDir,
-              `profile-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
-            );
-            await fsp.mkdir(subProfileDir, { recursive: true });
-
-            // Assign to Crawlee's launcher
-            // Crawlee preLaunchHooks expects launchContext to be mutated in-place.
-            // eslint-disable-next-line no-param-reassign
-            launchContext.userDataDir = subProfileDir;
-
-            // Safely extend launchOptions
             // eslint-disable-next-line no-param-reassign
             launchContext.launchOptions = {
               ...launchContext.launchOptions,
@@ -426,9 +409,6 @@ const crawlDomain = async ({
               ...(process.env.OOBEE_DISABLE_BROWSER_DOWNLOAD && { acceptDownloads: false }),
               ...(extraHTTPHeaders && { extraHTTPHeaders }),
             };
-
-            // Optionally log for debugging
-            // console.log(`[HOOK] Using userDataDir: ${subProfileDir}`);
           },
         ],
       },

--- a/src/crawlers/crawlSitemap.ts
+++ b/src/crawlers/crawlSitemap.ts
@@ -138,6 +138,8 @@ const crawlSitemap = async ({
         preLaunchHooks: [
           async (_pageId, launchContext) => {
             await fsp.mkdir(userDataDirectory, { recursive: true });
+            // Remove stale SingletonLock left by prior Oobee browser instances
+            await fsp.rm(path.join(userDataDirectory, 'SingletonLock'), { force: true });
 
             // eslint-disable-next-line no-param-reassign
             launchContext.launchOptions = {

--- a/src/crawlers/crawlSitemap.ts
+++ b/src/crawlers/crawlSitemap.ts
@@ -158,6 +158,7 @@ const crawlSitemap = async ({
               ...launchContext.launchOptions,
               ignoreHTTPSErrors: true,
               ...playwrightDeviceDetailsObject,
+              ...(process.env.OOBEE_USER_AGENT && { userAgent: process.env.OOBEE_USER_AGENT }),
               ...(process.env.OOBEE_DISABLE_BROWSER_DOWNLOAD && { acceptDownloads: false }),
             };
 

--- a/src/crawlers/crawlSitemap.ts
+++ b/src/crawlers/crawlSitemap.ts
@@ -130,30 +130,16 @@ const crawlSitemap = async ({
       launchContext: {
         launcher: constants.launcher,
         launchOptions: getPlaywrightLaunchOptions(browser),
-        // Bug in Chrome which causes browser pool crash when userDataDirectory is set in non-headless mode
-        ...(process.env.CRAWLEE_HEADLESS === '1' && { userDataDir: userDataDirectory }),
+        userDataDir: userDataDirectory,
       },
       retryOnBlocked: true,
       browserPoolOptions: {
         useFingerprints: false,
         preLaunchHooks: [
           async (_pageId, launchContext) => {
-            const baseDir = userDataDirectory; // e.g., /Users/young/.../Chrome/oobee-...
+            await fsp.mkdir(userDataDirectory, { recursive: true });
 
-            // Ensure base exists
-            await fsp.mkdir(baseDir, { recursive: true });
-
-            // Create a unique subdir per browser
-            const subProfileDir = path.join(
-              baseDir,
-              `profile-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
-            );
-            await fsp.mkdir(subProfileDir, { recursive: true });
-
-            // Assign to Crawlee's launcher
-            launchContext.userDataDir = subProfileDir;
-
-            // Safely extend launchOptions
+            // eslint-disable-next-line no-param-reassign
             launchContext.launchOptions = {
               ...launchContext.launchOptions,
               ignoreHTTPSErrors: true,
@@ -161,9 +147,6 @@ const crawlSitemap = async ({
               ...(process.env.OOBEE_USER_AGENT && { userAgent: process.env.OOBEE_USER_AGENT }),
               ...(process.env.OOBEE_DISABLE_BROWSER_DOWNLOAD && { acceptDownloads: false }),
             };
-
-            // Optionally log for debugging
-            // console.log(`[HOOK] Using userDataDir: ${subProfileDir}`);
           },
         ],
       },

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -402,37 +402,8 @@ export const cleanUp = async (randomToken?: string, isError: boolean = false): P
       consoleLogger.warn(`Unable to force remove pdfs folder: ${error.message}`);
     }
     
-    let deleteErrorLogFile = true;
-
-    if (isError) {
-      let logsPath = storagePath;
-
-      if (process.env.OOBEE_LOGS_PATH) {
-        logsPath = process.env.OOBEE_LOGS_PATH;
-      }
-
-      if (fs.existsSync(errorsTxtPath)) {
-        try {
-          const logFilePath = path.join(logsPath, `logs-${randomToken}.txt`);
-          fs.copyFileSync(errorsTxtPath, logFilePath);
-          console.log(`An error occured. Log file is located at: ${logFilePath}`);
-
-        } catch (copyError) {
-          consoleLogger.error(`Error copying errors file during cleanup: ${copyError.message}`);
-          console.log(`An error occured. Log file is located at: ${errorsTxtPath}`);
-          deleteErrorLogFile = false; // Do not delete the log file if copy failed
-        }
-    
-        if (deleteErrorLogFile && fs.existsSync(errorsTxtPath)) {
-          try {
-            fs.unlinkSync(errorsTxtPath);
-          } catch (error) {
-            consoleLogger.warn(`Unable to delete log file ${errorsTxtPath}: ${error.message}`);
-          }
-        }
-
-      }
-
+    if (isError && fs.existsSync(errorsTxtPath)) {
+      console.log(`An error occured. Log file is located at: ${errorsTxtPath}`);
     } 
     
     if (fs.existsSync(storagePath) && fs.readdirSync(storagePath).length === 0) {


### PR DESCRIPTION
## Summary

- `initModifiedUserAgent()` replaces `HeadlessChrome` with `Chrome` in the UA string and stores it in `process.env.OOBEE_USER_AGENT`, but the domain and sitemap crawlers never passed it to the Playwright browser context.
- WAF-protected sites (e.g. scdf.gov.sg) return 403 because the browser still advertises itself as `HeadlessChrome`.
- Fixed by adding `userAgent: process.env.OOBEE_USER_AGENT` to `launchOptions` in the `preLaunchHooks` of both `crawlDomain` and `crawlSitemap` `PlaywrightCrawler` instances.
- Additionally simplified Chrome profile handling (use cloned profile directly, remove stale SingletonLock) and added `--disable-blink-features=AutomationControlled` to hide automation signals.
- Simplified error log handling: on error, point directly to the Winston log file instead of copying to a separate location.

## Root cause

| Crawler | Before | After |
|---------|--------|-------|
| `crawlDomain.ts` | UA never set on context | `userAgent` passed in `preLaunchHooks` |
| `crawlSitemap.ts` | UA never set on context | `userAgent` passed in `preLaunchHooks` |
| `crawlIntelligentSitemap.ts` | Already correct | No change |
| `runCustom.ts` | Already correct | No change |

Since both crawlers always set `userDataDir` in the preLaunchHook, Crawlee uses `launchPersistentContext(userDataDir, options)` which accepts `userAgent` as a context-level option within `launchOptions`.

## Changes

| Commit | File | Change |
|--------|------|--------|
| `f2526c7` | `src/crawlers/crawlDomain.ts` | Pass `OOBEE_USER_AGENT` in preLaunchHooks |
| `f2526c7` | `src/crawlers/crawlSitemap.ts` | Pass `OOBEE_USER_AGENT` in preLaunchHooks |
| `1825efd` | `src/constants/common.ts` | Add `--disable-blink-features=AutomationControlled` to launch args |
| `0846e22` | `src/crawlers/crawlDomain.ts` | Use cloned Chrome profile directly instead of creating empty sub-profiles |
| `0846e22` | `src/crawlers/crawlSitemap.ts` | Use cloned Chrome profile directly instead of creating empty sub-profiles |
| `18aa792` | `src/crawlers/crawlDomain.ts` | Remove stale `SingletonLock` before launching browser |
| `18aa792` | `src/crawlers/crawlSitemap.ts` | Remove stale `SingletonLock` before launching browser |
| `7454ef7` | `src/utils.ts` | Simplify error log: point to Winston log path directly, no copy/delete |

## Test plan

- [ ] `npx tsc --noEmit` passes
- [ ] Scan a WAF-protected site (e.g. `https://www.scdf.gov.sg/home/civil-defence-shelter`) using Website scan type — should no longer get 403
- [ ] Scan a normal site — verify no regression in scan results
- [ ] Verify `navigator.userAgent` in the crawled page does not contain `HeadlessChrome`
- [ ] Verify error log path is printed correctly on scan failure (points to Winston UUID log file)
- [ ] Verify Oobee Desktop "Copy error log" button still works on the error screen
