### PR TITLE
Fix/sentry scan metadata by category and websiteTag custom variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,6 +400,9 @@ Options:
                                      [string] [choices: "yes", "no"] [default: "no"]
   -l, --scanDuration                 Maximum scan duration in seconds (0 means u
                                      nlimited)             [number] [default: 0]
+  -z, --websiteTag                   Tag to identify the website in telemetry.
+                                     Overrides OOBEE_TAGGED_WEBSITE env var.
+                                                                       [string]
 
 Examples:
   To scan sitemap of website:', 'npm run cli -- -c [ 1 | sitemap ] -u <url_lin

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -228,6 +228,10 @@ if (!options.strategy) {
   options.strategy = options.scanner === ScannerTypes.SITEMAP ? 'ignore' : 'same-domain';
 }
 
+if (options.websiteTag) {
+  process.env.OOBEE_TAGGED_WEBSITE = options.websiteTag;
+}
+
 const scanInit = async (argvs: Answers): Promise<string> => {
   const updatedArgvs = { ...argvs };
 

--- a/src/constants/cliFunctions.ts
+++ b/src/constants/cliFunctions.ts
@@ -341,5 +341,12 @@ To obtain the JSON files, you need to base64-decode the file followed by gunzip.
     demandOption: false,
     coerce: val => Number(val),
   },
+  z: {
+    alias: 'websiteTag',
+    describe: 'Tag to identify the website in telemetry. Overrides OOBEE_TAGGED_WEBSITE env var.',
+    type: 'string',
+    requiresArg: true,
+    demandOption: false,
+  },
 };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,6 +52,7 @@ export type Answers = {
   ruleset: RuleFlags[];
   generateJsonFiles: boolean;
   scanDuration?: number;
+  websiteTag?: string;
 };
 
 export type Data = {

--- a/src/mergeAxeResults.ts
+++ b/src/mergeAxeResults.ts
@@ -681,6 +681,8 @@ export const createRuleIdJson = async (allIssues, itemsStore?: ItemsStore) => {
   const compiledRuleJson = {};
 
   for (const category of ['mustFix', 'goodToFix', 'needsReview'] as const) {
+    compiledRuleJson[category] = {};
+
     for (const rule of allIssues.items[category].rules) {
       let allItems: any[] = [];
 
@@ -692,7 +694,7 @@ export const createRuleIdJson = async (allIssues, itemsStore?: ItemsStore) => {
         allItems = rule.pagesAffected.flatMap(page => page.items || []);
       }
 
-      compiledRuleJson[rule.rule] = extractRuleAiData(rule.rule, rule.totalItems, allItems);
+      compiledRuleJson[category][rule.rule] = extractRuleAiData(rule.rule, rule.totalItems, allItems);
     }
   }
 
@@ -704,10 +706,12 @@ export const createBasicFormHTMLSnippet = filteredResults => {
   const compiledRuleJson = {};
 
   ['mustFix', 'goodToFix', 'needsReview'].forEach(category => {
+    compiledRuleJson[category] = {};
+
     if (filteredResults[category] && filteredResults[category].rules) {
       Object.entries(filteredResults[category].rules).forEach(
         ([ruleId, ruleVal]: [string, any]) => {
-          compiledRuleJson[ruleId] = extractRuleAiData(ruleId, ruleVal.totalItems, ruleVal.items);
+          compiledRuleJson[category][ruleId] = extractRuleAiData(ruleId, ruleVal.totalItems, ruleVal.items);
         },
       );
     }

--- a/src/mergeAxeResults/sentryTelemetry.ts
+++ b/src/mergeAxeResults/sentryTelemetry.ts
@@ -144,6 +144,9 @@ const sendWcagBreakdownToSentry = async (
         ...(process.env.OOBEE_SCAN_PRODUCT && {
           scanProduct: process.env.OOBEE_SCAN_PRODUCT,
         }),
+        ...(process.env.OOBEE_TAGGED_WEBSITE && {
+          websiteTag: process.env.OOBEE_TAGGED_WEBSITE,
+        }),
       },
       user: {
         ...(scanInfo.email && scanInfo.name


### PR DESCRIPTION
This PR adds... <!-- A brief description of what your PR does -->

- Group additionalScanMetadata in Sentry telemetry by category (mustFix, goodToFix, needsReview) instead of a flat rule-keyed object
- Add websiteTag custom variable to Sentry events, settable via -z, --websiteTag CLI flag or OOBEE_TAGGED_WEBSITE env var (CLI flag takes precedence)

<!-- This checklist is just a guideline.-->
<!-- If any of the following does not apply to your PR, please leave them unchecked and explain in the PR -->

- [ ] I've kept this PR as small as possible (~500 lines) by splitting it into PRs with manageable chunks of code
- [ ] I've requested reviews from 1 reviewer
- [ ] I've tested existing features (website scan, sitemap, custom flow) in both node index and cli
- [ ] I've synced this fork with GovTechSG repo
- [ ] I've added/updated unit tests
- [ ] I've added/updated any necessary dependencies in `package[-lock].json` `npm audit`, portable installation on GitHub Actions
