### PR TITLE
Add httpHeaders support to sitemap scan on basic auth protected UAT env

### DIFF
--- a/src/crawlers/crawlSitemap.ts
+++ b/src/crawlers/crawlSitemap.ts
@@ -4,7 +4,7 @@ import fs from 'fs';
 import {
   createCrawleeSubFolders,
   getPreLaunchHook,
-  preNavigationHooks,
+  splitAuthHeaders,
   runAxeScript,
   isUrlPdf,
 } from './commonCrawlerFunc.js';
@@ -86,6 +86,8 @@ const crawlSitemap = async ({
     specifiedMaxConcurrency || constants.maxConcurrency,
   );
 
+  const { nonAuthHeaders, httpCredentials } = splitAuthHeaders(extraHTTPHeaders);
+
   if (fromCrawlIntelligentSitemap) {
     dataset = datasetFromIntelligent;
     urlsCrawled = urlsCrawledFromIntelligent;
@@ -142,6 +144,8 @@ const crawlSitemap = async ({
               ...playwrightDeviceDetailsObject,
               ...(process.env.OOBEE_USER_AGENT && { userAgent: process.env.OOBEE_USER_AGENT }),
               ...(process.env.OOBEE_DISABLE_BROWSER_DOWNLOAD && { acceptDownloads: false }),
+              ...(nonAuthHeaders && { extraHTTPHeaders: nonAuthHeaders }),
+              ...(httpCredentials && { httpCredentials }),
             };
           },
         ],
@@ -197,7 +201,8 @@ const crawlSitemap = async ({
         },
       ],
       preNavigationHooks: [
-        async ({ request, page }, gotoOptions) => {
+        async (crawlingContext) => {
+          const { request } = crawlingContext;
           const url = request.url.toLowerCase();
 
           const isNotSupportedDocument = disallowedListOfPatterns.some(pattern =>
@@ -214,7 +219,9 @@ const crawlSitemap = async ({
             return;
           }
 
-          preNavigationHooks(extraHTTPHeaders);
+          if (extraHTTPHeaders) {
+            request.headers = extraHTTPHeaders;
+          }
         },
       ],
       requestHandlerTimeoutSecs: 90,


### PR DESCRIPTION
This PR adds... <!-- A brief description of what your PR does -->

<!-- This checklist is just a guideline.-->
<!-- If any of the following does not apply to your PR, please leave them unchecked and explain in the PR -->

- [ ] I've kept this PR as small as possible (~500 lines) by splitting it into PRs with manageable chunks of code
- [ ] I've requested reviews from 1 reviewer
- [ ] I've tested existing features (website scan, sitemap, custom flow) in both node index and cli
- [ ] I've synced this fork with GovTechSG repo
- [ ] I've added/updated unit tests
- [ ] I've added/updated any necessary dependencies in `package[-lock].json` `npm audit`, portable installation on GitHub Actions
