### PR TITLE
refactor(crawler): use common preNavigationHooks for auth headers in crawlDomain and crawlSitemap

### DIFF
--- a/src/crawlers/crawlDomain.ts
+++ b/src/crawlers/crawlDomain.ts
@@ -5,6 +5,7 @@ import type { PlaywrightCrawlingContext, RequestOptions } from 'crawlee';
 import {
   createCrawleeSubFolders,
   getPreLaunchHook,
+  preNavigationHooks,
   runAxeScript,
   isUrlPdf,
   shouldSkipClickDueToDisallowedHref,
@@ -415,11 +416,7 @@ const crawlDomain = async ({
       },
       requestQueue,
       preNavigationHooks: [
-        async (crawlingContext) => {
-          if (extraHTTPHeaders) {
-            crawlingContext.request.headers = extraHTTPHeaders;
-          }
-        },
+        ...preNavigationHooks(extraHTTPHeaders),
       ],
       postNavigationHooks: [
         async crawlingContext => {

--- a/src/crawlers/crawlSitemap.ts
+++ b/src/crawlers/crawlSitemap.ts
@@ -197,6 +197,7 @@ const crawlSitemap = async ({
         },
       ],
       preNavigationHooks: [
+        ...preNavigationHooks(extraHTTPHeaders),
         async ({ request, page }, gotoOptions) => {
           const url = request.url.toLowerCase();
 
@@ -213,8 +214,6 @@ const crawlSitemap = async ({
 
             return;
           }
-
-          preNavigationHooks(extraHTTPHeaders);
         },
       ],
       requestHandlerTimeoutSecs: 90,


### PR DESCRIPTION
Previously, `crawlDomain` manually set `crawlingContext.request.headers = extraHTTPHeaders` locally inside an inline hook, while `crawlSitemap` was either not applying them properly or doing it inconsistently compared to the domain scanner. 

Now, both crawlers cleanly import and leverage the shared `preNavigationHooks` utility from `commonCrawlerFunc`.

## Why is this change necessary?
- **Consistency**: Eliminates duplicate logic and ensures all our Playwright-based crawlers handle `extraHTTPHeaders` parsing synchronously via the same helper file.
- **Correctness**: Fixes issues where `Authorization` headers might cause CORS preflight failures on subsequent cross-domain sub-assets. Applying headers specifically at the `preNavigationHook` level guarantees that `extraHTTPHeaders` act exclusively on the primary navigation document.

## How was this tested?
- Confirmed compilation using `npm run build`.
- Ran Sitemap and Domain edge-case tests against local paths and live sites (e.g., `tech.gov.sg`) confirming both valid HTTP statuses and that custom CLI Authorization credentials route successfully to Playwright's network layer.