### PR TITLE
Fix Jetpack/XSL sitemap handling and skip image sitemap feeds

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -112,6 +112,10 @@ Important behaviors:
 - The crawler itself enforces `maxRequestsPerCrawl` by counting only successfully scanned pages
 - `constants.sitemapFetchedLinks` stores the total discovered count for `scanData.json` reporting
 - For sitemap indexes, child sitemaps are processed recursively
+- Some sitemap XMLs include `<?xml-stylesheet ...?>` (XSL). In `getDataUsingPlaywright()`:
+  - Use `waitUntil: 'domcontentloaded'` (not `networkidle`) to avoid 60s timeouts caused by stylesheet/resource loading
+  - Prefer `response.text()` to capture raw XML before browser XSL transformation (preserves `<sitemapindex>` / `<urlset>` structure)
+  - Only fall back to DOM extraction when raw response text is unavailable
 
 ## Shared Mutable State
 

--- a/src/constants/common.ts
+++ b/src/constants/common.ts
@@ -1147,11 +1147,28 @@ export const getLinksFromSitemap = async (
 
         const page = await browserContext.newPage();
 
-        await page.goto(url, { waitUntil: 'networkidle', timeout: 60000 });
+        // Use 'domcontentloaded' instead of 'networkidle' — sitemap XMLs with
+        // XSL stylesheet references (e.g. <?xml-stylesheet ...?>) cause the browser
+        // to fetch and apply the stylesheet, which may load additional resources
+        // (fonts, CSS, images) that prevent 'networkidle' from ever being reached.
+        const response = await page.goto(url, { waitUntil: 'domcontentloaded', timeout: 60000 });
 
-        if ((await page.locator('body').count()) > 0) {
-          data = await page.locator('body').innerText();
-        } else {
+        // Prefer the raw response body — this gives us the original XML before
+        // the browser applies any XSL transformation (which would turn the XML
+        // into rendered HTML, losing the sitemap structure).
+        if (response) {
+          try {
+            data = await response.text();
+          } catch {
+            // response.text() can fail if the body was already consumed or
+            // if a redirect occurred; fall through to DOM extraction below.
+          }
+        }
+
+        if (!data) {
+          if ((await page.locator('body').count()) > 0) {
+            data = await page.locator('body').innerText();
+          } else {
           const urlSet = page.locator('urlset');
           const sitemapIndex = page.locator('sitemapindex');
           const rss = page.locator('rss');
@@ -1166,6 +1183,7 @@ export const getLinksFromSitemap = async (
             data = await rss.evaluate(elem => elem.outerHTML);
           } else if (await isRoot(feed)) {
             data = await feed.evaluate(elem => elem.outerHTML);
+            }
           }
         }
       } finally {

--- a/src/constants/common.ts
+++ b/src/constants/common.ts
@@ -1236,7 +1236,7 @@ export const getLinksFromSitemap = async (
 
     switch (sitemapType) {
       case constants.xmlSitemapTypes.xmlIndex:
-        consoleLogger.info(`This is a XML format sitemap index.`);
+        consoleLogger.info(`This is a XML format sitemap index: ${url}`);
         for (const childSitemapUrl of $('loc')) {
           const childSitemapUrlText = $(childSitemapUrl).text();
           if (childSitemapUrlText.endsWith('.xml') || childSitemapUrlText.endsWith('.txt')) {
@@ -1247,19 +1247,19 @@ export const getLinksFromSitemap = async (
         }
         break;
       case constants.xmlSitemapTypes.xml:
-        consoleLogger.info(`This is a XML format sitemap.`);
+        consoleLogger.info(`This is a XML format sitemap: ${url}`);
         await processXmlSitemap($, sitemapType, 'loc', 'lastmod', 'url');
         break;
       case constants.xmlSitemapTypes.rss:
-        consoleLogger.info(`This is a RSS format sitemap.`);
+        consoleLogger.info(`This is a RSS format sitemap: ${url}`);
         await processXmlSitemap($, sitemapType, 'link', 'pubDate', 'item');
         break;
       case constants.xmlSitemapTypes.atom:
-        consoleLogger.info(`This is a Atom format sitemap.`);
+        consoleLogger.info(`This is a Atom format sitemap: ${url}`);
         await processXmlSitemap($, sitemapType, 'link', 'published', 'entry');
         break;
       default:
-        consoleLogger.info(`This is an unrecognised XML sitemap format.`);
+        consoleLogger.info(`This is an unrecognised XML sitemap format: ${url}`);
         processNonStandardSitemap(data);
     }
 


### PR DESCRIPTION
This PR improves sitemap discovery reliability for Jetpack-generated sitemap XML files and reduces noisy/irrelevant sitemap processing.

## What changed
- Avoid sitemap fetch failures caused by waiting for `networkidle` when XML stylesheets trigger additional resource loading.
- Improve sitemap logging by including the current sitemap URL in sitemap type logs.
- Harden sitemap index parsing and recursive child-sitemap detection.
- Skip image sitemap feeds intentionally (both by URL pattern and image sitemap namespace) to focus crawl candidates on page URLs.
- Document the sitemap XSL fetching behavior and rationale in the developer guide.

## Why
Some sitemap XML endpoints include `<?xml-stylesheet ...?>` and related assets that can prevent `networkidle` from being reached, causing false negatives or fallback parsing behavior. In addition, image-only sitemaps can add noise without contributing page targets for accessibility scanning.

## Impact
- Jetpack/XSL sitemap index files are now recognized and followed more reliably.
- Sitemap processing is less noisy and excludes image sitemap branches by design.
- Logs are easier to interpret during sitemap crawl diagnostics.

## Testing
- Manual validation via CLI against `https://fulcrum.sg/sitemap.xml`.
- Observed behavior after build:
  - XML sitemap index is detected and followed.
  - Child sitemap files are processed.
  - Image sitemap feeds are skipped intentionally.

## Commits in this PR
- `fix: handle XSL sitemap fetch without networkidle timeout`
- `docs: document sitemap XSL stylesheet fetch behavior`
- `chore: include sitemap URL in sitemap type logs`
- `Fix sitemap index parsing and skip image sitemaps`
