### PR TITLE
Fix/report a11y issues

### DIFF
--- a/src/static/ejs/partials/components/allIssues/CategoryBadges.ejs
+++ b/src/static/ejs/partials/components/allIssues/CategoryBadges.ejs
@@ -7,6 +7,7 @@
         <button
           type="button"
           class="category-tooltip-icon"
+          aria-label="About Must Fix category"
           aria-describedby="mustFixTooltip"
         >
           <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14"
@@ -34,6 +35,7 @@
         <button
           type="button"
           class="category-tooltip-icon"
+          aria-label="About Good to Fix category"
           aria-describedby="goodToFixTooltip"
         >
           <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14"
@@ -61,6 +63,7 @@
         <button
           type="button"
           class="category-tooltip-icon"
+          aria-label="About Manual Test category"
           aria-describedby="manualTestTooltip"
         >
           <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14"

--- a/src/static/ejs/partials/components/allIssues/IssuesTable.ejs
+++ b/src/static/ejs/partials/components/allIssues/IssuesTable.ejs
@@ -2,21 +2,21 @@
   <table class="issues-table" id="issuesTable">
     <thead>
       <tr>
-        <th class="sortable" role="button" tabindex="0" aria-sort="none" style="width: 15%;">
+        <th class="sortable" tabindex="0" aria-sort="none" style="width: 15%;">
           <span>Severity</span>
           <svg class="sort-icon" width="24" height="24" viewBox="0 0 24 24" fill="none" aria-hidden="true">
             <path d="M7 9L12 4L17 9H7Z" fill="currentColor" opacity="1" />
             <path d="M7 15L12 20L17 15H7Z" fill="currentColor" opacity="0.3" />
           </svg>
         </th>
-        <th class="sortable" role="button" tabindex="0" aria-sort="none">
+        <th class="sortable" tabindex="0" aria-sort="none">
           <span>Issue Name</span>
           <svg class="sort-icon" width="24" height="24" viewBox="0 0 24 24" fill="none" aria-hidden="true">
             <path d="M7 9L12 4L17 9H7Z" fill="currentColor" opacity="0.3" />
             <path d="M7 15L12 20L17 15H7Z" fill="currentColor" opacity="1" />
           </svg>
         </th>
-        <th class="sortable" role="button" tabindex="0" aria-sort="descending" style="width: 15%;">
+        <th class="sortable" tabindex="0" aria-sort="descending" style="width: 15%;">
           <span>Occurrence</span>
           <svg class="sort-icon" width="24" height="24" viewBox="0 0 24 24" fill="none" aria-hidden="true">
             <path d="M7 9L12 4L17 9H7Z" fill="currentColor" opacity="0.3" />

--- a/src/static/ejs/partials/scripts/prioritiseIssues/PrioritiseIssues.ejs
+++ b/src/static/ejs/partials/scripts/prioritiseIssues/PrioritiseIssues.ejs
@@ -84,11 +84,13 @@
                 : '';
 
             return `
-              <li class="priority-issue-item d-flex g-one" data-rule-id="${issue.ruleId}" role="button" tabindex="0">
-                <div class="d-flex justify-content-between align-items-center w-90">
-                    <div class="priority-issue-title">${issue.description}</div>
-                    ${disabilityBadges}
-                </div>
+              <li class="priority-issue-item" data-rule-id="${issue.ruleId}">
+                <button type="button" class="priority-issue-action d-flex g-one" aria-pressed="false">
+                  <div class="d-flex justify-content-between align-items-center w-90">
+                      <div class="priority-issue-title">${issue.description}</div>
+                      ${disabilityBadges}
+                  </div>
+                </button>
               </li>
             `;
           })
@@ -122,7 +124,7 @@
               data-bs-parent="#prioritiseIssuesAccordion"
             >
               <div class="accordion-body">
-                <ul class="priority-issues-list">
+                <ul class="priority-issues-list" aria-label="Priority issues">
                   ${issuesListHTML}
                 </ul>
               </div>
@@ -135,19 +137,25 @@
     accordionContainer.innerHTML = accordionHTML;
 
     document.querySelectorAll('.priority-issue-item').forEach(item => {
+      const actionButton = item.querySelector('.priority-issue-action');
+      if (!actionButton) return;
+
       const selectIssue = function () {
         const ruleId = item.getAttribute('data-rule-id');
 
         document.querySelectorAll('.priority-issue-item').forEach(el => {
           el.classList.remove('active');
-          el.setAttribute('aria-selected', 'false');
+          const button = el.querySelector('.priority-issue-action');
+          if (button) {
+            button.setAttribute('aria-pressed', 'false');
+          }
         });
         document.querySelectorAll('.priority-issue-title').forEach(el => {
           el.classList.remove('active');
         });
 
         item.classList.add('active');
-        item.setAttribute('aria-selected', 'true');
+        actionButton.setAttribute('aria-pressed', 'true');
         const title = item.querySelector('.priority-issue-title');
         if (title) {
           title.classList.add('active');
@@ -167,16 +175,7 @@
         }
       };
 
-      // Click handler
-      item.addEventListener('click', selectIssue);
-
-      // Keyboard handler
-      item.addEventListener('keydown', function (event) {
-        if (event.key === 'Enter' || event.key === ' ') {
-          event.preventDefault();
-          selectIssue();
-        }
-      });
+      actionButton.addEventListener('click', selectIssue);
     });
 
     // Automatically open first accordion and select first issue
@@ -197,7 +196,10 @@
       const firstIssueItem = document.querySelector('.priority-issue-item');
       if (firstIssueItem) {
         firstIssueItem.classList.add('active');
-        firstIssueItem.setAttribute('aria-selected', 'true');
+        const firstIssueButton = firstIssueItem.querySelector('.priority-issue-action');
+        if (firstIssueButton) {
+          firstIssueButton.setAttribute('aria-pressed', 'true');
+        }
         const firstIssueTitle = firstIssueItem.querySelector('.priority-issue-title');
         if (firstIssueTitle) {
           firstIssueTitle.classList.add('active');

--- a/src/static/ejs/partials/styles/header/SiteInfo.ejs
+++ b/src/static/ejs/partials/styles/header/SiteInfo.ejs
@@ -112,7 +112,7 @@
 
   .link {
     color: var(--a11y-majorelle-blue);
-    text-decoration: none;
+    text-decoration: underline;
   }
 
   .link:hover {

--- a/src/static/ejs/partials/styles/header/aboutScanModal/ScanDetails.ejs
+++ b/src/static/ejs/partials/styles/header/aboutScanModal/ScanDetails.ejs
@@ -114,7 +114,7 @@
 
   .about-scan-link-text {
     color: var(--a11y-majorelle-blue);
-    text-decoration: none;
+    text-decoration: underline;
     cursor: pointer;
   }
 

--- a/src/static/ejs/partials/styles/prioritiseIssues/PrioritiseIssues.ejs
+++ b/src/static/ejs/partials/styles/prioritiseIssues/PrioritiseIssues.ejs
@@ -120,15 +120,36 @@
 
   .priority-issue-item {
     padding: 0.75rem;
-    cursor: pointer;
     position: relative;
     padding-left: 1.5rem;
+    display: flex;
+    align-items: flex-start;
+  }
+
+  .priority-issue-action {
+    appearance: none;
+    border: 0;
+    background: transparent;
+    width: 100%;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    text-align: left;
+    cursor: pointer;
+    color: inherit;
+    line-height: 1.5;
+  }
+
+  .priority-issue-action > .w-90 {
+    width: 100% !important;
   }
 
   .priority-issue-item::before {
     counter-increment: issue-counter;
     content: counter(issue-counter) '.';
     line-height: 1.5;
+    margin-right: 0.5rem;
+    flex-shrink: 0;
   }
 
   .priority-issue-item:hover:not(.active) {

--- a/src/static/ejs/partials/styles/styles.ejs
+++ b/src/static/ejs/partials/styles/styles.ejs
@@ -98,7 +98,7 @@
 
   a {
     color: var(--a11y-majorelle-blue);
-    text-decoration: none;
+    text-decoration: underline;
   }
 
   a:hover {

--- a/testStaticJSScanner.html
+++ b/testStaticJSScanner.html
@@ -98,7 +98,7 @@
       font-size: 0.78rem; color: #0d6efd; text-decoration: none;
       white-space: nowrap;
     }
-    .goto-link:hover { text-decoration: underline; }
+    /* .goto-link:hover { text-decoration: underline; } */
     .item-message {
       display: block; font-size: 0.75rem; color: #6c757d;
       margin: 1px 0 6px; font-style: italic;


### PR DESCRIPTION

## Overview
This PR addresses multiple accessibility and UX issues in report templates, including ARIA usage, semantic list/button structure, keyboard behavior preservation, and several CSS regressions introduced during fixes.

---

## Why this change was needed

### 1) Accessibility/semantics issues
- Some interactive elements had incorrect or incomplete ARIA semantics.
- Sortable table headers had invalid `role="button"` usage on `<th>`.
- Tooltip icon buttons lacked explicit accessible names.

### 2) Prioritised Issues layout regression
- During semantic refactor (`li` + `button`), list item width/layout became compressed due to missing button reset/layout CSS.
- Number marker and title could break onto separate lines (`1.` then title below).

### 3) Link visibility/accessibility
- Links were styled with `text-decoration: none` by default in multiple places and only underlined on hover.
- This caused links (including long URLs and about-scan links) to be flagged as not visually identifiable as links.

---

## What was changed

## A. Accessibility + semantic fixes (branch commit content)

### `src/static/ejs/partials/components/allIssues/CategoryBadges.ejs`
- Added missing `aria-label` attributes for category tooltip icon buttons:
  - “About Must Fix category”
  - “About Good to Fix category”
  - “About Manual Test category”

### `src/static/ejs/partials/components/allIssues/IssuesTable.ejs`
- Removed invalid `role="button"` from sortable `<th>` elements.
- Preserved existing sort UI behavior and keyboard focusability