### PR TITLE
fix: url guard infinite redirect and missing scan overlay on macOS/Windows

### DIFF
--- a/src/crawlers/custom/utils.ts
+++ b/src/crawlers/custom/utils.ts
@@ -1228,19 +1228,32 @@ export const initNewPage = async (page, pageClosePromises, processPageParams, pa
         const allowed = isOverlayAllowed(page.url(), processPageParams.entryUrl);
 
         if (!allowed) {
-          await Promise.race([
-            removeOverlayMenu(page),
-            new Promise((_, reject) => {
-              setTimeout(() => {
-                reject(
-                  new Error(
-                    `removeOverlayMenu timed out after ${OVERLAY_OPERATION_TIMEOUT_MS}ms`,
-                  ),
-                );
-              }, OVERLAY_OPERATION_TIMEOUT_MS);
-            }),
-          ]);
-          return;
+          // On macOS and Windows the custom flow always runs headful.
+          // The URL guard (urlGuard.ts) intercepts non-http/https navigations
+          // and calls page.goto(safeUrl). Do NOT remove the overlay here —
+          // removing it causes it to stay permanently disabled if the redirect
+          // races ahead of the next reconcile cycle.
+          // Instead, fall through to the hasOverlay / addOverlayMenu block so
+          // the overlay is (re-)injected even on transient non-http/https URLs
+          // (e.g. file://, about:blank) and again after the guard's redirect.
+          const isDesktopHost = process.platform === 'darwin' || process.platform === 'win32';
+          if (!isDesktopHost) {
+            // On Linux / Docker: remove overlay for non-http/https URLs and stop.
+            await Promise.race([
+              removeOverlayMenu(page),
+              new Promise((_, reject) => {
+                setTimeout(() => {
+                  reject(
+                    new Error(
+                      `removeOverlayMenu timed out after ${OVERLAY_OPERATION_TIMEOUT_MS}ms`,
+                    ),
+                  );
+                }, OVERLAY_OPERATION_TIMEOUT_MS);
+              }),
+            ]);
+            return;
+          }
+          // Desktop hosts: skip removal and fall through to re-add overlay.
         }
 
         const hasOverlay = await page.evaluate(() =>

--- a/src/crawlers/guards/urlGuard.ts
+++ b/src/crawlers/guards/urlGuard.ts
@@ -35,8 +35,18 @@ export function addUrlGuardScript(context, opts = {}) {
       });
 
     const restoreToSafeUrl = async (page, attemptedUrl) => {
+      const safeUrl = lastAllowedUrlByPage.get(page) || fallbackUrl || 'about:blank';
+      // Only redirect if the safe URL is itself an allowed (http/https) URL.
+      // If the entry URL is file:// (e.g. scanning a local HTML file), the
+      // fallback is also file://, and redirecting would create an infinite loop:
+      //   file:// → restoreToSafeUrl → file:// → framenavigated → restoreToSafeUrl → …
       try {
-        const safeUrl = lastAllowedUrlByPage.get(page) || fallbackUrl || 'about:blank';
+        const safeObj = new URL(safeUrl);
+        if (!ALLOWED_PROTOCOLS.has(safeObj.protocol)) return;
+      } catch {
+        return;
+      }
+      try {
         await page.goto(safeUrl, { waitUntil: 'domcontentloaded' });
       } catch {
         // page might be closing; ignore
@@ -58,6 +68,13 @@ export function addUrlGuardScript(context, opts = {}) {
         lastAllowedUrlByPage.set(page, urlObj.toString());
         return;
       }
+
+      // Skip browser-internal transitional states (about:blank, about:srcdoc, etc.).
+      // page.goto() navigates through about:blank before loading the target URL.
+      // Redirecting from about: creates an infinite loop:
+      //   restoreToSafeUrl → page.goto(safeUrl) → about:blank → restoreToSafeUrl → …
+      if (urlObj.protocol === 'about:') return;
+
       await restoreToSafeUrl(page, urlStr);
     });
   };


### PR DESCRIPTION
## Problem

Two related bugs in the custom flow (`-c 3`) on macOS and Windows:

1. **Infinite reload loop** when the entry URL is a `file://` path (e.g. scanning a local HTML report with `-u '/path/to/report.html'`):
   - `urlGuard.ts` intercepts every `framenavigated` event for non-http/https URLs and calls `restoreToSafeUrl → page.goto(safeUrl)`.
   - When `safeUrl` is itself `file://` (because the entry URL is `file://`), the goto fires another `framenavigated` for `file://`, which triggers `restoreToSafeUrl` again → infinite loop.
   - Additionally, `page.goto()` always fires an intermediate `framenavigated` for `about:blank` before loading the target URL. The guard intercepted that too, calling `restoreToSafeUrl` a second time mid-navigation — another infinite loop path.

2. **Scan overlay permanently disabled** after any navigation to a non-http/https URL (e.g. a `file://` link on the page, or the initial `file://` entry):
   - `reconcileOverlayMenu` in `custom/utils.ts` called `removeOverlayMenu` whenever `isOverlayAllowed` returned `false` (non-http/https URL) and returned early.
   - Since page navigation replaces the DOM, the overlay was gone and — with the early return — `addOverlayMenu` was never called to restore it, leaving the overlay permanently missing.

## Root Causes

| # | File | Root cause |
|---|------|------------|
| 1a | `urlGuard.ts` | `restoreToSafeUrl` called `page.goto(file://)` when fallback was `file://`, creating a redirect-to-itself loop |
| 1b | `urlGuard.ts` | `framenavigated` fired for `about:blank` (browser-internal intermediate state during `page.goto`) and was mistakenly treated as a dangerous navigation |
| 2 | `custom/utils.ts` | On macOS/Windows, `reconcileOverlayMenu` removed the overlay and returned early for any non-http/https URL, never re-adding it |

## Fix

### `src/crawlers/guards/urlGuard.ts`

**`restoreToSafeUrl`** — validate the safe URL before redirecting:
```ts
// Only redirect if the safe URL is itself http/https.
// If the entry URL is file://, the fallback is also file://, so
// redirecting would create an infinite loop.
const safeObj = new URL(safeUrl);
if (!ALLOWED_PROTOCOLS.has(safeObj.protocol)) return;
```

**`framenavigated` handler** — skip `about:` protocol navigations:
```ts
// about:blank is a transient browser-internal state during page.goto().
// Redirecting from it creates an infinite loop.
if (urlObj.protocol === 'about:') return;
```

### `src/crawlers/custom/utils.ts`

**`reconcileOverlayMenu`** — on `darwin`/`win32`, skip removal and fall through to re-add:
```ts
if (!allowed) {
  const isDesktopHost = process.platform === 'darwin' || process.platform === 'win32';
  if (!isDesktopHost) {
    await removeOverlayMenu(page);
    return;
  }
  // Desktop: skip removal, fall through to addOverlayMenu below.
}
// addOverlayMenu called for all cases on desktop hosts.
```

On macOS/Windows the custom flow always runs headful. The URL guard handles any unsafe navigation by redirecting back to the safe URL, which fires a new `framenavigated` that reconciles the overlay correctly. There is no need to remove the overlay during the transient non-http/https state — doing so permanently disables it.

## Behaviour After Fix

| Scenario | Before | After |
|----------|--------|-------|
| `-u file:///path/to/report.html` (file:// entry) | Infinite page reload | Page loads, overlay injected |
| Navigate to `file://` link mid-scan (http/https entry) | Overlay removed, sometimes not restored | Guard redirects back; overlay preserved/re-added |
| `about:blank` intermediate during `page.goto` | Guard re-triggered → loop | Skipped silently |
| Linux / Docker (headless) | Unchanged | Unchanged |

## Files Changed

- `src/crawlers/guards/urlGuard.ts`
- `src/crawlers/custom/utils.ts`