### PR TITLE
improve: redirect entry URL handling and harden sitemap crawl resiliency

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -264,9 +264,10 @@ const scanInit = async (argvs: Answers): Promise<string> => {
     consoleLogger.info(`Connectivity Check HTTP Response Code: ${res.httpStatus}`);
 
   if (res.status === statuses.success.code) {
-    // Custom flow should continue from the user-provided entry URL so auth redirects
-    // do not replace the original domain used for overlay gating and navigation.
+    // Keep browser-resolved URL as entryUrl for downstream scan metadata/events
+    // on non-custom scans.
     if (data.type !== ScannerTypes.CUSTOM) {
+      data.entryUrl = res.url;
       data.url = res.url;
     }
     if (process.env.OOBEE_VALIDATE_URL) {

--- a/src/combine.ts
+++ b/src/combine.ts
@@ -45,6 +45,7 @@ const combineRun = async (details: Data, deviceToScan: string) => {
   const {
     type,
     url,
+    entryUrl,
     nameEmail,
     randomToken,
     deviceChosen,
@@ -104,8 +105,8 @@ const combineRun = async (details: Data, deviceToScan: string) => {
 
   // remove basic-auth credentials from URL
   const finalUrl = !(type === ScannerTypes.SITEMAP || type === ScannerTypes.LOCALFILE)
-    ? new URL(url)
-    : new URL(pathToFileURL(url));
+    ? new URL(entryUrl)
+    : new URL(pathToFileURL(entryUrl));
 
   // Use the string version of finalUrl to reduce logic at submitForm
   const finalUrlString = finalUrl.toString();

--- a/src/constants/common.ts
+++ b/src/constants/common.ts
@@ -597,6 +597,12 @@ export const checkUrl = async (
   extraHTTPHeaders: Record<string, string>,
   fileTypes: FileTypes,
 ) => {
+  if (scanner === ScannerTypes.LOCALFILE && !url.toLowerCase().startsWith('file://')) {
+    const res = new RES();
+    res.status = constants.urlCheckStatuses.notALocalFile.code;
+    return res;
+  }
+
   const res = await checkUrlConnectivityWithBrowser(
     url,
     browser,
@@ -686,6 +692,7 @@ export const prepareData = async (argv: Answers): Promise<Data> => {
     ruleset,
     generateJsonFiles,
     scanDuration,
+    finalUrl,
   } = argv;
 
   const extraHTTPHeaders = parseHeaders(header);
@@ -718,6 +725,10 @@ export const prepareData = async (argv: Answers): Promise<Data> => {
     temp.password = '';
     url = temp.toString();
   }
+
+  // Keep browser-resolved URL (if provided by pre-check flow) as canonical entry URL.
+  // For local file paths, keep using the normalized `url` value below.
+  const resolvedEntryUrl = finalUrl && !isFilePath(finalUrl) ? finalUrl : url;
 
   // construct filename for scan results
   const [date, time] = new Date().toLocaleString('sv').replaceAll(/-|:/g, '').split(' ');
@@ -763,7 +774,7 @@ export const prepareData = async (argv: Answers): Promise<Data> => {
   return {
     type: scanner,
     url,
-    entryUrl: url,
+    entryUrl: resolvedEntryUrl,
     isHeadless: headless,
     deviceChosen,
     customDevice,

--- a/src/constants/common.ts
+++ b/src/constants/common.ts
@@ -597,14 +597,22 @@ export const checkUrl = async (
   extraHTTPHeaders: Record<string, string>,
   fileTypes: FileTypes,
 ) => {
-  if (scanner === ScannerTypes.LOCALFILE && !url.toLowerCase().startsWith('file://')) {
-    const res = new RES();
-    res.status = constants.urlCheckStatuses.notALocalFile.code;
-    return res;
+  let urlToCheck = url;
+
+  if (scanner === ScannerTypes.LOCALFILE) {
+    if (!isFilePath(url)) {
+      const res = new RES();
+      res.status = constants.urlCheckStatuses.notALocalFile.code;
+      return res;
+    }
+
+    if (!url.toLowerCase().startsWith('file://')) {
+      urlToCheck = pathToFileURL(path.resolve(url)).toString();
+    }
   }
 
   const res = await checkUrlConnectivityWithBrowser(
-    url,
+    urlToCheck,
     browser,
     clonedDataDir,
     playwrightDeviceDetailsObject,
@@ -1230,10 +1238,16 @@ export const getLinksFromSitemap = async (
     }
 
     const $ = cheerio.load(data, { xml: true });
+    const countBefore = allUrls.size;
 
     // This case is when the document is not an XML format document
     if ($(':root').length === 0) {
       processNonStandardSitemap(data);
+
+      const linksFromThisSitemap = allUrls.size - countBefore;
+      if (linksFromThisSitemap > 0) {
+        sitemapLinkCounts[url] = (sitemapLinkCounts[url] || 0) + linksFromThisSitemap;
+      }
       return;
     }
 
@@ -1267,8 +1281,6 @@ export const getLinksFromSitemap = async (
     } else {
       sitemapType = constants.xmlSitemapTypes.unknown;
     }
-
-    const countBefore = allUrls.size;
 
     switch (sitemapType) {
       case constants.xmlSitemapTypes.xmlIndex:
@@ -2254,6 +2266,7 @@ export const isFilePath = (url: string): boolean => {
   const driveLetterPattern = /^[A-Z]:/i;
   const backslashPattern = /\\/;
   return (
+    url.toLowerCase().startsWith('file://') ||
     url.startsWith('/') ||
     driveLetterPattern.test(url) ||
     backslashPattern.test(url) ||

--- a/src/crawlers/crawlDomain.ts
+++ b/src/crawlers/crawlDomain.ts
@@ -415,6 +415,8 @@ const crawlDomain = async ({
         ],
       },
       requestQueue,
+      maxRequestRetries: 3,
+      maxSessionRotations: 1,
       preNavigationHooks: [
         ...preNavigationHooks(extraHTTPHeaders),
       ],

--- a/src/crawlers/crawlSitemap.ts
+++ b/src/crawlers/crawlSitemap.ts
@@ -151,6 +151,8 @@ const crawlSitemap = async ({
         ],
       },
       requestList,
+      maxRequestRetries: 3,
+      maxSessionRotations: 1,
       postNavigationHooks: [
         async ({ page }) => {
           try {

--- a/src/crawlers/crawlSitemap.ts
+++ b/src/crawlers/crawlSitemap.ts
@@ -86,6 +86,7 @@ const crawlSitemap = async ({
     maxRequestsPerCrawl,
     specifiedMaxConcurrency || constants.maxConcurrency,
   );
+  const initialNoSuccessFailureAbortThreshold = Math.max(5, Math.min(maxRequestsPerCrawl, 25));
 
   if (fromCrawlIntelligentSitemap) {
     dataset = datasetFromIntelligent;
@@ -454,6 +455,17 @@ const crawlSitemap = async ({
           httpStatusCode: typeof status === 'number' ? status : 0,
         });
         crawlee.log.error(`Failed Request - ${request.url}: ${request.errorMessages}`);
+
+        if (
+          urlsCrawled.scanned.length === 0 &&
+          urlsCrawled.error.length >= initialNoSuccessFailureAbortThreshold
+        ) {
+          consoleLogger.info(
+            `Aborting sitemap crawl: ${urlsCrawled.error.length} failed pages with 0 successful scans.`,
+          );
+          isAbortingScan = true;
+          crawler.autoscaledPool?.abort();
+        }
       },
       maxRequestsPerCrawl: Infinity,
       maxConcurrency: specifiedMaxConcurrency || maxConcurrency,


### PR DESCRIPTION
This branch includes four related improvements:

1. Fix redirect-aware `entryUrl` propagation and local-file URL validation.
2. Improve URL logging for discovered sitemap sources.
3. Align crawler retry/session behavior across domain and sitemap crawls.
4. Add a sitemap early-abort guard for repeated failures with zero successful scans.

## Commits in this branch

- `6ca52e77` — **Fix redirect-aware entryUrl propagation and localfile URL validation**
  - Files:
    - `src/cli.ts`
    - `src/combine.ts`
    - `src/constants/common.ts`
- `d1f9fc45` — **Update URL logging in found sitemaps**
  - File:
    - `src/constants/common.ts`
- `3d344c80` — **Set crawler retries and session rotations for domain and sitemap scans**
  - Files:
    - `src/crawlers/crawlDomain.ts`
    - `src/crawlers/crawlSitemap.ts`
  - Explicit settings:
    - `maxRequestRetries: 3`
    - `maxSessionRotations: 1`
- `fc0ae8ed` — **Abort sitemap crawl early when no pages succeed and failures accumulate**
  - File:
    - `src/crawlers/crawlSitemap.ts`
  - Added guard:
    - `initialNoSuccessFailureAbortThreshold = max(5, min(maxRequestsPerCrawl, 25))`
    - Abort when:
      - `urlsCrawled.scanned.length === 0`, and
      - `urlsCrawled.error.length >= initialNoSuccessFailureAbortThreshold`

## Why this change

- Ensures scan metadata and routing remain correct under redirects.
- Improves observability for sitemap discovery/logging.
- Standardizes retry/session behavior across crawler entry points.
- Prevents prolonged sitemap scans from repeatedly pinging sites when pages are mostly inaccessible (e.g. 403-heavy responses) and no successful scans are possible.

## Scope

- Focused on crawl orchestration, URL handling/logging, and crawler resiliency behavior.
- No report format changes.
- No changes to adaptive concurrency algorithm logic itself.