### PR TITLE
docs: add OpenSpec 2026-06-30 Oobee improvements specs

### DIFF
--- a/.cline/skills/openspec-apply-change/SKILL.md
+++ b/.cline/skills/openspec-apply-change/SKILL.md
@@ -1,0 +1,159 @@
+---
+name: openspec-apply-change
+description: Implement tasks from an OpenSpec change. Use when the user wants to start implementing, continue implementation, or work through tasks.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.4.1"
+---
+
+Implement tasks from an OpenSpec change.
+
+**Input**: Optionally specify a change name. If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **Select the change**
+
+   If a name is provided, use it. Otherwise:
+   - Infer from conversation context if the user mentioned a change
+   - Auto-select if only one active change exists
+   - If ambiguous, run `openspec list --json` to get available changes and use the **AskUserQuestion tool** to let the user select
+
+   Always announce: "Using change: <name>" and how to override (e.g., `/opsx:apply <other>`).
+
+2. **Check status to understand the schema**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used (e.g., "spec-driven")
+   - `planningHome`, `changeRoot`, and `actionContext`: planning scope and edit constraints
+   - Which artifact contains the tasks (typically "tasks" for spec-driven, check status for others)
+
+3. **Get apply instructions**
+
+   ```bash
+   openspec instructions apply --change "<name>" --json
+   ```
+
+   This returns:
+   - `contextFiles`: artifact ID -> array of concrete file paths (varies by schema - could be proposal/specs/design/tasks or spec/tests/implementation/docs)
+   - Progress (total, complete, remaining)
+   - Task list with status
+   - Dynamic instruction based on current state
+
+   **Handle states:**
+   - If `state: "blocked"` (missing artifacts): show message, suggest using openspec-continue-change
+   - If `state: "all_done"`: congratulate, suggest archive
+   - Otherwise: proceed to implementation
+
+   **Workspace guard:** If status JSON reports `actionContext.mode: "workspace-planning"` and `allowedEditRoots` is empty, explain that full workspace apply is not supported in this slice. Treat linked repos and folders as read-only context, ask the user to select an affected area through an explicit implementation workflow, and STOP before editing files.
+
+4. **Read context files**
+
+   Read every file path listed under `contextFiles` from the apply instructions output.
+   The files depend on the schema being used:
+   - **spec-driven**: proposal, specs, design, tasks
+   - Other schemas: follow the contextFiles from CLI output
+
+5. **Show current progress**
+
+   Display:
+   - Schema being used
+   - Progress: "N/M tasks complete"
+   - Remaining tasks overview
+   - Dynamic instruction from CLI
+
+6. **Implement tasks (loop until done or blocked)**
+
+   For each pending task:
+   - Show which task is being worked on
+   - Make the code changes required
+   - Keep changes minimal and focused
+   - Mark task complete in the tasks file: `- [ ]` → `- [x]`
+   - Continue to next task
+
+   **Pause if:**
+   - Task is unclear → ask for clarification
+   - Implementation reveals a design issue → suggest updating artifacts
+   - Error or blocker encountered → report and wait for guidance
+   - User interrupts
+
+7. **On completion or pause, show status**
+
+   Display:
+   - Tasks completed this session
+   - Overall progress: "N/M tasks complete"
+   - If all done: suggest archive
+   - If paused: explain why and wait for guidance
+
+**Output During Implementation**
+
+```
+## Implementing: <change-name> (schema: <schema-name>)
+
+Working on task 3/7: <task description>
+[...implementation happening...]
+✓ Task complete
+
+Working on task 4/7: <task description>
+[...implementation happening...]
+✓ Task complete
+```
+
+**Output On Completion**
+
+```
+## Implementation Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 7/7 tasks complete ✓
+
+### Completed This Session
+- [x] Task 1
+- [x] Task 2
+...
+
+All tasks complete! Ready to archive this change.
+```
+
+**Output On Pause (Issue Encountered)**
+
+```
+## Implementation Paused
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 4/7 tasks complete
+
+### Issue Encountered
+<description of the issue>
+
+**Options:**
+1. <option 1>
+2. <option 2>
+3. Other approach
+
+What would you like to do?
+```
+
+**Guardrails**
+- Keep going through tasks until done or blocked
+- Always read context files before starting (from the apply instructions output)
+- If task is ambiguous, pause and ask before implementing
+- If implementation reveals issues, pause and suggest artifact updates
+- Keep code changes minimal and scoped to each task
+- Update task checkbox immediately after completing each task
+- Pause on errors, blockers, or unclear requirements - don't guess
+- Use contextFiles from CLI output, don't assume specific file names
+
+**Fluid Workflow Integration**
+
+This skill supports the "actions on a change" model:
+
+- **Can be invoked anytime**: Before all artifacts are done (if tasks exist), after partial implementation, interleaved with other actions
+- **Allows artifact updates**: If implementation reveals design issues, suggest updating artifacts - not phase-locked, work fluidly

--- a/.cline/skills/openspec-archive-change/SKILL.md
+++ b/.cline/skills/openspec-archive-change/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: openspec-archive-change
+description: Archive a completed change in the experimental workflow. Use when the user wants to finalize and archive a change after implementation is complete.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.4.1"
+---
+
+Archive a completed change in the experimental workflow.
+
+**Input**: Optionally specify a change name. If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **If no change name provided, prompt for selection**
+
+   Run `openspec list --json` to get available changes. Use the **AskUserQuestion tool** to let the user select.
+
+   Show only active changes (not already archived).
+   Include the schema used for each change if available.
+
+   **IMPORTANT**: Do NOT guess or auto-select a change. Always let the user choose.
+
+2. **Check artifact completion status**
+
+   Run `openspec status --change "<name>" --json` to check artifact completion.
+
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used
+   - `planningHome`, `changeRoot`, `artifactPaths`, and `actionContext`: path and scope context
+   - `artifacts`: List of artifacts with their status (`done` or other)
+
+   If status reports `actionContext.mode: "workspace-planning"`, explain that workspace archive is not supported in this slice and STOP. Do not move workspace changes into repo-local archives or edit linked repos.
+
+   **If any artifacts are not `done`:**
+   - Display warning listing incomplete artifacts
+   - Use **AskUserQuestion tool** to confirm user wants to proceed
+   - Proceed if user confirms
+
+3. **Check task completion status**
+
+   Read the tasks file (typically `tasks.md`) to check for incomplete tasks.
+
+   Count tasks marked with `- [ ]` (incomplete) vs `- [x]` (complete).
+
+   **If incomplete tasks found:**
+   - Display warning showing count of incomplete tasks
+   - Use **AskUserQuestion tool** to confirm user wants to proceed
+   - Proceed if user confirms
+
+   **If no tasks file exists:** Proceed without task-related warning.
+
+4. **Assess delta spec sync state**
+
+   Use `artifactPaths.specs.existingOutputPaths` from status JSON to check for delta specs. If none exist, proceed without sync prompt.
+
+   **If delta specs exist:**
+   - Compare each delta spec with its corresponding main spec at `openspec/specs/<capability>/spec.md`
+   - Determine what changes would be applied (adds, modifications, removals, renames)
+   - Show a combined summary before prompting
+
+   **Prompt options:**
+   - If changes needed: "Sync now (recommended)", "Archive without syncing"
+   - If already synced: "Archive now", "Sync anyway", "Cancel"
+
+   If user chooses sync, use Task tool (subagent_type: "general-purpose", prompt: "Use Skill tool to invoke openspec-sync-specs for change '<name>'. Delta spec analysis: <include the analyzed delta spec summary>"). Proceed to archive regardless of choice.
+
+5. **Perform the archive**
+
+   Create an `archive` directory under `planningHome.changesDir` if it doesn't exist:
+   ```bash
+   mkdir -p "<planningHome.changesDir>/archive"
+   ```
+
+   Generate target name using current date: `YYYY-MM-DD-<change-name>`
+
+   **Check if target already exists:**
+   - If yes: Fail with error, suggest renaming existing archive or using different date
+   - If no: Move `changeRoot` to the archive directory
+
+   ```bash
+   mv "<changeRoot>" "<planningHome.changesDir>/archive/YYYY-MM-DD-<name>"
+   ```
+
+6. **Display summary**
+
+   Show archive completion summary including:
+   - Change name
+   - Schema that was used
+   - Archive location
+   - Whether specs were synced (if applicable)
+   - Note about any warnings (incomplete artifacts/tasks)
+
+**Output On Success**
+
+```
+## Archive Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Archived to:** the archive path derived from `planningHome.changesDir`/YYYY-MM-DD-<name>/
+**Specs:** ✓ Synced to main specs (or "No delta specs" or "Sync skipped")
+
+All artifacts complete. All tasks complete.
+```
+
+**Guardrails**
+- Always prompt for change selection if not provided
+- Use artifact graph (openspec status --json) for completion checking
+- Don't block archive on warnings - just inform and confirm
+- Preserve .openspec.yaml when moving to archive (it moves with the directory)
+- Show clear summary of what happened
+- If sync is requested, use openspec-sync-specs approach (agent-driven)
+- If delta specs exist, always run the sync assessment and show the combined summary before prompting

--- a/.cline/skills/openspec-explore/SKILL.md
+++ b/.cline/skills/openspec-explore/SKILL.md
@@ -1,0 +1,287 @@
+---
+name: openspec-explore
+description: Enter explore mode - a thinking partner for exploring ideas, investigating problems, and clarifying requirements. Use when the user wants to think through something before or during a change.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.4.1"
+---
+
+Enter explore mode. Think deeply. Visualize freely. Follow the conversation wherever it goes.
+
+**IMPORTANT: Explore mode is for thinking, not implementing.** You may read files, search code, and investigate the codebase, but you must NEVER write code or implement features. If the user asks you to implement something, remind them to exit explore mode first and create a change proposal. You MAY create OpenSpec artifacts (proposals, designs, specs) if the user asks—that's capturing thinking, not implementing.
+
+**This is a stance, not a workflow.** There are no fixed steps, no required sequence, no mandatory outputs. You're a thinking partner helping the user explore.
+
+---
+
+## The Stance
+
+- **Curious, not prescriptive** - Ask questions that emerge naturally, don't follow a script
+- **Open threads, not interrogations** - Surface multiple interesting directions and let the user follow what resonates. Don't funnel them through a single path of questions.
+- **Visual** - Use ASCII diagrams liberally when they'd help clarify thinking
+- **Adaptive** - Follow interesting threads, pivot when new information emerges
+- **Patient** - Don't rush to conclusions, let the shape of the problem emerge
+- **Grounded** - Explore the actual codebase when relevant, don't just theorize
+
+---
+
+## What You Might Do
+
+Depending on what the user brings, you might:
+
+**Explore the problem space**
+- Ask clarifying questions that emerge from what they said
+- Challenge assumptions
+- Reframe the problem
+- Find analogies
+
+**Investigate the codebase**
+- Map existing architecture relevant to the discussion
+- Find integration points
+- Identify patterns already in use
+- Surface hidden complexity
+
+**Compare options**
+- Brainstorm multiple approaches
+- Build comparison tables
+- Sketch tradeoffs
+- Recommend a path (if asked)
+
+**Visualize**
+```
+┌─────────────────────────────────────────┐
+│     Use ASCII diagrams liberally        │
+├─────────────────────────────────────────┤
+│                                         │
+│      ┌────────┐         ┌────────┐      │
+│      │ State  │────────▶│ State  │      │
+│      │   A    │         │   B    │      │
+│      └────────┘         └────────┘      │
+│                                         │
+│   System diagrams, state machines,      │
+│   data flows, architecture sketches,    │
+│   dependency graphs, comparison tables  │
+│                                         │
+└─────────────────────────────────────────┘
+```
+
+**Surface risks and unknowns**
+- Identify what could go wrong
+- Find gaps in understanding
+- Suggest spikes or investigations
+
+---
+
+## OpenSpec Awareness
+
+You have full context of the OpenSpec system. Use it naturally, don't force it.
+
+### Check for context
+
+At the start, quickly check what exists:
+```bash
+openspec list --json
+```
+
+This tells you:
+- If there are active changes
+- Their names, schemas, and status
+- What the user might be working on
+
+### When no change exists
+
+Think freely. When insights crystallize, you might offer:
+
+- "This feels solid enough to start a change. Want me to create a proposal?"
+- Or keep exploring - no pressure to formalize
+
+### When a change exists
+
+If the user mentions a change or you detect one is relevant:
+
+1. **Resolve and read existing artifacts for context**
+   - Run `openspec status --change "<name>" --json`.
+   - Use `changeRoot`, `artifactPaths`, and `actionContext` from the status JSON.
+   - Read existing files from `artifactPaths.<artifact>.existingOutputPaths`.
+
+2. **Reference them naturally in conversation**
+   - "Your design mentions using Redis, but we just realized SQLite fits better..."
+   - "The proposal scopes this to premium users, but we're now thinking everyone..."
+
+3. **Offer to capture when decisions are made**
+
+    | Insight Type               | Where to Capture               |
+    |----------------------------|--------------------------------|
+    | New requirement discovered | `specs/<capability>/spec.md` |
+    | Requirement changed        | `specs/<capability>/spec.md` |
+    | Design decision made       | `design.md`                  |
+    | Scope changed              | `proposal.md`                |
+    | New work identified        | `tasks.md`                   |
+    | Assumption invalidated     | Relevant artifact              |
+
+   Example offers:
+   - "That's a design decision. Capture it in design.md?"
+   - "This is a new requirement. Add it to specs?"
+   - "This changes scope. Update the proposal?"
+
+4. **The user decides** - Offer and move on. Don't pressure. Don't auto-capture.
+
+---
+
+## What You Don't Have To Do
+
+- Follow a script
+- Ask the same questions every time
+- Produce a specific artifact
+- Reach a conclusion
+- Stay on topic if a tangent is valuable
+- Be brief (this is thinking time)
+
+---
+
+## Handling Different Entry Points
+
+**User brings a vague idea:**
+```
+User: I'm thinking about adding real-time collaboration
+
+You: Real-time collab is a big space. Let me think about this...
+
+      COLLABORATION SPECTRUM
+      ════════════════════════════════════════════
+
+      Awareness          Coordination         Sync
+          │                   │                 │
+          ▼                   ▼                 ▼
+      ┌────────┐         ┌────────┐        ┌────────┐
+      │Presence│         │Cursors │        │  CRDT  │
+      │  "3    │         │ Multi  │        │Conflict│
+      │online" │         │ select │        │  free  │
+      └────────┘         └────────┘        └────────┘
+          │                   │                 │
+       trivial            moderate           complex
+
+      Where's your head at?
+```
+
+**User brings a specific problem:**
+```
+User: The auth system is a mess
+
+You: [reads codebase]
+
+     ┌─────────────────────────────────────────────┐
+     │              CURRENT AUTH FLOW              │
+     └─────────────────────────────────────────────┘
+                        │
+          ┌─────────────┼─────────────┐
+          ▼             ▼             ▼
+     ┌─────────┐  ┌─────────┐  ┌─────────┐
+     │ Google  │  │  GitHub │  │  Email  │
+     │  OAuth  │  │  OAuth  │  │  Magic  │
+     └────┬────┘  └────┬────┘  └────┬────┘
+          │             │             │
+          └─────────────┼─────────────┘
+                        ▼
+                  ┌───────────┐
+                  │  Session  │
+                  └─────┬─────┘
+                        │
+                        ▼
+                  ┌───────────┐
+                  │   Perms   │
+                  └───────────┘
+
+     I see three tangles. Which one's burning?
+```
+
+**User is stuck mid-implementation:**
+```
+User: /opsx:explore add-auth-system
+      The OAuth integration is more complex than expected
+
+You: [reads change artifacts]
+
+     You're on task 4: "Implement OAuth flow"
+
+     Let me trace what's involved...
+
+     [draws diagram, explores options, suggests paths]
+
+     Want to update the design to reflect this?
+     Or add a spike task to investigate?
+```
+
+**User wants to compare options:**
+```
+User: Should we use Postgres or SQLite?
+
+You: Generic answer is boring. What's the context?
+
+User: A CLI tool that tracks local dev environments
+
+You: That changes everything.
+
+     ┌─────────────────────────────────────────────────┐
+     │          CLI TOOL DATA STORAGE                  │
+     └─────────────────────────────────────────────────┘
+
+     Key constraints:
+     • No daemon running
+     • Must work offline
+     • Single user
+
+                  SQLite          Postgres
+     Deployment   embedded ✓      needs server ✗
+     Offline      yes ✓           no ✗
+     Single file  yes ✓           no ✗
+
+     SQLite. Not even close.
+
+     Unless... is there a sync component?
+```
+
+---
+
+## Ending Discovery
+
+There's no required ending. Discovery might:
+
+- **Flow into a proposal**: "Ready to start? I can create a change proposal."
+- **Result in artifact updates**: "Updated design.md with these decisions"
+- **Just provide clarity**: User has what they need, moves on
+- **Continue later**: "We can pick this up anytime"
+
+When it feels like things are crystallizing, you might summarize:
+
+```
+## What We Figured Out
+
+**The problem**: [crystallized understanding]
+
+**The approach**: [if one emerged]
+
+**Open questions**: [if any remain]
+
+**Next steps** (if ready):
+- Create a change proposal
+- Keep exploring: just keep talking
+```
+
+But this summary is optional. Sometimes the thinking IS the value.
+
+---
+
+## Guardrails
+
+- **Don't implement** - Never write code or implement features. Creating OpenSpec artifacts is fine, writing application code is not.
+- **Don't fake understanding** - If something is unclear, dig deeper
+- **Don't rush** - Discovery is thinking time, not task time
+- **Don't force structure** - Let patterns emerge naturally
+- **Don't auto-capture** - Offer to save insights, don't just do it
+- **Do visualize** - A good diagram is worth many paragraphs
+- **Do explore the codebase** - Ground discussions in reality
+- **Do question assumptions** - Including the user's and your own

--- a/.cline/skills/openspec-propose/SKILL.md
+++ b/.cline/skills/openspec-propose/SKILL.md
@@ -1,0 +1,111 @@
+---
+name: openspec-propose
+description: Propose a new change with all artifacts generated in one step. Use when the user wants to quickly describe what they want to build and get a complete proposal with design, specs, and tasks ready for implementation.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.4.1"
+---
+
+Propose a new change - create the change and generate all artifacts in one step.
+
+I'll create a change with artifacts:
+- proposal.md (what & why)
+- design.md (how)
+- tasks.md (implementation steps)
+
+When ready to implement, run /opsx:apply
+
+---
+
+**Input**: The user's request should include a change name (kebab-case) OR a description of what they want to build.
+
+**Steps**
+
+1. **If no clear input provided, ask what they want to build**
+
+   Use the **AskUserQuestion tool** (open-ended, no preset options) to ask:
+   > "What change do you want to work on? Describe what you want to build or fix."
+
+   From their description, derive a kebab-case name (e.g., "add user authentication" → `add-user-auth`).
+
+   **IMPORTANT**: Do NOT proceed without understanding what the user wants to build.
+
+2. **Create the change directory**
+   ```bash
+   openspec new change "<name>"
+   ```
+   This creates a scaffolded change in the planning home resolved by the CLI with `.openspec.yaml`.
+
+3. **Get the artifact build order**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to get:
+   - `applyRequires`: array of artifact IDs needed before implementation (e.g., `["tasks"]`)
+   - `artifacts`: list of all artifacts with their status and dependencies
+   - `planningHome`, `changeRoot`, `artifactPaths`, and `actionContext`: path and scope context. Use these instead of assuming repo-local paths.
+
+4. **Create artifacts in sequence until apply-ready**
+
+   Use the **TodoWrite tool** to track progress through the artifacts.
+
+   Loop through artifacts in dependency order (artifacts with no pending dependencies first):
+
+   a. **For each artifact that is `ready` (dependencies satisfied)**:
+      - Get instructions:
+        ```bash
+        openspec instructions <artifact-id> --change "<name>" --json
+        ```
+      - The instructions JSON includes:
+        - `context`: Project background (constraints for you - do NOT include in output)
+        - `rules`: Artifact-specific rules (constraints for you - do NOT include in output)
+        - `template`: The structure to use for your output file
+        - `instruction`: Schema-specific guidance for this artifact type
+        - `resolvedOutputPath`: Resolved path or pattern to write the artifact
+        - `dependencies`: Completed artifacts to read for context
+      - Read any completed dependency files for context
+      - Create the artifact file using `template` as the structure and write it to `resolvedOutputPath`
+      - Apply `context` and `rules` as constraints - but do NOT copy them into the file
+      - Show brief progress: "Created <artifact-id>"
+
+   b. **Continue until all `applyRequires` artifacts are complete**
+      - After creating each artifact, re-run `openspec status --change "<name>" --json`
+      - Check if every artifact ID in `applyRequires` has `status: "done"` in the artifacts array
+      - Stop when all `applyRequires` artifacts are done
+
+   c. **If an artifact requires user input** (unclear context):
+      - Use **AskUserQuestion tool** to clarify
+      - Then continue with creation
+
+5. **Show final status**
+   ```bash
+   openspec status --change "<name>"
+   ```
+
+**Output**
+
+After completing all artifacts, summarize:
+- Change name and location
+- List of artifacts created with brief descriptions
+- What's ready: "All artifacts created! Ready for implementation."
+- Prompt: "Run `/opsx:apply` or ask me to implement to start working on the tasks."
+
+**Artifact Creation Guidelines**
+
+- Follow the `instruction` field from `openspec instructions` for each artifact type
+- The schema defines what each artifact should contain - follow it
+- Read dependency artifacts for context before creating new ones
+- Use `template` as the structure for your output file - fill in its sections
+- **IMPORTANT**: `context` and `rules` are constraints for YOU, not content for the file
+  - Do NOT copy `<context>`, `<rules>`, `<project_context>` blocks into the artifact
+  - These guide what you write, but should never appear in the output
+
+**Guardrails**
+- Create ALL artifacts needed for implementation (as defined by schema's `apply.requires`)
+- Always read dependency artifacts before creating a new one
+- If context is critically unclear, ask the user - but prefer making reasonable decisions to keep momentum
+- If a change with that name already exists, ask if user wants to continue it or create a new one
+- Verify each artifact file exists after writing before proceeding to next

--- a/.cline/skills/openspec-sync-specs/SKILL.md
+++ b/.cline/skills/openspec-sync-specs/SKILL.md
@@ -1,0 +1,147 @@
+---
+name: openspec-sync-specs
+description: Sync delta specs from a change to main specs. Use when the user wants to update main specs with changes from a delta spec, without archiving the change.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.4.1"
+---
+
+Sync delta specs from a change to main specs.
+
+This is an **agent-driven** operation - you will read delta specs and directly edit main specs to apply the changes. This allows intelligent merging (e.g., adding a scenario without copying the entire requirement).
+
+**Input**: Optionally specify a change name. If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **If no change name provided, prompt for selection**
+
+   Run `openspec list --json` to get available changes. Use the **AskUserQuestion tool** to let the user select.
+
+   Show changes that have delta specs (under `specs/` directory).
+
+   **IMPORTANT**: Do NOT guess or auto-select a change. Always let the user choose.
+
+2. **Resolve change context**
+
+   Run:
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+
+   If status reports `actionContext.mode: "workspace-planning"`, explain that workspace spec sync is not supported in this slice and STOP. Do not fall back to repo-local paths or edit linked repos.
+
+3. **Find delta specs**
+
+   Use `artifactPaths.specs.existingOutputPaths` from the status JSON as the list of delta spec files.
+
+   Each delta spec file contains sections like:
+   - `## ADDED Requirements` - New requirements to add
+   - `## MODIFIED Requirements` - Changes to existing requirements
+   - `## REMOVED Requirements` - Requirements to remove
+   - `## RENAMED Requirements` - Requirements to rename (FROM:/TO: format)
+
+   If no delta specs found, inform user and stop.
+
+4. **For each delta spec, apply changes to main specs**
+
+   For each repo-local capability delta spec path returned by the CLI:
+
+   a. **Read the delta spec** to understand the intended changes
+
+   b. **Read the main spec** at `openspec/specs/<capability>/spec.md` (may not exist yet)
+
+   c. **Apply changes intelligently**:
+
+      **ADDED Requirements:**
+      - If requirement doesn't exist in main spec → add it
+      - If requirement already exists → update it to match (treat as implicit MODIFIED)
+
+      **MODIFIED Requirements:**
+      - Find the requirement in main spec
+      - Apply the changes - this can be:
+        - Adding new scenarios (don't need to copy existing ones)
+        - Modifying existing scenarios
+        - Changing the requirement description
+      - Preserve scenarios/content not mentioned in the delta
+
+      **REMOVED Requirements:**
+      - Remove the entire requirement block from main spec
+
+      **RENAMED Requirements:**
+      - Find the FROM requirement, rename to TO
+
+   d. **Create new main spec** if capability doesn't exist yet:
+      - Create `openspec/specs/<capability>/spec.md`
+      - Add Purpose section (can be brief, mark as TBD)
+      - Add Requirements section with the ADDED requirements
+
+5. **Show summary**
+
+   After applying all changes, summarize:
+   - Which capabilities were updated
+   - What changes were made (requirements added/modified/removed/renamed)
+
+**Delta Spec Format Reference**
+
+```markdown
+## ADDED Requirements
+
+### Requirement: New Feature
+The system SHALL do something new.
+
+#### Scenario: Basic case
+- **WHEN** user does X
+- **THEN** system does Y
+
+## MODIFIED Requirements
+
+### Requirement: Existing Feature
+#### Scenario: New scenario to add
+- **WHEN** user does A
+- **THEN** system does B
+
+## REMOVED Requirements
+
+### Requirement: Deprecated Feature
+
+## RENAMED Requirements
+
+- FROM: `### Requirement: Old Name`
+- TO: `### Requirement: New Name`
+```
+
+**Key Principle: Intelligent Merging**
+
+Unlike programmatic merging, you can apply **partial updates**:
+- To add a scenario, just include that scenario under MODIFIED - don't copy existing scenarios
+- The delta represents *intent*, not a wholesale replacement
+- Use your judgment to merge changes sensibly
+
+**Output On Success**
+
+```
+## Specs Synced: <change-name>
+
+Updated main specs:
+
+**<capability-1>**:
+- Added requirement: "New Feature"
+- Modified requirement: "Existing Feature" (added 1 scenario)
+
+**<capability-2>**:
+- Created new spec file
+- Added requirement: "Another Feature"
+
+Main specs are now updated. The change remains active - archive when implementation is complete.
+```
+
+**Guardrails**
+- Read both delta and main specs before making changes
+- Preserve existing content not mentioned in delta
+- If something is unclear, ask for clarification
+- Show what you're changing as you go
+- The operation should be idempotent - running twice should give same result

--- a/.clinerules/workflows/opsx-apply.md
+++ b/.clinerules/workflows/opsx-apply.md
@@ -1,0 +1,152 @@
+# OPSX: Apply
+
+Implement tasks from an OpenSpec change (Experimental)
+
+Implement tasks from an OpenSpec change.
+
+**Input**: Optionally specify a change name (e.g., `/opsx:apply add-auth`). If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **Select the change**
+
+   If a name is provided, use it. Otherwise:
+   - Infer from conversation context if the user mentioned a change
+   - Auto-select if only one active change exists
+   - If ambiguous, run `openspec list --json` to get available changes and use the **AskUserQuestion tool** to let the user select
+
+   Always announce: "Using change: <name>" and how to override (e.g., `/opsx:apply <other>`).
+
+2. **Check status to understand the schema**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used (e.g., "spec-driven")
+   - `planningHome`, `changeRoot`, and `actionContext`: planning scope and edit constraints
+   - Which artifact contains the tasks (typically "tasks" for spec-driven, check status for others)
+
+3. **Get apply instructions**
+
+   ```bash
+   openspec instructions apply --change "<name>" --json
+   ```
+
+   This returns:
+   - `contextFiles`: artifact ID -> array of concrete file paths (varies by schema)
+   - Progress (total, complete, remaining)
+   - Task list with status
+   - Dynamic instruction based on current state
+
+   **Handle states:**
+   - If `state: "blocked"` (missing artifacts): show message, suggest using `/opsx:continue`
+   - If `state: "all_done"`: congratulate, suggest archive
+   - Otherwise: proceed to implementation
+
+   **Workspace guard:** If status JSON reports `actionContext.mode: "workspace-planning"` and `allowedEditRoots` is empty, explain that full workspace apply is not supported in this slice. Treat linked repos and folders as read-only context, ask the user to select an affected area through an explicit implementation workflow, and STOP before editing files.
+
+4. **Read context files**
+
+   Read every file path listed under `contextFiles` from the apply instructions output.
+   The files depend on the schema being used:
+   - **spec-driven**: proposal, specs, design, tasks
+   - Other schemas: follow the contextFiles from CLI output
+
+5. **Show current progress**
+
+   Display:
+   - Schema being used
+   - Progress: "N/M tasks complete"
+   - Remaining tasks overview
+   - Dynamic instruction from CLI
+
+6. **Implement tasks (loop until done or blocked)**
+
+   For each pending task:
+   - Show which task is being worked on
+   - Make the code changes required
+   - Keep changes minimal and focused
+   - Mark task complete in the tasks file: `- [ ]` → `- [x]`
+   - Continue to next task
+
+   **Pause if:**
+   - Task is unclear → ask for clarification
+   - Implementation reveals a design issue → suggest updating artifacts
+   - Error or blocker encountered → report and wait for guidance
+   - User interrupts
+
+7. **On completion or pause, show status**
+
+   Display:
+   - Tasks completed this session
+   - Overall progress: "N/M tasks complete"
+   - If all done: suggest archive
+   - If paused: explain why and wait for guidance
+
+**Output During Implementation**
+
+```
+## Implementing: <change-name> (schema: <schema-name>)
+
+Working on task 3/7: <task description>
+[...implementation happening...]
+✓ Task complete
+
+Working on task 4/7: <task description>
+[...implementation happening...]
+✓ Task complete
+```
+
+**Output On Completion**
+
+```
+## Implementation Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 7/7 tasks complete ✓
+
+### Completed This Session
+- [x] Task 1
+- [x] Task 2
+...
+
+All tasks complete! You can archive this change with `/opsx:archive`.
+```
+
+**Output On Pause (Issue Encountered)**
+
+```
+## Implementation Paused
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 4/7 tasks complete
+
+### Issue Encountered
+<description of the issue>
+
+**Options:**
+1. <option 1>
+2. <option 2>
+3. Other approach
+
+What would you like to do?
+```
+
+**Guardrails**
+- Keep going through tasks until done or blocked
+- Always read context files before starting (from the apply instructions output)
+- If task is ambiguous, pause and ask before implementing
+- If implementation reveals issues, pause and suggest artifact updates
+- Keep code changes minimal and scoped to each task
+- Update task checkbox immediately after completing each task
+- Pause on errors, blockers, or unclear requirements - don't guess
+- Use contextFiles from CLI output, don't assume specific file names
+
+**Fluid Workflow Integration**
+
+This skill supports the "actions on a change" model:
+
+- **Can be invoked anytime**: Before all artifacts are done (if tasks exist), after partial implementation, interleaved with other actions
+- **Allows artifact updates**: If implementation reveals design issues, suggest updating artifacts - not phase-locked, work fluidly

--- a/.clinerules/workflows/opsx-archive.md
+++ b/.clinerules/workflows/opsx-archive.md
@@ -1,0 +1,157 @@
+# OPSX: Archive
+
+Archive a completed change in the experimental workflow
+
+Archive a completed change in the experimental workflow.
+
+**Input**: Optionally specify a change name after `/opsx:archive` (e.g., `/opsx:archive add-auth`). If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **If no change name provided, prompt for selection**
+
+   Run `openspec list --json` to get available changes. Use the **AskUserQuestion tool** to let the user select.
+
+   Show only active changes (not already archived).
+   Include the schema used for each change if available.
+
+   **IMPORTANT**: Do NOT guess or auto-select a change. Always let the user choose.
+
+2. **Check artifact completion status**
+
+   Run `openspec status --change "<name>" --json` to check artifact completion.
+
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used
+   - `planningHome`, `changeRoot`, `artifactPaths`, and `actionContext`: path and scope context
+   - `artifacts`: List of artifacts with their status (`done` or other)
+
+   If status reports `actionContext.mode: "workspace-planning"`, explain that workspace archive is not supported in this slice and STOP. Do not move workspace changes into repo-local archives or edit linked repos.
+
+   **If any artifacts are not `done`:**
+   - Display warning listing incomplete artifacts
+   - Prompt user for confirmation to continue
+   - Proceed if user confirms
+
+3. **Check task completion status**
+
+   Read the tasks file (typically `tasks.md`) to check for incomplete tasks.
+
+   Count tasks marked with `- [ ]` (incomplete) vs `- [x]` (complete).
+
+   **If incomplete tasks found:**
+   - Display warning showing count of incomplete tasks
+   - Prompt user for confirmation to continue
+   - Proceed if user confirms
+
+   **If no tasks file exists:** Proceed without task-related warning.
+
+4. **Assess delta spec sync state**
+
+   Use `artifactPaths.specs.existingOutputPaths` from status JSON to check for delta specs. If none exist, proceed without sync prompt.
+
+   **If delta specs exist:**
+   - Compare each delta spec with its corresponding main spec at `openspec/specs/<capability>/spec.md`
+   - Determine what changes would be applied (adds, modifications, removals, renames)
+   - Show a combined summary before prompting
+
+   **Prompt options:**
+   - If changes needed: "Sync now (recommended)", "Archive without syncing"
+   - If already synced: "Archive now", "Sync anyway", "Cancel"
+
+   If user chooses sync, use Task tool (subagent_type: "general-purpose", prompt: "Use Skill tool to invoke openspec-sync-specs for change '<name>'. Delta spec analysis: <include the analyzed delta spec summary>"). Proceed to archive regardless of choice.
+
+5. **Perform the archive**
+
+   Create an `archive` directory under `planningHome.changesDir` if it doesn't exist:
+   ```bash
+   mkdir -p "<planningHome.changesDir>/archive"
+   ```
+
+   Generate target name using current date: `YYYY-MM-DD-<change-name>`
+
+   **Check if target already exists:**
+   - If yes: Fail with error, suggest renaming existing archive or using different date
+   - If no: Move `changeRoot` to the archive directory
+
+   ```bash
+   mv "<changeRoot>" "<planningHome.changesDir>/archive/YYYY-MM-DD-<name>"
+   ```
+
+6. **Display summary**
+
+   Show archive completion summary including:
+   - Change name
+   - Schema that was used
+   - Archive location
+   - Spec sync status (synced / sync skipped / no delta specs)
+   - Note about any warnings (incomplete artifacts/tasks)
+
+**Output On Success**
+
+```
+## Archive Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Archived to:** the archive path derived from `planningHome.changesDir`/YYYY-MM-DD-<name>/
+**Specs:** ✓ Synced to main specs
+
+All artifacts complete. All tasks complete.
+```
+
+**Output On Success (No Delta Specs)**
+
+```
+## Archive Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Archived to:** the archive path derived from `planningHome.changesDir`/YYYY-MM-DD-<name>/
+**Specs:** No delta specs
+
+All artifacts complete. All tasks complete.
+```
+
+**Output On Success With Warnings**
+
+```
+## Archive Complete (with warnings)
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Archived to:** the archive path derived from `planningHome.changesDir`/YYYY-MM-DD-<name>/
+**Specs:** Sync skipped (user chose to skip)
+
+**Warnings:**
+- Archived with 2 incomplete artifacts
+- Archived with 3 incomplete tasks
+- Delta spec sync was skipped (user chose to skip)
+
+Review the archive if this was not intentional.
+```
+
+**Output On Error (Archive Exists)**
+
+```
+## Archive Failed
+
+**Change:** <change-name>
+**Target:** the archive path derived from `planningHome.changesDir`/YYYY-MM-DD-<name>/
+
+Target archive directory already exists.
+
+**Options:**
+1. Rename the existing archive
+2. Delete the existing archive if it's a duplicate
+3. Wait until a different date to archive
+```
+
+**Guardrails**
+- Always prompt for change selection if not provided
+- Use artifact graph (openspec status --json) for completion checking
+- Don't block archive on warnings - just inform and confirm
+- Preserve .openspec.yaml when moving to archive (it moves with the directory)
+- Show clear summary of what happened
+- If sync is requested, use the Skill tool to invoke `openspec-sync-specs` (agent-driven)
+- If delta specs exist, always run the sync assessment and show the combined summary before prompting

--- a/.clinerules/workflows/opsx-explore.md
+++ b/.clinerules/workflows/opsx-explore.md
@@ -1,0 +1,169 @@
+# OPSX: Explore
+
+Enter explore mode - think through ideas, investigate problems, clarify requirements
+
+Enter explore mode. Think deeply. Visualize freely. Follow the conversation wherever it goes.
+
+**IMPORTANT: Explore mode is for thinking, not implementing.** You may read files, search code, and investigate the codebase, but you must NEVER write code or implement features. If the user asks you to implement something, remind them to exit explore mode first and create a change proposal. You MAY create OpenSpec artifacts (proposals, designs, specs) if the user asks—that's capturing thinking, not implementing.
+
+**This is a stance, not a workflow.** There are no fixed steps, no required sequence, no mandatory outputs. You're a thinking partner helping the user explore.
+
+**Input**: The argument after `/opsx:explore` is whatever the user wants to think about. Could be:
+- A vague idea: "real-time collaboration"
+- A specific problem: "the auth system is getting unwieldy"
+- A change name: "add-dark-mode" (to explore in context of that change)
+- A comparison: "postgres vs sqlite for this"
+- Nothing (just enter explore mode)
+
+---
+
+## The Stance
+
+- **Curious, not prescriptive** - Ask questions that emerge naturally, don't follow a script
+- **Open threads, not interrogations** - Surface multiple interesting directions and let the user follow what resonates. Don't funnel them through a single path of questions.
+- **Visual** - Use ASCII diagrams liberally when they'd help clarify thinking
+- **Adaptive** - Follow interesting threads, pivot when new information emerges
+- **Patient** - Don't rush to conclusions, let the shape of the problem emerge
+- **Grounded** - Explore the actual codebase when relevant, don't just theorize
+
+---
+
+## What You Might Do
+
+Depending on what the user brings, you might:
+
+**Explore the problem space**
+- Ask clarifying questions that emerge from what they said
+- Challenge assumptions
+- Reframe the problem
+- Find analogies
+
+**Investigate the codebase**
+- Map existing architecture relevant to the discussion
+- Find integration points
+- Identify patterns already in use
+- Surface hidden complexity
+
+**Compare options**
+- Brainstorm multiple approaches
+- Build comparison tables
+- Sketch tradeoffs
+- Recommend a path (if asked)
+
+**Visualize**
+```
+┌─────────────────────────────────────────┐
+│     Use ASCII diagrams liberally        │
+├─────────────────────────────────────────┤
+│                                         │
+│      ┌────────┐         ┌────────┐      │
+│      │ State  │────────▶│ State  │      │
+│      │   A    │         │   B    │      │
+│      └────────┘         └────────┘      │
+│                                         │
+│   System diagrams, state machines,      │
+│   data flows, architecture sketches,    │
+│   dependency graphs, comparison tables  │
+│                                         │
+└─────────────────────────────────────────┘
+```
+
+**Surface risks and unknowns**
+- Identify what could go wrong
+- Find gaps in understanding
+- Suggest spikes or investigations
+
+---
+
+## OpenSpec Awareness
+
+You have full context of the OpenSpec system. Use it naturally, don't force it.
+
+### Check for context
+
+At the start, quickly check what exists:
+```bash
+openspec list --json
+```
+
+This tells you:
+- If there are active changes
+- Their names, schemas, and status
+- What the user might be working on
+
+If the user mentioned a specific change name, read its artifacts for context.
+
+### When no change exists
+
+Think freely. When insights crystallize, you might offer:
+
+- "This feels solid enough to start a change. Want me to create a proposal?"
+- Or keep exploring - no pressure to formalize
+
+### When a change exists
+
+If the user mentions a change or you detect one is relevant:
+
+1. **Resolve and read existing artifacts for context**
+   - Run `openspec status --change "<name>" --json`.
+   - Use `changeRoot`, `artifactPaths`, and `actionContext` from the status JSON.
+   - Read existing files from `artifactPaths.<artifact>.existingOutputPaths`.
+
+2. **Reference them naturally in conversation**
+   - "Your design mentions using Redis, but we just realized SQLite fits better..."
+   - "The proposal scopes this to premium users, but we're now thinking everyone..."
+
+3. **Offer to capture when decisions are made**
+
+    | Insight Type               | Where to Capture               |
+    |----------------------------|--------------------------------|
+    | New requirement discovered | `specs/<capability>/spec.md` |
+    | Requirement changed        | `specs/<capability>/spec.md` |
+    | Design decision made       | `design.md`                  |
+    | Scope changed              | `proposal.md`                |
+    | New work identified        | `tasks.md`                   |
+    | Assumption invalidated     | Relevant artifact              |
+
+   Example offers:
+   - "That's a design decision. Capture it in design.md?"
+   - "This is a new requirement. Add it to specs?"
+   - "This changes scope. Update the proposal?"
+
+4. **The user decides** - Offer and move on. Don't pressure. Don't auto-capture.
+
+---
+
+## What You Don't Have To Do
+
+- Follow a script
+- Ask the same questions every time
+- Produce a specific artifact
+- Reach a conclusion
+- Stay on topic if a tangent is valuable
+- Be brief (this is thinking time)
+
+---
+
+## Ending Discovery
+
+There's no required ending. Discovery might:
+
+- **Flow into a proposal**: "Ready to start? I can create a change proposal."
+- **Result in artifact updates**: "Updated design.md with these decisions"
+- **Just provide clarity**: User has what they need, moves on
+- **Continue later**: "We can pick this up anytime"
+
+When things crystallize, you might offer a summary - but it's optional. Sometimes the thinking IS the value.
+
+---
+
+## Guardrails
+
+- **Don't implement** - Never write code or implement features. Creating OpenSpec artifacts is fine, writing application code is not.
+- **Don't fake understanding** - If something is unclear, dig deeper
+- **Don't rush** - Discovery is thinking time, not task time
+- **Don't force structure** - Let patterns emerge naturally
+- **Don't auto-capture** - Offer to save insights, don't just do it
+- **Do visualize** - A good diagram is worth many paragraphs
+- **Do explore the codebase** - Ground discussions in reality
+- **Do question assumptions** - Including the user's and your own

--- a/.clinerules/workflows/opsx-propose.md
+++ b/.clinerules/workflows/opsx-propose.md
@@ -1,0 +1,104 @@
+# OPSX: Propose
+
+Propose a new change - create it and generate all artifacts in one step
+
+Propose a new change - create the change and generate all artifacts in one step.
+
+I'll create a change with artifacts:
+- proposal.md (what & why)
+- design.md (how)
+- tasks.md (implementation steps)
+
+When ready to implement, run /opsx:apply
+
+---
+
+**Input**: The argument after `/opsx:propose` is the change name (kebab-case), OR a description of what the user wants to build.
+
+**Steps**
+
+1. **If no input provided, ask what they want to build**
+
+   Use the **AskUserQuestion tool** (open-ended, no preset options) to ask:
+   > "What change do you want to work on? Describe what you want to build or fix."
+
+   From their description, derive a kebab-case name (e.g., "add user authentication" → `add-user-auth`).
+
+   **IMPORTANT**: Do NOT proceed without understanding what the user wants to build.
+
+2. **Create the change directory**
+   ```bash
+   openspec new change "<name>"
+   ```
+   This creates a scaffolded change in the planning home resolved by the CLI with `.openspec.yaml`.
+
+3. **Get the artifact build order**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to get:
+   - `applyRequires`: array of artifact IDs needed before implementation (e.g., `["tasks"]`)
+   - `artifacts`: list of all artifacts with their status and dependencies
+   - `planningHome`, `changeRoot`, `artifactPaths`, and `actionContext`: path and scope context. Use these instead of assuming repo-local paths.
+
+4. **Create artifacts in sequence until apply-ready**
+
+   Use the **TodoWrite tool** to track progress through the artifacts.
+
+   Loop through artifacts in dependency order (artifacts with no pending dependencies first):
+
+   a. **For each artifact that is `ready` (dependencies satisfied)**:
+      - Get instructions:
+        ```bash
+        openspec instructions <artifact-id> --change "<name>" --json
+        ```
+      - The instructions JSON includes:
+        - `context`: Project background (constraints for you - do NOT include in output)
+        - `rules`: Artifact-specific rules (constraints for you - do NOT include in output)
+        - `template`: The structure to use for your output file
+        - `instruction`: Schema-specific guidance for this artifact type
+        - `resolvedOutputPath`: Resolved path or pattern to write the artifact
+        - `dependencies`: Completed artifacts to read for context
+      - Read any completed dependency files for context
+      - Create the artifact file using `template` as the structure and write it to `resolvedOutputPath`
+      - Apply `context` and `rules` as constraints - but do NOT copy them into the file
+      - Show brief progress: "Created <artifact-id>"
+
+   b. **Continue until all `applyRequires` artifacts are complete**
+      - After creating each artifact, re-run `openspec status --change "<name>" --json`
+      - Check if every artifact ID in `applyRequires` has `status: "done"` in the artifacts array
+      - Stop when all `applyRequires` artifacts are done
+
+   c. **If an artifact requires user input** (unclear context):
+      - Use **AskUserQuestion tool** to clarify
+      - Then continue with creation
+
+5. **Show final status**
+   ```bash
+   openspec status --change "<name>"
+   ```
+
+**Output**
+
+After completing all artifacts, summarize:
+- Change name and location
+- List of artifacts created with brief descriptions
+- What's ready: "All artifacts created! Ready for implementation."
+- Prompt: "Run `/opsx:apply` to start implementing."
+
+**Artifact Creation Guidelines**
+
+- Follow the `instruction` field from `openspec instructions` for each artifact type
+- The schema defines what each artifact should contain - follow it
+- Read dependency artifacts for context before creating new ones
+- Use `template` as the structure for your output file - fill in its sections
+- **IMPORTANT**: `context` and `rules` are constraints for YOU, not content for the file
+  - Do NOT copy `<context>`, `<rules>`, `<project_context>` blocks into the artifact
+  - These guide what you write, but should never appear in the output
+
+**Guardrails**
+- Create ALL artifacts needed for implementation (as defined by schema's `apply.requires`)
+- Always read dependency artifacts before creating a new one
+- If context is critically unclear, ask the user - but prefer making reasonable decisions to keep momentum
+- If a change with that name already exists, ask if user wants to continue it or create a new one
+- Verify each artifact file exists after writing before proceeding to next

--- a/.clinerules/workflows/opsx-sync.md
+++ b/.clinerules/workflows/opsx-sync.md
@@ -1,0 +1,140 @@
+# OPSX: Sync
+
+Sync delta specs from a change to main specs
+
+Sync delta specs from a change to main specs.
+
+This is an **agent-driven** operation - you will read delta specs and directly edit main specs to apply the changes. This allows intelligent merging (e.g., adding a scenario without copying the entire requirement).
+
+**Input**: Optionally specify a change name after `/opsx:sync` (e.g., `/opsx:sync add-auth`). If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **If no change name provided, prompt for selection**
+
+   Run `openspec list --json` to get available changes. Use the **AskUserQuestion tool** to let the user select.
+
+   Show changes that have delta specs (under `specs/` directory).
+
+   **IMPORTANT**: Do NOT guess or auto-select a change. Always let the user choose.
+
+2. **Resolve change context**
+
+   Run:
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+
+   If status reports `actionContext.mode: "workspace-planning"`, explain that workspace spec sync is not supported in this slice and STOP. Do not fall back to repo-local paths or edit linked repos.
+
+3. **Find delta specs**
+
+   Use `artifactPaths.specs.existingOutputPaths` from the status JSON as the list of delta spec files.
+
+   Each delta spec file contains sections like:
+   - `## ADDED Requirements` - New requirements to add
+   - `## MODIFIED Requirements` - Changes to existing requirements
+   - `## REMOVED Requirements` - Requirements to remove
+   - `## RENAMED Requirements` - Requirements to rename (FROM:/TO: format)
+
+   If no delta specs found, inform user and stop.
+
+4. **For each delta spec, apply changes to main specs**
+
+   For each repo-local capability delta spec path returned by the CLI:
+
+   a. **Read the delta spec** to understand the intended changes
+
+   b. **Read the main spec** at `openspec/specs/<capability>/spec.md` (may not exist yet)
+
+   c. **Apply changes intelligently**:
+
+      **ADDED Requirements:**
+      - If requirement doesn't exist in main spec → add it
+      - If requirement already exists → update it to match (treat as implicit MODIFIED)
+
+      **MODIFIED Requirements:**
+      - Find the requirement in main spec
+      - Apply the changes - this can be:
+        - Adding new scenarios (don't need to copy existing ones)
+        - Modifying existing scenarios
+        - Changing the requirement description
+      - Preserve scenarios/content not mentioned in the delta
+
+      **REMOVED Requirements:**
+      - Remove the entire requirement block from main spec
+
+      **RENAMED Requirements:**
+      - Find the FROM requirement, rename to TO
+
+   d. **Create new main spec** if capability doesn't exist yet:
+      - Create `openspec/specs/<capability>/spec.md`
+      - Add Purpose section (can be brief, mark as TBD)
+      - Add Requirements section with the ADDED requirements
+
+5. **Show summary**
+
+   After applying all changes, summarize:
+   - Which capabilities were updated
+   - What changes were made (requirements added/modified/removed/renamed)
+
+**Delta Spec Format Reference**
+
+```markdown
+## ADDED Requirements
+
+### Requirement: New Feature
+The system SHALL do something new.
+
+#### Scenario: Basic case
+- **WHEN** user does X
+- **THEN** system does Y
+
+## MODIFIED Requirements
+
+### Requirement: Existing Feature
+#### Scenario: New scenario to add
+- **WHEN** user does A
+- **THEN** system does B
+
+## REMOVED Requirements
+
+### Requirement: Deprecated Feature
+
+## RENAMED Requirements
+
+- FROM: `### Requirement: Old Name`
+- TO: `### Requirement: New Name`
+```
+
+**Key Principle: Intelligent Merging**
+
+Unlike programmatic merging, you can apply **partial updates**:
+- To add a scenario, just include that scenario under MODIFIED - don't copy existing scenarios
+- The delta represents *intent*, not a wholesale replacement
+- Use your judgment to merge changes sensibly
+
+**Output On Success**
+
+```
+## Specs Synced: <change-name>
+
+Updated main specs:
+
+**<capability-1>**:
+- Added requirement: "New Feature"
+- Modified requirement: "Existing Feature" (added 1 scenario)
+
+**<capability-2>**:
+- Created new spec file
+- Added requirement: "Another Feature"
+
+Main specs are now updated. The change remains active - archive when implementation is complete.
+```
+
+**Guardrails**
+- Read both delta and main specs before making changes
+- Preserve existing content not mentioned in delta
+- If something is unclear, ask for clarification
+- Show what you're changing as you go
+- The operation should be idempotent - running twice should give same result

--- a/openspec/changes/2026-06-30-oobee-improvements/.openspec.yaml
+++ b/openspec/changes/2026-06-30-oobee-improvements/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-24

--- a/openspec/changes/2026-06-30-oobee-improvements/README.md
+++ b/openspec/changes/2026-06-30-oobee-improvements/README.md
@@ -1,0 +1,3 @@
+# 2026-06-30-oobee-improvements
+
+Capture important Oobee web-crawling and report-generation behaviors introduced since 8cf8f9d937c1b4e320b81a35425ba5040b8c9fc5 (2026-06-30 Oobee improvements).

--- a/openspec/changes/2026-06-30-oobee-improvements/design.md
+++ b/openspec/changes/2026-06-30-oobee-improvements/design.md
@@ -1,0 +1,27 @@
+## Context
+
+This change codifies crawler/report hardening behavior introduced across commits from `e32187cf` through `dfc6be34` into durable OpenSpec requirements.
+
+## Scope Mapping
+
+- **Rate and budget control**: adaptive concurrency, slot-claim timing, circuit breaker safety.
+- **Sitemap robustness**: robots/sitemap discovery, XSL-safe fetch strategy, image sitemap exclusion, accurate discovered-link accounting.
+- **Auth/header safety**: scoped auth propagation, CORS-safe header handling, avoidance of unnecessary global header rewrites.
+- **Redirect and URL boundary safety**: normalization and hostname equivalence rules, out-of-scope redirect discard behavior.
+- **Custom-flow guard resilience**: loop prevention for `file://` and `about:blank`, overlay continuity in headful macOS/Windows.
+- **Report pipeline resilience**: graceful Crawlee storage cleanup, Windows EPERM tolerance, JSONL corruption tolerance, retry-safe error recording.
+
+## Design Decisions
+
+1. **Capability-first decomposition**
+   - Separate specs by concern domain to keep requirements testable and independently maintainable.
+2. **Normative behavioral language**
+   - Use SHALL/MUST to encode invariant behavior that must survive refactors.
+3. **Scenario-driven acceptance**
+   - Every requirement includes concrete WHEN/THEN scenarios that map directly to tests or regression checks.
+
+## Validation Strategy
+
+- Use `openspec validate --strict` to ensure artifact schema validity.
+- Cross-check scenarios against known pitfalls in `AGENTS.md` and crawler/report modules.
+- Keep capability boundaries aligned with real module ownership to reduce drift.

--- a/openspec/changes/2026-06-30-oobee-improvements/proposal.md
+++ b/openspec/changes/2026-06-30-oobee-improvements/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+Oobee accumulated critical crawler hardening fixes across many commits, but those behaviors are only implicit in code and changelogs. A formal OpenSpec baseline is needed so future refactors preserve these web-crawling guarantees and edge-case protections.
+
+## What Changes
+
+- Create first-class OpenSpec capability specs for crawler rate control, sitemap resiliency, auth/header safety, redirect/hostname boundaries, custom-flow URL guard behavior, and report artifact resiliency.
+- Convert critical post-`8cf8f9d937c1b4e320b81a35425ba5040b8c9fc5` behaviors into normative SHALL/MUST requirements with explicit scenarios.
+- Add an implementation-oriented task breakdown for maintaining and validating these crawler specifications over time.
+
+## Capabilities
+
+### New Capabilities
+- `crawl-rate-control`: Governs max-pages accounting, adaptive concurrency, and failure circuit breaking under WAF/rate-limited sites.
+- `sitemap-resilience`: Defines robust sitemap discovery/fetch/parsing behavior including XSL and image-sitemap edge cases.
+- `auth-header-isolation`: Prevents auth header leakage/CORS regressions and suppresses unnecessary Playwright header-rewrite overhead.
+- `redirect-boundary-enforcement`: Enforces canonical URL/hostname comparison and in-scope redirect handling rules.
+- `custom-flow-guard-overlay`: Hardens custom-flow URL guard redirects and overlay behavior across platform/headful differences.
+- `report-artifact-resilience`: Preserves report generation stability, intermediate data integrity, and retry-safe error accounting.
+
+### Modified Capabilities
+- None.
+
+## Impact
+
+- Affected areas: `src/crawlers/*`, `src/constants/common.ts`, `src/utils.ts`, `src/mergeAxeResults.ts`, `src/mergeAxeResults/itemsStore.ts`, and custom-flow guard modules.
+- Operational impact: tighter guarantees for large crawls, authenticated scans, sitemap-heavy targets, and Windows-specific cleanup stability.
+- Maintenance impact: future crawler/report changes can be validated against explicit OpenSpec requirements instead of inferred tribal knowledge.

--- a/openspec/changes/2026-06-30-oobee-improvements/specs/auth-header-isolation/spec.md
+++ b/openspec/changes/2026-06-30-oobee-improvements/specs/auth-header-isolation/spec.md
@@ -1,0 +1,37 @@
+## ADDED Requirements
+
+### Requirement: Authorization header scoping
+Authorization credentials MUST NOT be broadcast as global browser-context `extraHTTPHeaders`.
+
+#### Scenario: Prevent cross-origin credential leakage
+- **WHEN** a scan is configured with Authorization credentials
+- **THEN** Authorization MUST be sent only to intended same-origin requests via scoped interception/navigation hooks
+
+#### Scenario: Basic auth challenge handling
+- **WHEN** credentials are Basic Auth compatible
+- **THEN** the scanner MUST use browser `httpCredentials` for origin-aware challenge responses
+
+### Requirement: Non-auth header rewrite minimization
+Crawler pre-navigation header rewriting MUST only be enabled when non-empty shared headers are explicitly required.
+
+#### Scenario: Unauthenticated scan without shared headers
+- **WHEN** no non-auth headers are configured
+- **THEN** request header rewriting MUST remain disabled to avoid unnecessary Playwright performance warnings
+
+#### Scenario: Authenticated scan with shared headers
+- **WHEN** non-auth shared headers are configured alongside auth credentials
+- **THEN** header rewriting MUST be enabled and the expected Playwright header-rewrite warning is acceptable
+
+### Requirement: Connectivity-check header isolation
+Connectivity probing MUST avoid mutating shared crawl header objects.
+
+#### Scenario: Local Accept injection only
+- **WHEN** URL connectivity checks require an `Accept` header
+- **THEN** the scanner MUST add it to a local header copy and MUST NOT mutate the shared crawler `extraHTTPHeaders` object
+
+### Requirement: Common preNavigationHooks for auth header delivery
+Auth headers MUST be delivered through a shared hook used by all crawlers to prevent inconsistent auth behavior across scan types.
+
+#### Scenario: Consistent auth delivery across domain and sitemap crawls
+- **WHEN** an authenticated scan runs in either domain or sitemap mode
+- **THEN** both crawler types MUST use the same `preNavigationHooks` implementation for header injection

--- a/openspec/changes/2026-06-30-oobee-improvements/specs/crawl-rate-control/spec.md
+++ b/openspec/changes/2026-06-30-oobee-improvements/specs/crawl-rate-control/spec.md
@@ -1,0 +1,37 @@
+## ADDED Requirements
+
+### Requirement: Successful-page budget enforcement
+The crawler MUST enforce `maxRequestsPerCrawl` based on successfully scanned pages, not on attempted requests or enqueued URLs.
+
+#### Scenario: Failed pages do not consume scan budget
+- **WHEN** a request fails or is discarded before becoming a successful scan result
+- **THEN** the crawler MUST NOT decrement or consume a `maxRequestsPerCrawl` success slot
+
+#### Scenario: Last slot is claimed at success point
+- **WHEN** a page is about to be added to the successful scanned-pages set
+- **THEN** the crawler MUST claim the slot synchronously at that success point and only abort after the last slot is actually claimed
+
+### Requirement: Adaptive concurrency under HTTP rate limiting
+The crawler MUST reduce pressure on targets that respond with HTTP 4xx/5xx by adapting concurrency downward and MUST recover concurrency after sustained successes.
+
+#### Scenario: Concurrency reduction on server rejection
+- **WHEN** consecutive HTTP 4xx/5xx responses are observed
+- **THEN** concurrency MUST be reduced by halving, with a lower bound of 1
+
+#### Scenario: Concurrency recovery on stable success
+- **WHEN** 10 consecutive successful scans occur after a degraded period
+- **THEN** concurrency MUST increase by 2 toward the original configured level
+
+### Requirement: Consecutive-failure circuit breaker
+The crawler MUST stop gracefully when HTTP 4xx/5xx failures reach a configured consecutive threshold to avoid unbounded scans on blocked targets.
+
+#### Scenario: Abort on threshold breach
+- **WHEN** consecutive HTTP 4xx/5xx failures reach `OOBEE_CONSECUTIVE_MAX_RETRIES` (default 100)
+- **THEN** the crawler MUST abort and continue with artifact generation instead of running indefinitely
+
+### Requirement: Only HTTP status errors trigger rate adaptation
+Timeouts, DNS failures, and other network-level errors MUST NOT trigger concurrency adaptation or increment the circuit breaker counter.
+
+#### Scenario: Timeout does not degrade concurrency
+- **WHEN** a request fails due to network timeout or connection error
+- **THEN** the crawler MUST NOT reduce concurrency or count the failure toward the consecutive-failure threshold

--- a/openspec/changes/2026-06-30-oobee-improvements/specs/custom-flow-guard-overlay/spec.md
+++ b/openspec/changes/2026-06-30-oobee-improvements/specs/custom-flow-guard-overlay/spec.md
@@ -1,0 +1,44 @@
+## ADDED Requirements
+
+### Requirement: Safe fallback validation before URL guard restore
+URL guard recovery MUST validate fallback URL protocol safety before performing forced navigation.
+
+#### Scenario: file-scheme fallback is rejected
+- **WHEN** the configured safe fallback resolves to a non-HTTP(S) protocol such as `file://`
+- **THEN** guard recovery MUST NOT call `page.goto()` to that fallback URL
+
+### Requirement: about-blank transition immunity
+URL guard logic MUST ignore transient `about:` frame navigations to prevent self-triggering restore loops.
+
+#### Scenario: about:blank during normal navigation
+- **WHEN** Chromium emits `framenavigated` with `about:blank` as an intermediate step
+- **THEN** guard logic MUST return without initiating safe-url restoration
+
+### Requirement: Overlay continuity in headful desktop platforms
+On macOS and Windows headful custom flow, overlay controls MUST remain available through transient disallowed URLs.
+
+#### Scenario: Transient disallowed URL on macOS/Windows
+- **WHEN** current URL temporarily fails overlay-allowed checks but guard restoration is expected
+- **THEN** overlay removal MUST be skipped and overlay MUST be re-injected or preserved for user continuity
+
+#### Scenario: Linux/Docker headless overlay removal
+- **WHEN** `isOverlayAllowed` returns false on Linux/Docker headless mode
+- **THEN** overlay removal behavior is unchanged and overlay MAY be removed
+
+### Requirement: Defensive closed-page handling
+Custom-flow guard event handlers MUST tolerate unexpectedly closed pages and contexts.
+
+#### Scenario: Page closes during guard callback
+- **WHEN** a guard callback runs after page/context closure
+- **THEN** the callback MUST fail safely without unhandled exceptions or infinite recovery attempts
+
+### Requirement: Navigation wait strategy for domcontentloaded
+The preNavigationHooks MUST set `waitUntil: 'domcontentloaded'` via in-place mutation of gotoOptions, not reassignment.
+
+#### Scenario: gotoOptions mutation propagates to Crawlee
+- **WHEN** preNavigationHooks sets navigation wait strategy
+- **THEN** properties MUST be set by mutating the existing `gotoOptions` object and MUST NOT reassign the local parameter
+
+#### Scenario: Sites with persistent network activity do not hang
+- **WHEN** a site uses WebSockets, analytics polling, or lazy-load beacons
+- **THEN** navigation MUST complete at `domcontentloaded` without waiting for network to idle

--- a/openspec/changes/2026-06-30-oobee-improvements/specs/redirect-boundary-enforcement/spec.md
+++ b/openspec/changes/2026-06-30-oobee-improvements/specs/redirect-boundary-enforcement/spec.md
@@ -1,0 +1,48 @@
+## ADDED Requirements
+
+### Requirement: Canonical URL and hostname equivalence
+The scanner MUST normalize URLs for deduplication and MUST treat `www.` and non-`www.` hostnames as equivalent origins for scope decisions.
+
+#### Scenario: Trailing slash canonicalization
+- **WHEN** `https://example.com` and `https://example.com/` are evaluated
+- **THEN** they MUST be treated as the same page identity for deduplication and budget accounting
+
+#### Scenario: www/non-www host comparison
+- **WHEN** a link transitions between `www.example.com` and `example.com`
+- **THEN** hostname comparisons MUST consider them equivalent for in-scope decisions
+
+### Requirement: Redirect boundary enforcement
+The scanner MUST reject results that leave the queued hostname, including redirects that occur after initial navigation.
+
+#### Scenario: Pre-scan redirect out of scope
+- **WHEN** navigation resolves to a different hostname before scan execution
+- **THEN** that page result MUST be discarded as out-of-scope
+
+#### Scenario: Post-scan JavaScript redirect out of scope
+- **WHEN** the page hostname changes during or after scan operations
+- **THEN** the scanner MUST discard the result and MUST NOT count it as a successful in-scope scan
+
+### Requirement: Entry URL identity preservation in custom flow
+Custom-flow metadata MUST preserve the user-provided entry URL even if runtime navigation redirects elsewhere.
+
+#### Scenario: Redirected entry in custom flow
+- **WHEN** the first navigated page redirects
+- **THEN** report metadata MUST retain the original user input as the entry URL identity
+
+### Requirement: robots.txt disallow enforcement for dynamically discovered URLs
+URLs discovered through interactive clicks, popups, or frame navigations MUST be checked against robots.txt rules before enqueue.
+
+#### Scenario: Click-discovered URL blocked by robots.txt
+- **WHEN** a URL is found via popup or interactive click that bypasses `transformRequestFunction`
+- **THEN** the scanner MUST verify the URL against `isDisallowedInRobotsTxt` before enqueueing
+
+### Requirement: robots.txt path pattern correctness
+Bare disallow paths MUST generate both exact-path and children-glob patterns, and special characters MUST be escaped for pattern matching.
+
+#### Scenario: Path generates exact and children patterns
+- **WHEN** robots.txt contains `Disallow: /subscription/unsubscribe`
+- **THEN** the scanner MUST produce both the exact-path pattern AND `/subscription/unsubscribe/**` for matching
+
+#### Scenario: Query-string character escaping
+- **WHEN** a robots.txt disallow path contains `?`
+- **THEN** the `?` MUST be escaped before pattern matching since minimatch treats unescaped `?` as single-char wildcard

--- a/openspec/changes/2026-06-30-oobee-improvements/specs/report-artifact-resilience/spec.md
+++ b/openspec/changes/2026-06-30-oobee-improvements/specs/report-artifact-resilience/spec.md
@@ -1,0 +1,71 @@
+## ADDED Requirements
+
+### Requirement: Retry-safe failed-request accounting
+Scan error records MUST be emitted only after crawler retry exhaustion to avoid duplicates and false positives.
+
+#### Scenario: Intermediate request-handler exception
+- **WHEN** a request fails but still has remaining retries
+- **THEN** the scanner MUST NOT record it as a final failed URL entry yet
+
+#### Scenario: Retries exhausted
+- **WHEN** Crawlee invokes final failed-request handling after all retries
+- **THEN** the scanner MUST record the error exactly once in failed results
+
+### Requirement: Report-generation stability on Windows lock races
+Report generation MUST tolerate late Crawlee lock-file operations that can surface EPERM errors on Windows after crawl completion.
+
+#### Scenario: Late lock-file EPERM during artifact phase
+- **WHEN** scoped Windows EPERM lock race errors occur during report generation
+- **THEN** the process MUST suppress those known non-fatal exceptions and continue artifact generation
+
+### Requirement: Graceful dataset cleanup ordering
+Temporary Crawlee data MUST be removed in a cleanup sequence that preserves zip/report correctness.
+
+#### Scenario: Cleanup before zipping
+- **WHEN** artifact generation is finalizing outputs
+- **THEN** dataset and intermediate temporary stores MUST be cleaned before zipping, with awaited delays to allow pending I/O flushes
+
+#### Scenario: Dataset drop uses Crawlee API
+- **WHEN** the crawler dataset needs disposal
+- **THEN** `dataset.drop()` MUST be used for graceful storage cleanup instead of raw filesystem deletion
+
+### Requirement: Corruption-tolerant intermediate JSONL store
+Intermediate per-rule JSONL item storage MUST serialize writes and tolerate malformed historical lines during reads.
+
+#### Scenario: Concurrent append attempts
+- **WHEN** multiple issue writes target the same rule file
+- **THEN** appends MUST be serialized to prevent interleaved JSONL corruption
+
+#### Scenario: Malformed historical JSONL line
+- **WHEN** readback encounters invalid legacy lines
+- **THEN** reader logic MUST skip malformed entries and continue processing remaining valid records
+
+#### Scenario: Control character sanitization
+- **WHEN** website HTML inputs contain literal newline or carriage-return control characters
+- **THEN** the JSONL writer MUST sanitize these immediately after `JSON.stringify()` to prevent illegal implicit line boundaries
+
+### Requirement: Page lifecycle-safe metadata and rule verification
+Scan-time metadata capture and post-axe false-positive mitigation MUST account for dynamic page state changes.
+
+#### Scenario: Title capture before page instability
+- **WHEN** `runAxeScript()` starts on a live page
+- **THEN** `document.title` MUST be captured before operations that may close or navigate the page
+
+#### Scenario: aria-hidden-focus race revalidation
+- **WHEN** `aria-hidden-focus` findings may be affected by delayed `tabindex` updates
+- **THEN** the scanner MUST re-verify live DOM focusability after yielding to the event loop and filter false positives accordingly
+
+### Requirement: Browser profile isolation and cleanup
+Each scan MUST use a cloned browser profile to avoid cross-scan state pollution and MUST clean up after completion.
+
+#### Scenario: Profile cloning with unique token
+- **WHEN** a new scan starts
+- **THEN** browser profiles MUST be cloned with the scan's `randomToken` suffix into isolated directories
+
+#### Scenario: Pool re-launch profile uniqueness on Windows
+- **WHEN** Crawlee retires and re-launches browser instances during a scan
+- **THEN** each re-launch MUST use a unique `_pool{N}` directory to avoid Chrome exit code 21 from stale lock contention
+
+#### Scenario: Profile clone failure fallback
+- **WHEN** Chrome/Edge profile cloning fails (e.g., `EBUSY` on Windows)
+- **THEN** the scanner MUST fall back to an empty cloned profile directory rather than crashing

--- a/openspec/changes/2026-06-30-oobee-improvements/specs/sitemap-resilience/spec.md
+++ b/openspec/changes/2026-06-30-oobee-improvements/specs/sitemap-resilience/spec.md
@@ -1,0 +1,48 @@
+## ADDED Requirements
+
+### Requirement: Comprehensive sitemap discovery and recursion
+The scanner MUST discover sitemap sources from `robots.txt` directives and known sitemap paths, and MUST recursively process sitemap indexes.
+
+#### Scenario: Robots and probed sitemap paths are combined
+- **WHEN** intelligent sitemap crawl starts
+- **THEN** sitemap URLs from both `robots.txt` and known path probing MUST be included for discovery
+
+#### Scenario: Sitemap index recursion
+- **WHEN** a sitemap index contains child sitemap URLs
+- **THEN** each child sitemap MUST be fetched and parsed recursively until URL sets are resolved
+
+### Requirement: XSL-safe XML fetching strategy
+Sitemap fetching MUST use a strategy resilient to XML stylesheet and long-lived network resources.
+
+#### Scenario: Avoid networkidle deadlocks
+- **WHEN** fetching sitemap XML via browser automation
+- **THEN** navigation MUST wait for `domcontentloaded` (not `networkidle`) to avoid hangs/timeouts caused by stylesheet-linked resources
+
+#### Scenario: Preserve raw XML semantics
+- **WHEN** response text is available from sitemap fetch
+- **THEN** raw `response.text()` MUST be preferred over transformed DOM extraction to preserve `<sitemapindex>` and `<urlset>` structures
+
+### Requirement: Non-page sitemap feeds exclusion
+Image sitemap feeds and non-page sitemap entries MUST be excluded from crawl URL enqueueing.
+
+#### Scenario: Skip image sitemap feeds
+- **WHEN** sitemap content resolves to image-only feed structures
+- **THEN** those entries MUST be ignored for crawl queue construction
+
+### Requirement: Accurate sitemap discovery accounting
+Total discovered sitemap links MUST be tracked independently from scan success counts for reporting.
+
+#### Scenario: Report discovered links count
+- **WHEN** sitemap discovery completes
+- **THEN** the scanner MUST store total discovered count for `scanData.json` diagnostics, even if crawl success count is lower
+
+#### Scenario: Reset per scan
+- **WHEN** a new scan starts
+- **THEN** previous sitemap discovery counters MUST be reset to prevent cross-scan contamination
+
+### Requirement: User-agent for sitemap probing
+All sitemap discovery network contexts MUST use the patched non-headless user-agent to avoid WAF rejection.
+
+#### Scenario: Headless user-agent patching for sitemap probing
+- **WHEN** browser automation fetches robots.txt or sitemap XML in headless mode
+- **THEN** the context MUST send `OOBEE_USER_AGENT` (with `HeadlessChrome` replaced by `Chrome`) to prevent bot-blocking

--- a/openspec/changes/2026-06-30-oobee-improvements/tasks.md
+++ b/openspec/changes/2026-06-30-oobee-improvements/tasks.md
@@ -1,0 +1,17 @@
+## 1. Source Analysis and Requirement Extraction
+
+- [ ] 1.1 Map all crawler/report-relevant commits since `8cf8f9d937c1b4e320b81a35425ba5040b8c9fc5` to behavioral deltas.
+- [ ] 1.2 Reconcile extracted behaviors against `AGENTS.md` pitfalls/testing considerations to remove ambiguity.
+- [ ] 1.3 Group extracted behaviors into stable capability domains.
+
+## 2. OpenSpec Artifact Authoring
+
+- [ ] 2.1 Write `proposal.md` with clear motivation, impact, and capability contract.
+- [ ] 2.2 Author one `spec.md` per capability under `specs/` using ADDED requirements and executable scenarios.
+- [ ] 2.3 Document implementation rationale and source mapping in `design.md`.
+
+## 3. Quality Gates and Change Hygiene
+
+- [ ] 3.1 Validate OpenSpec artifacts (`openspec validate --strict`).
+- [ ] 3.2 Ensure requirement language is normative (SHALL/MUST) and scenario complete.
+- [ ] 3.3 Keep this change isolated on a dedicated branch and commit all OpenSpec artifacts together.


### PR DESCRIPTION
Initialize OpenSpec in the project and capture critical web-crawling and report-generation behaviors from commits since 8cf8f9d937c into formal normative specifications.

Change name: 2026-06-30-oobee-improvements

New capability specs:
- crawl-rate-control: budget enforcement, adaptive concurrency, circuit breaker
- sitemap-resilience: discovery, XSL-safe fetch, image exclusion, accounting
- auth-header-isolation: scoped auth, CORS safety, header rewrite minimization
- redirect-boundary-enforcement: URL normalization, hostname equivalence, robots.txt
- custom-flow-guard-overlay: loop prevention, overlay continuity, closed-page safety
- report-artifact-resilience: retry accounting, EPERM tolerance, JSONL integrity

This PR adds... <!-- A brief description of what your PR does -->

<!-- This checklist is just a guideline.-->
<!-- If any of the following does not apply to your PR, please leave them unchecked and explain in the PR -->

- [ ] I've kept this PR as small as possible (~500 lines) by splitting it into PRs with manageable chunks of code
- [ ] I've requested reviews from 1 reviewer
- [ ] I've tested existing features (website scan, sitemap, custom flow) in both node index and cli
- [ ] I've synced this fork with GovTechSG repo
- [ ] I've added/updated unit tests
- [ ] I've added/updated any necessary dependencies in `package[-lock].json` `npm audit`, portable installation on GitHub Actions
