### PR TITLE
improv: omit passed items from disk writes to reduce storage usage

### DIFF
--- a/src/combine.ts
+++ b/src/combine.ts
@@ -89,6 +89,13 @@ const combineRun = async (details: Data, deviceToScan: string) => {
       consoleLogger.info(`Suppressed Crawlee ps-tree locale error: ${err.message}`);
       return;
     }
+    // Suppress stale Playwright in-process connection errors that fire asynchronously
+    // after the browser is closed in writeSummaryPdf. The deferred IPC message arrives
+    // via setImmediate after the browser instance has already been disposed.
+    if (err.message?.includes('was not bound in the connection')) {
+      consoleLogger.info(`Suppressed Playwright post-close connection error: ${err.message}`);
+      return;
+    }
     throw err;
   };
   process.on('uncaughtException', psTreeHandler);

--- a/src/constants/common.ts
+++ b/src/constants/common.ts
@@ -1497,11 +1497,13 @@ export const getBrowserToRun = (
  * after checkingUrl and unable to utilise same cookie for scan
  * */
 export const getClonedProfilesWithRandomToken = (browser: string, randomToken: string): string => {
-  // In Docker, redirect browser temp files into the scan's user data directory to avoid /tmp ENOSPC
+  // In Docker, redirect browser temp files away from /tmp to avoid ENOSPC.
+  // Keep the path short — Chrome creates Unix sockets inside TMPDIR-based paths,
+  // and socket paths are limited to 107 bytes on Linux.
   if (fs.existsSync('/.dockerenv')) {
     const baseDir = getDefaultChromiumDataDir();
     if (baseDir) {
-      const scanTmpDir = path.join(baseDir, `oobee-${randomToken}`, 'tmp');
+      const scanTmpDir = path.join(baseDir, 'tmp');
       fs.mkdirSync(scanTmpDir, { recursive: true });
       process.env.TMPDIR = scanTmpDir;
     }

--- a/src/constants/common.ts
+++ b/src/constants/common.ts
@@ -1497,6 +1497,16 @@ export const getBrowserToRun = (
  * after checkingUrl and unable to utilise same cookie for scan
  * */
 export const getClonedProfilesWithRandomToken = (browser: string, randomToken: string): string => {
+  // In Docker, redirect browser temp files into the scan's user data directory to avoid /tmp ENOSPC
+  if (fs.existsSync('/.dockerenv')) {
+    const baseDir = getDefaultChromiumDataDir();
+    if (baseDir) {
+      const scanTmpDir = path.join(baseDir, `oobee-${randomToken}`, 'tmp');
+      fs.mkdirSync(scanTmpDir, { recursive: true });
+      process.env.TMPDIR = scanTmpDir;
+    }
+  }
+
   if (browser === BrowserTypes.CHROME) {
     return cloneChromeProfiles(randomToken);
   }

--- a/src/generateHtmlReport.ts
+++ b/src/generateHtmlReport.ts
@@ -126,6 +126,18 @@ export const generateHtmlReport = async (
     const scanData = JSON.parse(await fs.readFile(scanDataJsonPath, 'utf8'));
     const scanItemsAll = JSON.parse(await fs.readFile(scanItemsJsonPath, 'utf8'));
 
+    // Disk space: passed may be absent from scanItems.json (excluded to reduce disk usage).
+    // Provide an empty-category fallback so convertItemsToReferences does not crash.
+    // To revert (when passed is restored in scanItems.json), remove this block.
+    if (!scanItemsAll.passed) {
+      scanItemsAll.passed = {
+        description: itemTypeDescription.passed,
+        totalItems: 0,
+        totalRuleIssues: 0,
+        rules: [],
+      };
+    }
+
     // Build the lighter scanItems payload used by the HTML report.
     const lightScanItemsPayload = convertItemsToReferences({
       items: scanItemsAll,
@@ -141,7 +153,7 @@ export const generateHtmlReport = async (
       mustFix: ensureCategory(mustFix, 'mustFix'),
       goodToFix: ensureCategory(goodToFix, 'goodToFix'),
       needsReview: ensureCategory(needsReview, 'needsReview'),
-      passed: ensureCategory(scanItemsAll.passed || {}, 'passed'),
+      passed: ensureCategory(scanItemsAll.passed, 'passed'),
     };
 
     const pagesScanned = Array.isArray(scanData.pagesScanned) ? scanData.pagesScanned : [];

--- a/src/logs.ts
+++ b/src/logs.ts
@@ -39,6 +39,10 @@ export const errorsTxtPath = path.join(basePath, `${uuid}.txt`);
 
 const consoleLogger = createLogger({
   silent: !(process.env.RUNNING_FROM_PH_GUI || process.env.OOBEE_VERBOSE),
+  // exitOnError: false — Winston logs uncaught exceptions but does not call process.exit().
+  // Process lifecycle is controlled by psTreeHandler in combine.ts, which suppresses known
+  // benign errors (e.g. Playwright post-close connection errors) and rethrows real ones.
+  exitOnError: false,
   format: combine(timestamp({ format: 'YYYY-MM-DD HH:mm:ss' }), logFormat),
   transports: [
     new transports.Console({ level: 'info' }),
@@ -54,6 +58,8 @@ const consoleLogger = createLogger({
 // Also used in common functions to not link internal information
 // if running from mass scanner, log out errors in console
 const silentLogger = createLogger({
+  // exitOnError: false — see consoleLogger comment above.
+  exitOnError: false,
   format: combine(timestamp({ format: 'YYYY-MM-DD HH:mm:ss' }), logFormat),
   transports: [
     new transports.File({ 

--- a/src/mergeAxeResults.ts
+++ b/src/mergeAxeResults.ts
@@ -525,26 +525,40 @@ const pushResults = async (pageResults, allIssues, isCustomFlow, itemsStore: Ite
           metadata,
           itemsCount: items.length,
         };
-        await itemsStore.appendPageItems(category, rule, {
-          url,
-          pageTitle,
-          items,
-          pageIndex,
-          pageImagePath,
-          metadata,
-        });
+        // Disk space: skip storing passed items in itemsStore.
+        // To revert, remove the `if` guard and use the original call directly:
+        // await itemsStore.appendPageItems(category, rule, {
+        //   url, pageTitle, items, pageIndex, pageImagePath, metadata,
+        // });
+        if (category !== 'passed') {
+          await itemsStore.appendPageItems(category, rule, {
+            url,
+            pageTitle,
+            items,
+            pageIndex,
+            pageImagePath,
+            metadata,
+          });
+        }
       } else if (!(url in currRuleFromAllIssues.pagesAffected)) {
         currRuleFromAllIssues.pagesAffected[url] = {
           pageTitle,
           itemsCount: items.length,
           ...(filePath && { filePath }),
         };
-        await itemsStore.appendPageItems(category, rule, {
-          url,
-          pageTitle,
-          items,
-          ...(filePath && { filePath }),
-        });
+        // Disk space: skip storing passed items in itemsStore.
+        // To revert, remove the `if` guard and use the original call directly:
+        // await itemsStore.appendPageItems(category, rule, {
+        //   url, pageTitle, items, ...(filePath && { filePath }),
+        // });
+        if (category !== 'passed') {
+          await itemsStore.appendPageItems(category, rule, {
+            url,
+            pageTitle,
+            items,
+            ...(filePath && { filePath }),
+          });
+        }
       }
     }
   }
@@ -924,7 +938,9 @@ const generateArtifacts = async (
   populateScanPagesDetail(allIssues);
 
   // Build htmlGroups in a second pass from disk-backed items
-  for (const category of ['mustFix', 'goodToFix', 'needsReview', 'passed'] as const) {
+  // Disk space: 'passed' removed from this loop (no items stored in itemsStore for passed).
+  // To revert, restore: ['mustFix', 'goodToFix', 'needsReview', 'passed']
+  for (const category of ['mustFix', 'goodToFix', 'needsReview'] as const) {
     for (const rule of allIssues.items[category].rules) {
       for await (const entry of itemsStore.readRuleItems(category, rule.rule)) {
         buildHtmlGroups(rule, entry.items, entry.url);

--- a/src/mergeAxeResults.ts
+++ b/src/mergeAxeResults.ts
@@ -359,6 +359,11 @@ const writeSummaryPdf = async (
   browser: string,
   _userDataDirectory: string,
 ) => {
+  // Flush stale browser temp files before launching PDF browser
+  if (process.env.TMPDIR) {
+    fs.emptyDirSync(process.env.TMPDIR);
+  }
+
   const renderPdfWithBrowser = async (browserToUse: string) => {
     let browserInstance;
     let context;

--- a/src/mergeAxeResults/jsonArtifacts.ts
+++ b/src/mergeAxeResults/jsonArtifacts.ts
@@ -292,9 +292,14 @@ const writeJsonAndBase64Files = async (
   const { items, ...rest } = allIssues;
   const { jsonFilePath: scanDataJsonFilePath, base64FilePath: scanDataBase64FilePath } =
     await writeJsonFileAndCompressedJsonFile(rest, storagePath, 'scanData');
+  // Disk space: passed items excluded from scanItems.json to reduce disk usage.
+  // Passed counts are still in scanData.json and the embedded report payload (scanItems-light).
+  // To revert, remove the destructure line and restore the original argument:
+  // { oobeeAppVersion: allIssues.oobeeAppVersion, ...items }
+  const { passed: _passedItems, ...itemsWithoutPassed } = items;
   const { jsonFilePath: scanItemsJsonFilePath, base64FilePath: scanItemsBase64FilePath } =
     await writeJsonFileAndCompressedJsonFile(
-      { oobeeAppVersion: allIssues.oobeeAppVersion, ...items },
+      { oobeeAppVersion: allIssues.oobeeAppVersion, ...itemsWithoutPassed },
       storagePath,
       'scanItems',
       itemsStore,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -388,6 +388,12 @@ export const cleanUp = async (randomToken?: string, isError: boolean = false): P
     consoleLogger.warn(`Unable to force remove userDataDirectory: ${error.message}`);
   }
 
+  if (process.env.TMPDIR) try {
+    fs.rmSync(process.env.TMPDIR, { recursive: true, force: true });
+  } catch (error) {
+    consoleLogger.warn(`Unable to force remove browser tmp dir: ${error.message}`);
+  }
+
   if (randomToken !== undefined) {
     const storagePath = getStoragePath(randomToken);
 


### PR DESCRIPTION
### Problem

On large scans, the Docker container running Oobee failed with two separate errors that compound each other:

**Error 1 — Disk exhaustion when writing `scanItems.json`:**
```
Error: ENOSPC: no space left on device, write
```
The `passed` category (elements that passed accessibility checks) dominates the size of `scanItems.json` on large sites — axe-core records hundreds of passing elements per page across potentially thousands of pages.

**Error 2 — Playwright post-close crash in `writeSummaryPdf`:**
```
Error: Object with guid response@... was not bound in the connection
```
After `writeSummaryPdf` closes the headless browser, deferred `setImmediate` callbacks from Playwright's in-process IPC factory fire attempting to dispatch to an already-disposed `Response` object. This arrives as an `uncaughtException`. Additionally, Winston's `handleExceptions: true` transport registers its own `uncaughtException` listener that fires *before* `psTreeHandler` and calls `process.exit(1)` by default — so the `psTreeHandler` suppression never had a chance to run.

**Error 3 — `/tmp` ENOSPC preventing `summary.pdf` generation:**
```
browserType.launchPersistentContext: ENOSPC: no space left on device, mkdtemp '/tmp/playwright-artifacts-...'
```
Chrome's `--disable-dev-shm-usage` flag (required in Docker where `/dev/shm` is only 64MB) redirects shared memory writes to `/tmp`. During the crawl phase, Chrome fills `/tmp` with SHM segments and temp files. When `writeSummaryPdf` later tries to launch a second browser for PDF rendering, Playwright cannot create its artifacts directory in `/tmp`.

**Why Error 3 was hidden before:** smaller scans don't accumulate enough temp data to exhaust `/tmp`, or large scans previously died at Error 1 before reaching `writeSummaryPdf`. Once Error 1 is fixed, Error 3 is exposed on large scans.

---

### Changes

#### `src/mergeAxeResults.ts`

- **`pushResults`**: Added `if (category !== 'passed')` guards around both `itemsStore.appendPageItems` call sites (custom flow and standard flow). Passed item counts and `pagesAffected` metadata are still tracked **in memory**; only the intermediate JSONL temp files on disk are skipped.
- **`buildHtmlGroups` loop**: Removed `'passed'` from the category array. No `passed` items are stored in `itemsStore` anymore, and `convertItemsToReferences` already excludes `htmlGroups` for `passed` — so iterating over it was a no-op.
- **`writeSummaryPdf`**: Flushes `TMPDIR` before launching the PDF browser, reclaiming space consumed by the crawl phase's temp files.

#### `src/mergeAxeResults/jsonArtifacts.ts`

- **`writeJsonAndBase64Files`**: Destructures `passed` out of `items` before building the `scanItems` write payload, so `scanItems.json` and its compressed `scanItems.json.gz.b64` no longer contain `passed` item details.

#### `src/generateHtmlReport.ts`

- Added a defensive fallback: if `scanItems.json` does not contain a `passed` key (files produced after this change), inject an empty-category object before calling `convertItemsToReferences` to prevent a crash when regenerating reports from existing JSON files.

#### `src/constants/common.ts`

- **`getClonedProfilesWithRandomToken`**: In Docker, sets `process.env.TMPDIR` to `<cwd>/Chromium Support/tmp`. This redirects all Chrome and Playwright temp file creation away from `/tmp` into the app's own writable directory. The path is kept short (e.g. `/app/oobee/Chromium Support/tmp/...`) to stay within Linux's 107-byte Unix socket path limit — longer paths (such as including the full `randomToken`) cause Chrome to crash with `SIGTRAP` when it tries to create IPC sockets.

#### `src/combine.ts`

- Extended `psTreeHandler` to suppress Playwright's `was not bound in the connection` `uncaughtException`. This error is a benign post-cleanup artefact — the browser was already closed and the scan output is complete.

#### `src/logs.ts`

- Set `exitOnError: false` on both `consoleLogger` and `silentLogger`. Winston's `handleExceptions: true` transport registers its own `uncaughtException` listener that previously fired before `psTreeHandler` and called `process.exit(1)`, preventing the suppression from ever running. With `exitOnError: false`, Winston logs the exception and returns, allowing `psTreeHandler` to decide whether to continue (benign errors) or rethrow (real errors that should terminate the process).

#### `src/utils.ts`

- **`cleanUp`**: Removes the `TMPDIR` directory (`Chromium Support/tmp`) on exit.

---

### What is preserved

| Data | Still available? |
|---|---|
| Passed item **count** (`totalItems`) | ✅ In memory + `scanData.json` via `allIssues.totalItems` |
| Passed rule names & counts | ✅ `scanIssuesSummary.json` |
| Passed rule/count metadata in HTML report | ✅ Embedded `scanItems-light` payload (built from in-memory `allIssues.items.passed`) |
| Per-page passed item details on disk | ❌ Removed (was the source of disk exhaustion) |

---

### Reverting

All changed lines in the disk-space optimization are annotated with `// Disk space:` and `// To revert:` comments in-code. To restore the original behaviour:

1. **`mergeAxeResults.ts` — `pushResults`**: Remove the two `if (category !== 'passed')` guards; the original unconditional `appendPageItems` calls are shown in the adjacent comments.
2. **`mergeAxeResults.ts` — `buildHtmlGroups` loop**: Restore `'passed'` to the category array: `['mustFix', 'goodToFix', 'needsReview', 'passed']`.
3. **`jsonArtifacts.ts`**: Remove the `const { passed: _passedItems, ...itemsWithoutPassed } = items;` line and restore the original argument: `{ oobeeAppVersion: allIssues.oobeeAppVersion, ...items }`.
4. **`generateHtmlReport.ts`**: Remove the `if (!scanItemsAll.passed) { ... }` fallback block.
5. **`combine.ts`**: Remove the `if (err.message?.includes('was not bound in the connection'))` suppression block from `psTreeHandler`.
6. **`logs.ts`**: Remove `exitOnError: false` from both logger configurations. **Note:** this must be reverted together with step 5 — `exitOnError: false` exists solely to prevent Winston from calling `process.exit(1)` before `psTreeHandler` can suppress the Playwright error. Removing it without also removing the step 5 suppression would cause Winston to exit the process before `psTreeHandler` runs again.
7. **`common.ts` — `getClonedProfilesWithRandomToken`**: Remove the `if (fs.existsSync('/.dockerenv'))` block that sets `TMPDIR`.
8. **`mergeAxeResults.ts` — `writeSummaryPdf`**: Remove the `if (process.env.TMPDIR) { fs.emptyDirSync(...) }` block.
9. **`utils.ts` — `cleanUp`**: Remove the `if (process.env.TMPDIR)` removal block.
