### PR TITLE
fix: restrict TMPDIR cleanup to Docker and isolate per scan instance

### DIFF
--- a/src/constants/common.ts
+++ b/src/constants/common.ts
@@ -1500,10 +1500,11 @@ export const getClonedProfilesWithRandomToken = (browser: string, randomToken: s
   // In Docker, redirect browser temp files away from /tmp to avoid ENOSPC.
   // Keep the path short — Chrome creates Unix sockets inside TMPDIR-based paths,
   // and socket paths are limited to 107 bytes on Linux.
+  // Use process.pid to isolate concurrent scan instances.
   if (fs.existsSync('/.dockerenv')) {
     const baseDir = getDefaultChromiumDataDir();
     if (baseDir) {
-      const scanTmpDir = path.join(baseDir, 'tmp');
+      const scanTmpDir = path.join(baseDir, 'tmp', String(process.pid));
       fs.mkdirSync(scanTmpDir, { recursive: true });
       process.env.TMPDIR = scanTmpDir;
     }

--- a/src/mergeAxeResults.ts
+++ b/src/mergeAxeResults.ts
@@ -359,9 +359,14 @@ const writeSummaryPdf = async (
   browser: string,
   _userDataDirectory: string,
 ) => {
-  // Flush stale browser temp files before launching PDF browser
-  if (process.env.TMPDIR) {
-    fs.emptyDirSync(process.env.TMPDIR);
+  // Flush stale browser temp files before launching PDF browser (Docker only,
+  // where TMPDIR is a per-scan subdirectory we control).
+  if (process.env.TMPDIR && fs.existsSync('/.dockerenv')) {
+    try {
+      fs.emptyDirSync(process.env.TMPDIR);
+    } catch {
+      // Best-effort; locked files from prior browser sessions are non-fatal.
+    }
   }
 
   const renderPdfWithBrowser = async (browserToUse: string) => {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -388,7 +388,7 @@ export const cleanUp = async (randomToken?: string, isError: boolean = false): P
     consoleLogger.warn(`Unable to force remove userDataDirectory: ${error.message}`);
   }
 
-  if (process.env.TMPDIR) try {
+  if (process.env.TMPDIR && fs.existsSync('/.dockerenv')) try {
     fs.rmSync(process.env.TMPDIR, { recursive: true, force: true });
   } catch (error) {
     consoleLogger.warn(`Unable to force remove browser tmp dir: ${error.message}`);


### PR DESCRIPTION
## Summary

- Fix crash on macOS/Windows where `fs.emptyDirSync(process.env.TMPDIR)` in `writeSummaryPdf` deleted the **system** temp directory, causing "Maximum number of attempts reached" when locked files from other processes threw an unhandled exception
- Restrict TMPDIR cleanup (`emptyDirSync` before PDF generation, `rmSync` at scan teardown) to Docker only, where TMPDIR is a controlled subdirectory
- Wrap the Docker `emptyDirSync` in try/catch so locked temp files from zombie browser processes don't crash the scan
- Isolate concurrent scans in Docker by appending `process.pid` to the TMPDIR path (`<baseDir>/tmp/<pid>`), preventing parallel scans from nuking each other's browser temp files

## Root cause

`writeSummaryPdf` called `fs.emptyDirSync(process.env.TMPDIR)` unconditionally. On macOS, TMPDIR points to a shared system directory (e.g. `/var/folders/.../T/`) used by all running processes. If any file there was locked, the call threw, and because it sat outside any try/catch within `writeSummaryPdf`, the error propagated through `retryFunction(..., 1)` which swallowed the real message and threw the generic "Maximum number of attempts reached".

## Test plan

- [ ] Run CLI scan on macOS — confirm PDF report generates without crash
- [ ] Run CLI scan in Docker — confirm TMPDIR is created at `<baseDir>/tmp/<pid>` and cleaned up after scan
- [ ] Run two concurrent scans in Docker — confirm they don't interfere with each other's temp files
