### PR TITLE
Fix/cleanup browser pool directories

### DIFF
--- a/src/crawlers/commonCrawlerFunc.ts
+++ b/src/crawlers/commonCrawlerFunc.ts
@@ -1233,6 +1233,13 @@ export const getPreLaunchHook = (userDataDirectory: string) => {
     // For pool re-launches, best-effort clone profile data from base directory
     // so authenticated sessions are preserved across browser pool retirements.
     if (launchCount > 1) {
+      const skipDirs = new Set([
+        'Singleton', 'lockfile', 'LOCK',
+        'Cache', 'Code Cache', 'GPUCache', 'DawnGraphiteCache', 'DawnWebGPUCache',
+        'Service Worker', 'ScriptCache', 'ShaderCache', 'GrShaderCache',
+        'component_crx_cache', 'optimization_guide_model_store',
+        'BrowserMetrics', 'Crashpad', 'FileTypePolicies',
+      ]);
       try {
         const copyRecursive = async (src: string, dest: string) => {
           const stat = await fsp.stat(src).catch(() => null);
@@ -1242,7 +1249,7 @@ export const getPreLaunchHook = (userDataDirectory: string) => {
             const entries = await fsp.readdir(src).catch(() => []);
             await Promise.all(
               entries
-                .filter(entry => !entry.startsWith('Singleton') && entry !== 'lockfile' && entry !== 'LOCK')
+                .filter(entry => !entry.startsWith('Singleton') && !skipDirs.has(entry))
                 .map(entry =>
                   copyRecursive(path.join(src, entry), path.join(dest, entry)).catch(() => {}),
                 ),

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,6 +2,7 @@ import { execSync, spawnSync } from 'child_process';
 import path from 'path';
 import os from 'os';
 import fs from 'fs-extra';
+import { globSync } from 'glob';
 import axe, { Rule } from 'axe-core';
 import { v4 as uuidv4 } from 'uuid';
 import { getDomain } from 'tldts';
@@ -382,10 +383,22 @@ export const cleanUp = async (randomToken?: string, isError: boolean = false): P
     randomToken = constants.randomToken;
   }
 
-  if (constants.userDataDirectory) try {
-    fs.rmSync(constants.userDataDirectory, { recursive: true, force: true });
-  } catch (error) {
-    consoleLogger.warn(`Unable to force remove userDataDirectory: ${error.message}`);
+  if (constants.userDataDirectory) {
+    try {
+      fs.rmSync(constants.userDataDirectory, { recursive: true, force: true });
+    } catch (error) {
+      consoleLogger.warn(`Unable to force remove userDataDirectory: ${error.message}`);
+    }
+
+    // Also remove _pool* sibling directories created by browser pool re-launches
+    const poolDirs = globSync(`${constants.userDataDirectory}_pool*`);
+    for (const dir of poolDirs) {
+      try {
+        fs.rmSync(dir, { recursive: true, force: true });
+      } catch (error) {
+        consoleLogger.warn(`Unable to force remove pool directory ${dir}: ${error.message}`);
+      }
+    }
   }
 
   if (process.env.TMPDIR && fs.existsSync('/.dockerenv')) try {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -391,13 +391,13 @@ export const cleanUp = async (randomToken?: string, isError: boolean = false): P
     }
 
     // Also remove _pool* sibling directories created by browser pool re-launches
-    const poolDirs = globSync(`${constants.userDataDirectory}_pool*`);
-    for (const dir of poolDirs) {
-      try {
+    try {
+      const poolDirs = globSync(`${constants.userDataDirectory}_pool*`);
+      for (const dir of poolDirs) {
         fs.rmSync(dir, { recursive: true, force: true });
-      } catch (error) {
-        consoleLogger.warn(`Unable to force remove pool directory ${dir}: ${error.message}`);
       }
+    } catch (error) {
+      consoleLogger.warn(`Unable to remove pool directories: ${error.message}`);
     }
   }
 


### PR DESCRIPTION
## fix: clean up browser pool directories and reduce their disk footprint

### Problem

During large scans (e.g. 5000 pages), the browser pool creates hundreds of sibling directories (`oobee-{token}_pool2`, `_pool3`, ...) under the Chrome User Data folder. Each pool directory is a full copy of the Chrome profile, consuming gigabytes of disk space.

Two issues caused these to accumulate permanently:

1. **Pool directories never cleaned up** — `cleanUp()` only deleted `constants.userDataDirectory` (the base `oobee-{token}` dir), but pool directories are siblings (`_pool*`), not children, so they were left behind.
2. **Full profile copied into each pool** — Every pool re-launch copied the entire base profile including `Cache`, `Code Cache`, `GPUCache`, `Service Worker`, etc. — directories that are large and unnecessary for preserving authentication.

### Changes

- **Add glob-based pool directory cleanup** (`src/utils.ts`) — After deleting the base user data directory, also match and delete all `{userDataDirectory}_pool*` siblings. Wrapped in a best-effort try/catch so failures don't interrupt remaining cleanup.
- **Skip large cache directories in pool profile cloning** (`src/crawlers/commonCrawlerFunc.ts`) — Filter out `Cache`, `Code Cache`, `GPUCache`, `DawnGraphiteCache`, `DawnWebGPUCache`, `Service Worker`, `ScriptCache`, `ShaderCache`, `GrShaderCache`, `component_crx_cache`, `optimization_guide_model_store`, `BrowserMetrics`, `Crashpad`, and `FileTypePolicies` when copying profiles to pool instances. Only auth/cookie files are preserved.

### Companion PR

- **oobee-desktop**: [fix/cleanup-browser-pool-directories](https://github.com/GovTechSG/oobee-desktop/pull/new/fix/cleanup-browser-pool-directories) — Changes `SIGKILL` to `SIGTERM` (with 5s fallback) when aborting scans, so the engine's cleanup handlers actually run.

### Test plan

- [ ] Run a 5000-page scan and verify pool directories are deleted after completion
- [ ] Abort a scan mid-way and verify cleanup still runs (SIGTERM path)
- [ ] Verify authenticated scans still work (cookies preserved across pool re-launches)
- [ ] Confirm no errors logged when pool directories don't exist (best-effort path)
