### PR TITLE
improv: false positive in oobee-accessible-label for non-perceivable empty elements

### DIFF
--- a/src/crawlers/custom/flagUnlabelledClickableElements.ts
+++ b/src/crawlers/custom/flagUnlabelledClickableElements.ts
@@ -457,8 +457,14 @@ function hasPointerCursor(node: Node): boolean {
   function isElementTooSmall(element: Element) {
     // Get the bounding rectangle of the element
     const rect = element.getBoundingClientRect();
-    
-    // Check if the element has a valid width or height
+
+    // If either dimension is 0 and the element has no children or text, it's non-perceivable
+    if ((rect.width === 0 || rect.height === 0) &&
+        element.children.length === 0 && getTextContent(element).trim().length === 0) {
+        return true;
+    }
+
+    // Check if the element has a valid width and height
     if (rect.width > 0 || rect.height > 0) {
         return false; // Element is not too small
     }

--- a/src/crawlers/custom/flagUnlabelledClickableElements.ts
+++ b/src/crawlers/custom/flagUnlabelledClickableElements.ts
@@ -458,9 +458,8 @@ function hasPointerCursor(node: Node): boolean {
     // Get the bounding rectangle of the element
     const rect = element.getBoundingClientRect();
 
-    // If either dimension is 0 and the element has no children or text, it's non-perceivable
-    if ((rect.width === 0 || rect.height === 0) &&
-        element.children.length === 0 && getTextContent(element).trim().length === 0) {
+    // If either dimension is 0, the element is non-perceivable
+    if (rect.width === 0 || rect.height === 0) {
         return true;
     }
 


### PR DESCRIPTION
### Root Cause

`isElementTooSmall` used OR logic (`width > 0 || height > 0`) to determine if an element is perceivable. This meant an element was only considered "too small" if **both** dimensions were 0. Elements with 0 width but non-zero height (e.g. 0×19, from inherited `line-height`) passed the size filter and flowed into the rule's flagging logic.

In the reported case, a CMS-generated `<a style="color: rgb(70,120,134);"></a>` had:
- 0 width (no content, no padding)
- 19px height (inherited line-height)
- `cursor: pointer` from a site-wide `a { cursor: pointer }` CSS rule

This combination caused it to pass both the size check and the clickability check, ultimately being flagged as a link without an accessible label — despite being a non-functional, invisible element.

### Fix

Add an early return in `isElementTooSmall`: if **either** dimension is 0, treat it as non-perceivable. An element with 0 width or 0 height cannot be seen or interacted with — any visible children would be evaluated independently by the rule.

### Test plan

- [ ] Scan a page containing `<a style="color: rgb(70,120,134);"></a>` (0×19) — verify it is no longer flagged
- [ ] Scan a page with `<a href="..."></a>` (empty link with href, non-zero dimensions) — verify it is still flagged
- [ ] Scan a page with `<a href="..."><img></a>` (image link without alt) — verify still flagged
- [ ] Scan a page with `<span></span>` that has 0 width from line-height — verify not flagged
- [ ] Scan a page with interactive elements (`<button>`, `<input>`) — verify no regressions
