### PR TITLE
feat: Page DOM and Screenshot Capture for UA Testing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -144,7 +144,7 @@ The `constants` default export object holds runtime state:
 | `OOBEE_SCAN_PRODUCT` | Adds `scanProduct` tag to Sentry events |
 | `OOBEE_CONSECUTIVE_MAX_RETRIES` | Max consecutive HTTP failures before circuit breaker aborts crawl (default 100) |
 | `OOBEE_VALIDATE_URL` | If set, exit after URL validation without scanning |
-| `OOBEE_SAVE_DOM` | `1` or `true` = save full-page DOM HTML to `pageDOMs/` in results directory. Supported scan types: Website, Sitemap, Intelligent, LocalFile, Custom |
+| `OOBEE_SAVE_DOM` | `1` or `true` = save full-page DOM HTML for desktop and mobile viewports to `pageDOMs/desktopPageDOMs/` and `pageDOMs/mobilePageDOMs/` in results directory. Mobile viewport uses iPhone 11 width programmatically. Supported scan types: Website, Sitemap, Intelligent, LocalFile, Custom |
 | `OOBEE_SAVE_PAGE_SCREENSHOT` | `1` or `true` = save full-page desktop + mobile viewport screenshots to `pageDOMs/desktopPageScreenshots/` and `pageDOMs/mobilePageScreenshots/`. Mobile viewport uses iPhone 11 width programmatically. Supported scan types: Website, Sitemap, Intelligent, LocalFile, Custom |
 | `GOOGLE_SAFE_BROWSING` | `1` = enable Google Safe Browsing (requires Chrome, not Chromium) |
 | `HTTP_PROXY` / `HTTPS_PROXY` / `ALL_PROXY` | Proxy configuration |
@@ -419,8 +419,11 @@ When making changes, validate these areas which have well-established edge cases
 ├── sitemap.xml             # Discovered URLs
 ├── screenshots/            # Violation screenshots (if enabled)
 └── pageDOMs/              # Page capture (if OOBEE_SAVE_DOM or OOBEE_SAVE_PAGE_SCREENSHOT)
-    ├── {hash}-{truncated_path}.html          # Full DOM (OOBEE_SAVE_DOM)
     ├── domManifest.json                     # Maps URLs → hash, file paths, errors
+    ├── desktopPageDOMs/                    # Desktop viewport DOM HTML (OOBEE_SAVE_DOM)
+    │   └── {hash}-{truncated_path}.html
+    ├── mobilePageDOMs/                     # Mobile viewport DOM HTML (OOBEE_SAVE_DOM)
+    │   └── {hash}-{truncated_path}.html
     ├── desktopPageScreenshots/             # Desktop viewport PNGs (OOBEE_SAVE_PAGE_SCREENSHOT)
     │   └── {hash}-{truncated_path}.png
     └── mobilePageScreenshots/              # Mobile viewport PNGs (OOBEE_SAVE_PAGE_SCREENSHOT)

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ verapdf --version
 | OOBEE_SCAN_METADATA | Overrides the `entryUrl` tag sent to telemetry. | |
 | OOBEE_SCAN_PRODUCT | Adds a `scanProduct` tag to telemetry events. | |
 | OOBEE_CONSECUTIVE_MAX_RETRIES | Max consecutive HTTP failures before the circuit breaker aborts the crawl. | `100` |
-| OOBEE_SAVE_DOM | Set to `1` or `true` to save full-page DOM HTML for each scanned page to the results directory. Works with all scan types (Website, Sitemap, Intelligent, LocalFile, Custom). | |
+| OOBEE_SAVE_DOM | Set to `1` or `true` to save full-page DOM HTML for each scanned page in both desktop and mobile viewports to the results directory. Mobile viewport width is determined from iPhone 11 device profile. Works with all scan types (Website, Sitemap, Intelligent, LocalFile, Custom). | |
 | OOBEE_SAVE_PAGE_SCREENSHOT | Set to `1` or `true` to save full-page desktop and mobile viewport screenshots for each scanned page. Mobile viewport width is determined from iPhone 11 device profile. Works with all scan types (Website, Sitemap, Intelligent, LocalFile, Custom). | |
 | HTTP_PROXY | URL of the proxy server to be used for HTTP requests (e.g. `http://proxy.example.com:8080`). | |
 | HTTPS_PROXY | URL of the proxy server to be used for HTTPS requests (e.g. `https://proxy.example.com:8080`). | |

--- a/src/combine.ts
+++ b/src/combine.ts
@@ -290,8 +290,11 @@ const combineRun = async (details: Data, deviceToScan: string) => {
   if (scanDetails.urlsCrawled) {
     if (scanDetails.urlsCrawled.scanned.length > 0) {
       await createAndUpdateResultsFolders(randomToken);
-      await writeManifest(randomToken);
-      resetCaptureEntries();
+      try {
+        await writeManifest(randomToken);
+      } finally {
+        resetCaptureEntries();
+      }
       const pagesNotScanned = [
         ...urlsCrawledObj.error,
         ...urlsCrawledObj.invalid,

--- a/src/crawlers/pageCapture.ts
+++ b/src/crawlers/pageCapture.ts
@@ -10,7 +10,8 @@ const MOBILE_VIEWPORT_HEIGHT = devices['iPhone 11'].viewport.height;
 export interface PageCaptureEntry {
   url: string;
   hash: string;
-  domFile?: string;
+  desktopDom?: string;
+  mobileDom?: string;
   desktopScreenshot?: string;
   mobileScreenshot?: string;
   errors: string[];
@@ -84,6 +85,11 @@ export async function capturePageData(
   const fileName = `${hash}-${truncatedPath}`;
   const pageDomsDir = getPageDomsDir(randomToken);
 
+  const desktopDomDir = path.join(pageDomsDir, 'desktopPageDOMs');
+  const mobileDomDir = path.join(pageDomsDir, 'mobilePageDOMs');
+  const desktopScreenshotDir = path.join(pageDomsDir, 'desktopPageScreenshots');
+  const mobileScreenshotDir = path.join(pageDomsDir, 'mobilePageScreenshots');
+
   const entry: PageCaptureEntry = {
     url,
     hash,
@@ -92,57 +98,77 @@ export async function capturePageData(
 
   if (isSaveDomEnabled()) {
     try {
-      await fs.ensureDir(pageDomsDir);
+      await fs.ensureDir(desktopDomDir);
       const domContent = await page.content();
-      const domFilePath = await getUniqueFilePath(pageDomsDir, fileName, '.html');
+      const domFilePath = await getUniqueFilePath(desktopDomDir, fileName, '.html');
       await fs.writeFile(domFilePath, domContent, 'utf-8');
-      entry.domFile = `pageDOMs/${getRelativeName(domFilePath, pageDomsDir)}`;
+      entry.desktopDom = `pageDOMs/desktopPageDOMs/${getRelativeName(domFilePath, desktopDomDir)}`;
     } catch (err) {
-      entry.errors.push(`DOM save failed: ${err instanceof Error ? err.message : String(err)}`);
+      entry.errors.push(
+        `Desktop DOM save failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
     }
   }
 
   if (isSavePageScreenshotEnabled()) {
-    const desktopDir = path.join(pageDomsDir, 'desktopPageScreenshots');
-    const mobileDir = path.join(pageDomsDir, 'mobilePageScreenshots');
-
     try {
-      await fs.ensureDir(desktopDir);
-      const desktopPath = await getUniqueFilePath(desktopDir, fileName, '.png');
+      await fs.ensureDir(desktopScreenshotDir);
+      const desktopPath = await getUniqueFilePath(desktopScreenshotDir, fileName, '.png');
       await page.screenshot({ path: desktopPath, fullPage: true });
-      entry.desktopScreenshot = `pageDOMs/desktopPageScreenshots/${getRelativeName(desktopPath, desktopDir)}`;
+      entry.desktopScreenshot = `pageDOMs/desktopPageScreenshots/${getRelativeName(desktopPath, desktopScreenshotDir)}`;
     } catch (err) {
       entry.errors.push(
         `Desktop screenshot failed: ${err instanceof Error ? err.message : String(err)}`,
       );
     }
+  }
 
-    const currentViewport = page.viewportSize();
-    try {
-      await fs.ensureDir(mobileDir);
+  const currentViewport = page.viewportSize();
+  try {
+    await page.setViewportSize({
+      width: MOBILE_VIEWPORT_WIDTH,
+      height: MOBILE_VIEWPORT_HEIGHT,
+    });
+    await page.waitForTimeout(500);
 
-      await page.setViewportSize({
-        width: MOBILE_VIEWPORT_WIDTH,
-        height: MOBILE_VIEWPORT_HEIGHT,
-      });
-      await page.waitForTimeout(500);
+    if (isSaveDomEnabled()) {
+      try {
+        await fs.ensureDir(mobileDomDir);
+        const domContent = await page.content();
+        const domFilePath = await getUniqueFilePath(mobileDomDir, fileName, '.html');
+        await fs.writeFile(domFilePath, domContent, 'utf-8');
+        entry.mobileDom = `pageDOMs/mobilePageDOMs/${getRelativeName(domFilePath, mobileDomDir)}`;
+      } catch (err) {
+        entry.errors.push(
+          `Mobile DOM save failed: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+    }
 
-      const mobilePath = await getUniqueFilePath(mobileDir, fileName, '.png');
-      await page.screenshot({ path: mobilePath, fullPage: true });
-      entry.mobileScreenshot = `pageDOMs/mobilePageScreenshots/${getRelativeName(mobilePath, mobileDir)}`;
-    } catch (err) {
-      entry.errors.push(
-        `Mobile screenshot failed: ${err instanceof Error ? err.message : String(err)}`,
-      );
-    } finally {
-      if (currentViewport) {
-        try {
-          await page.setViewportSize(currentViewport);
-        } catch (err) {
-          entry.errors.push(
-            `Viewport restore failed: ${err instanceof Error ? err.message : String(err)}`,
-          );
-        }
+    if (isSavePageScreenshotEnabled()) {
+      try {
+        await fs.ensureDir(mobileScreenshotDir);
+        const mobilePath = await getUniqueFilePath(mobileScreenshotDir, fileName, '.png');
+        await page.screenshot({ path: mobilePath, fullPage: true });
+        entry.mobileScreenshot = `pageDOMs/mobilePageScreenshots/${getRelativeName(mobilePath, mobileScreenshotDir)}`;
+      } catch (err) {
+        entry.errors.push(
+          `Mobile screenshot failed: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+    }
+  } catch (err) {
+    entry.errors.push(
+      `Mobile viewport switch failed: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  } finally {
+    if (currentViewport) {
+      try {
+        await page.setViewportSize(currentViewport);
+      } catch (err) {
+        entry.errors.push(
+          `Viewport restore failed: ${err instanceof Error ? err.message : String(err)}`,
+        );
       }
     }
   }
@@ -162,7 +188,8 @@ export async function writeManifest(randomToken: string): Promise<void> {
     pages: Array.from(captureEntries.values()).map(entry => ({
       url: entry.url,
       hash: entry.hash,
-      ...(entry.domFile && { domFile: entry.domFile }),
+      ...(entry.desktopDom && { desktopDom: entry.desktopDom }),
+      ...(entry.mobileDom && { mobileDom: entry.mobileDom }),
       ...(entry.desktopScreenshot && { desktopScreenshot: entry.desktopScreenshot }),
       ...(entry.mobileScreenshot && { mobileScreenshot: entry.mobileScreenshot }),
       errors: entry.errors,

--- a/src/crawlers/pageCapture.ts
+++ b/src/crawlers/pageCapture.ts
@@ -117,9 +117,9 @@ export async function capturePageData(
       );
     }
 
+    const currentViewport = page.viewportSize();
     try {
       await fs.ensureDir(mobileDir);
-      const currentViewport = page.viewportSize();
 
       await page.setViewportSize({
         width: MOBILE_VIEWPORT_WIDTH,
@@ -130,14 +130,20 @@ export async function capturePageData(
       const mobilePath = await getUniqueFilePath(mobileDir, fileName, '.png');
       await page.screenshot({ path: mobilePath, fullPage: true });
       entry.mobileScreenshot = `pageDOMs/mobilePageScreenshots/${getRelativeName(mobilePath, mobileDir)}`;
-
-      if (currentViewport) {
-        await page.setViewportSize(currentViewport);
-      }
     } catch (err) {
       entry.errors.push(
         `Mobile screenshot failed: ${err instanceof Error ? err.message : String(err)}`,
       );
+    } finally {
+      if (currentViewport) {
+        try {
+          await page.setViewportSize(currentViewport);
+        } catch (err) {
+          entry.errors.push(
+            `Viewport restore failed: ${err instanceof Error ? err.message : String(err)}`,
+          );
+        }
+      }
     }
   }
 


### PR DESCRIPTION
## feat: Page DOM and Screenshot Capture for UA Testing

### Summary

- Adds `OOBEE_SAVE_DOM` env var to save the full-page DOM HTML for each scanned page in both desktop and mobile viewports
- Adds `OOBEE_SAVE_PAGE_SCREENSHOT` env var to save full-page desktop and mobile viewport screenshots for each scanned page
- Generates a `domManifest.json` mapping each page URL to its hash, saved file paths, and any errors encountered during capture
- Supported across **all scan types**: Website, Sitemap, Intelligent, LocalFile, and Custom

### How it works

| Env Variable | Effect |
|---|---|
| `OOBEE_SAVE_DOM=1` | Saves desktop DOM to `pageDOMs/desktopPageDOMs/` and mobile DOM to `pageDOMs/mobilePageDOMs/` |
| `OOBEE_SAVE_PAGE_SCREENSHOT=1` | Saves desktop PNG to `pageDOMs/desktopPageScreenshots/` and mobile PNG to `pageDOMs/mobilePageScreenshots/` |

- **Hash**: 7-character SHA-256 of the page URL (consistent, like git short hashes)
- **Truncated path**: URL pathname with `/` replaced by `_`, max 80 chars, for human readability
- **Filename collisions**: Resolved by appending `-2`, `-3`, etc. before the file extension
- **Mobile viewport**: Width derived programmatically from Playwright's `devices['iPhone 11']` profile. The viewport is resized in-place (no separate tab) once per page to serve both DOM and screenshot capture, then restored to the original desktop size in a `finally` block
- **Manifest**: `pageDOMs/domManifest.json` is written when either env var is enabled; `resetCaptureEntries()` runs in a `finally` so a subsequent scan does not inherit stale entries

### Output structure

```
results/<token>/pageDOMs/
├── domManifest.json                         # URL → file path mapping
├── desktopPageDOMs/
│   └── <hash>-<truncated_path>.html         # Desktop viewport DOM (OOBEE_SAVE_DOM)
├── mobilePageDOMs/
│   └── <hash>-<truncated_path>.html         # Mobile viewport DOM (OOBEE_SAVE_DOM)
├── desktopPageScreenshots/
│   └── <hash>-<truncated_path>.png          # Desktop viewport PNG (OOBEE_SAVE_PAGE_SCREENSHOT)
└── mobilePageScreenshots/
    └── <hash>-<truncated_path>.png          # Mobile viewport PNG (OOBEE_SAVE_PAGE_SCREENSHOT)
```

### Example `domManifest.json`

```json
{
  "generatedAt": "2026-07-23T13:22:06.000Z",
  "pages": [
    {
      "url": "https://example.com/about",
      "hash": "a1b2c3d",
      "desktopDom": "pageDOMs/desktopPageDOMs/a1b2c3d-about.html",
      "mobileDom": "pageDOMs/mobilePageDOMs/a1b2c3d-about.html",
      "desktopScreenshot": "pageDOMs/desktopPageScreenshots/a1b2c3d-about.png",
      "mobileScreenshot": "pageDOMs/mobilePageScreenshots/a1b2c3d-about.png",
      "errors": []
    }
  ]
}
```

### Files changed

| File | Change |
|------|--------|
| `src/crawlers/pageCapture.ts` | **New** — core module for DOM/screenshot capture and manifest generation |
| `src/crawlers/crawlDomain.ts` | Calls `capturePageData()` after axe scan |
| `src/crawlers/crawlSitemap.ts` | Calls `capturePageData()` after axe scan |
| `src/crawlers/crawlLocalFile.ts` | Calls `capturePageData()` after axe scan |
| `src/crawlers/custom/utils.ts` | Calls `capturePageData()` after axe scan |
| `src/combine.ts` | Calls `writeManifest()` + `resetCaptureEntries()` post-crawl (wrapped in try/finally) |
| `README.md` | Documents new env vars |
| `AGENTS.md` | Documents new env vars and output structure |

### Test plan

- [ ] Run sitemap scan with `OOBEE_SAVE_DOM=1` — verify `.html` files appear in both `desktopPageDOMs/` and `mobilePageDOMs/`
- [ ] Run website scan with `OOBEE_SAVE_PAGE_SCREENSHOT=1` — verify desktop and mobile PNGs
- [ ] Run with both env vars set — verify `domManifest.json` contains `desktopDom`, `mobileDom`, `desktopScreenshot`, `mobileScreenshot` fields for each page
- [ ] Verify mobile viewport captures reflect responsive rendering (iPhone 11 width, 390px)
- [ ] Verify desktop viewport is restored after mobile capture (even if a step throws)
- [ ] Run without env vars set — verify no `pageDOMs/` directory is created
- [ ] Test URL with long path (>80 chars) — verify truncation
- [ ] Test filename collision scenario — verify `-2` suffix applied
- [ ] Run two scans back-to-back — verify the second manifest does not contain stale entries from the first
