### PR TITLE
fix: prevent Windows hang from browser pool resource exhaustion on large crawls

### DIFF
--- a/src/crawlers/commonCrawlerFunc.ts
+++ b/src/crawlers/commonCrawlerFunc.ts
@@ -1230,35 +1230,59 @@ export const getPreLaunchHook = (userDataDirectory: string) => {
 
     await fsp.mkdir(effectiveDir, { recursive: true });
 
-    // For pool re-launches, best-effort clone profile data from base directory
-    // so authenticated sessions are preserved across browser pool retirements.
+    // For pool re-launches, copy only auth-relevant files from the base
+    // directory so authenticated sessions are preserved without cloning the
+    // entire profile (which grows with caches, IndexedDB, etc. during the crawl).
     if (launchCount > 1) {
-      const skipDirs = new Set([
-        'Singleton', 'lockfile', 'LOCK',
-        'Cache', 'Code Cache', 'GPUCache', 'DawnGraphiteCache', 'DawnWebGPUCache',
-        'Service Worker', 'ScriptCache', 'ShaderCache', 'GrShaderCache',
-        'component_crx_cache', 'optimization_guide_model_store',
-        'BrowserMetrics', 'Crashpad', 'FileTypePolicies',
-      ]);
       try {
-        const copyRecursive = async (src: string, dest: string) => {
-          const stat = await fsp.stat(src).catch(() => null);
-          if (!stat) return;
-          if (stat.isDirectory()) {
-            await fsp.mkdir(dest, { recursive: true }).catch(() => {});
-            const entries = await fsp.readdir(src).catch(() => []);
-            await Promise.all(
-              entries
-                .filter(entry => !entry.startsWith('Singleton') && !skipDirs.has(entry))
-                .map(entry =>
-                  copyRecursive(path.join(src, entry), path.join(dest, entry)).catch(() => {}),
-                ),
-            );
-          } else {
-            await fsp.copyFile(src, dest).catch(() => {});
+        // Copy top-level Local State (cookie encryption keys on Windows)
+        const localStateSrc = path.join(userDataDirectory, 'Local State');
+        if (await fsp.stat(localStateSrc).catch(() => null)) {
+          await fsp.copyFile(localStateSrc, path.join(effectiveDir, 'Local State')).catch(() => {});
+        }
+
+        // Find profile directories (Default, Profile 1, Profile 2, etc.)
+        const entries = await fsp.readdir(userDataDirectory, { withFileTypes: true }).catch(() => []);
+        const profileDirs = (entries as any[]).filter(
+          (e: any) => e.isDirectory() && /^(Default|Profile \d+)$/i.test(e.name),
+        );
+
+        for (const profile of profileDirs) {
+          const srcProfile = path.join(userDataDirectory, profile.name);
+          const destProfile = path.join(effectiveDir, profile.name);
+          await fsp.mkdir(destProfile, { recursive: true }).catch(() => {});
+
+          // Cookies (macOS layout: <Profile>/Cookies)
+          const cookiesSrc = path.join(srcProfile, 'Cookies');
+          if (await fsp.stat(cookiesSrc).catch(() => null)) {
+            await fsp.copyFile(cookiesSrc, path.join(destProfile, 'Cookies')).catch(() => {});
           }
-        };
-        await copyRecursive(userDataDirectory, effectiveDir).catch(() => {});
+
+          // Cookies (Windows layout: <Profile>/Network/Cookies)
+          const networkCookiesSrc = path.join(srcProfile, 'Network', 'Cookies');
+          if (await fsp.stat(networkCookiesSrc).catch(() => null)) {
+            const destNetwork = path.join(destProfile, 'Network');
+            await fsp.mkdir(destNetwork, { recursive: true }).catch(() => {});
+            await fsp.copyFile(networkCookiesSrc, path.join(destNetwork, 'Cookies')).catch(() => {});
+          }
+
+          // Local Storage (auth tokens, session data)
+          const localStorageSrc = path.join(srcProfile, 'Local Storage');
+          const localStorageStat = await fsp.stat(localStorageSrc).catch(() => null);
+          if (localStorageStat && localStorageStat.isDirectory()) {
+            const destLocalStorage = path.join(destProfile, 'Local Storage');
+            await fsp.mkdir(destLocalStorage, { recursive: true }).catch(() => {});
+            const lsFiles = await fsp.readdir(localStorageSrc).catch(() => []);
+            await Promise.all(
+              lsFiles.map(f =>
+                fsp.copyFile(
+                  path.join(localStorageSrc, f),
+                  path.join(destLocalStorage, f),
+                ).catch(() => {}),
+              ),
+            );
+          }
+        }
       } catch {
         // Silent fallback: use empty profile if clone fails
       }

--- a/src/crawlers/crawlDomain.ts
+++ b/src/crawlers/crawlDomain.ts
@@ -398,6 +398,8 @@ const crawlDomain = async ({
       retryOnBlocked: true,
       browserPoolOptions: {
         useFingerprints: false,
+        retireBrowserAfterPageCount: 500,
+        closeInactiveBrowserAfterSecs: 30,
         preLaunchHooks: [
           getPreLaunchHook(userDataDirectory),
           async (_pageId, launchContext) => {

--- a/src/crawlers/crawlRateController.ts
+++ b/src/crawlers/crawlRateController.ts
@@ -36,14 +36,10 @@ export class CrawlRateController {
   }
 
   onFailure(httpStatus: number | undefined, pool?: { maxConcurrency: number }): boolean {
-    if (typeof httpStatus !== 'number' || httpStatus < 400) {
-      return false;
-    }
-
     this.consecutiveSuccesses = 0;
     this.consecutiveFailures++;
 
-    if (pool && pool.maxConcurrency > 1) {
+    if (typeof httpStatus === 'number' && httpStatus >= 400 && pool && pool.maxConcurrency > 1) {
       pool.maxConcurrency = Math.max(1, Math.floor(pool.maxConcurrency / 2));
       consoleLogger.info(
         `Rate limited (HTTP ${httpStatus}) — reducing concurrency to ${pool.maxConcurrency}`,

--- a/src/crawlers/crawlSitemap.ts
+++ b/src/crawlers/crawlSitemap.ts
@@ -136,6 +136,8 @@ const crawlSitemap = async ({
       retryOnBlocked: true,
       browserPoolOptions: {
         useFingerprints: false,
+        retireBrowserAfterPageCount: 500,
+        closeInactiveBrowserAfterSecs: 30,
         preLaunchHooks: [
           getPreLaunchHook(userDataDirectory),
           async (_pageId, launchContext) => {


### PR DESCRIPTION
## Summary

Fixes an issue where `crawlIntelligent` / `crawlSitemap` hangs indefinitely on Windows after ~3500+ pages. The crawler exhausts file handles through excessive browser pool churn, then gets stuck in an infinite retry loop because connection-level failures are not counted toward the abort threshold.

## Root Cause

Three contributing factors:

1. **Excessive browser retirements** — Crawlee's default `retireBrowserAfterPageCount: 100` causes ~35+ browser instances to be created over a 3500-page crawl. Each retirement triggers a profile directory clone.

2. **Heavy profile cloning on re-launch** — The `getPreLaunchHook` recursively copies the entire userDataDir (which Chrome has grown with History, IndexedDB, blob_storage, etc.) on every browser re-launch. This accumulates disk I/O and open file handles.

3. **Rate controller ignores connection errors** — `CrawlRateController.onFailure()` only counted HTTP 4xx/5xx toward the 100-consecutive-failure abort threshold. Connection-level errors (timeouts, ECONNREFUSED, EPIPE) from resource exhaustion were silently ignored, causing the crawler to retry indefinitely.

## Changes

| File | Change |
|------|--------|
| `crawlSitemap.ts` | Added `retireBrowserAfterPageCount: 500` and `closeInactiveBrowserAfterSecs: 30` |
| `crawlDomain.ts` | Same browser pool options |
| `commonCrawlerFunc.ts` | Replaced full recursive profile copy with targeted copy of only auth-relevant files (Cookies, Network/Cookies, Local State, Local Storage) per profile directory (Default, Profile 1, etc.) |
| `crawlRateController.ts` | `onFailure` now counts all failure types toward abort threshold; only HTTP 4xx/5xx triggers concurrency reduction |

## Impact

- `maxConcurrency` (page parallelism) is **not affected** — these changes only control browser lifecycle
- Browser restarts reduced from ~35 to ~7 for a 3500-page crawl
- Retired browsers cleaned up in 30s instead of 5 minutes
- Profile clone is now ~KBs (cookies + local storage) instead of potentially MBs
- Crawl will abort gracefully after 100 consecutive failures of any kind instead of hanging

## Test Plan

- [ ] TypeScript compiles without errors (`npx tsc --noEmit`)
- [ ] Run a large sitemap crawl (1000+ pages) on Windows — verify no hang
- [ ] Verify authenticated crawl still works after browser retirement (cookies preserved)
- [ ] Verify crawl aborts gracefully when target site is unreachable
