### PR TITLE
fix: intelligent crawl overshoots page limit (-p) across phases

### DIFF
--- a/src/crawlers/crawlDomain.ts
+++ b/src/crawlers/crawlDomain.ts
@@ -382,8 +382,11 @@ const crawlDomain = async ({
   };
 
   let isAbortingScanNow = false;
+  const remainingBudget = fromCrawlIntelligentSitemap
+    ? Math.max(0, maxRequestsPerCrawl - urlsCrawledFromIntelligent.scanned.length)
+    : maxRequestsPerCrawl;
   const rateController = new CrawlRateController(
-    maxRequestsPerCrawl,
+    remainingBudget,
     specifiedMaxConcurrency || constants.maxConcurrency,
   );
 

--- a/src/crawlers/crawlSitemap.ts
+++ b/src/crawlers/crawlSitemap.ts
@@ -85,8 +85,11 @@ const crawlSitemap = async ({
   let urlsCrawled: UrlsCrawled;
   let durationExceeded = false;
   let isAbortingScan = false;
+  const remainingBudget = fromCrawlIntelligentSitemap
+    ? Math.max(0, maxRequestsPerCrawl - urlsCrawledFromIntelligent.scanned.length)
+    : maxRequestsPerCrawl;
   const rateController = new CrawlRateController(
-    maxRequestsPerCrawl,
+    remainingBudget,
     specifiedMaxConcurrency || constants.maxConcurrency,
   );
   const initialNoSuccessFailureAbortThreshold = Math.max(5, Math.min(maxRequestsPerCrawl, 25));


### PR DESCRIPTION
## Summary

- Fix intelligent crawl (`-t intelligent`) overshooting the `-p` page limit across phases
- When multiple sitemaps are processed sequentially, or when the domain crawl phase follows sitemap, each phase was creating a fresh `CrawlRateController` with `scannedCount = 0` — effectively giving each phase the full budget instead of the remaining budget

## Root cause

`crawlIntelligentSitemap` shares a single `urlsCrawled` object across all phases (sitemap passes + domain crawl). However, each inner `crawlSitemap` / `crawlDomain` call creates its own `new CrawlRateController(maxRequestsPerCrawl, ...)`, starting the counter at 0. The outer loop checks `urlsCrawled.scanned.length >= maxRequestsPerCrawl` between phases, but in-flight pages within a phase are gated only by the rate controller — which doesn't know about prior phases.

Example with `-p 5000`:
1. Sitemap phase scans 1500 pages (rate controller allows up to 5000)
2. Domain crawl phase starts with a fresh rate controller (scannedCount = 0), scans another 5000
3. Total: 6500 pages — far exceeds the 5000 limit

## Fix

When `fromCrawlIntelligentSitemap` is true, initialize the rate controller with the remaining budget:

```ts
const remainingBudget = fromCrawlIntelligentSitemap
  ? Math.max(0, maxRequestsPerCrawl - urlsCrawledFromIntelligent.scanned.length)
  : maxRequestsPerCrawl;
```

Applied to both `crawlDomain.ts` and `crawlSitemap.ts`.

## Scan types affected

| Type | Affected? | Why |
|------|-----------|-----|
| `-t website` | No | Single phase, single rate controller |
| `-t sitemap` | No | Single phase, single rate controller |
| `-t intelligent` | **Yes** | Multiple phases sharing urlsCrawled |

## Files changed

- `src/crawlers/crawlDomain.ts` — use remaining budget when called from intelligent crawl
- `src/crawlers/crawlSitemap.ts` — use remaining budget when called from intelligent crawl

## Test plan

- [ ] `-t intelligent -p 100`: total scanned pages should not exceed 100
- [ ] `-t intelligent -p 5000` on a large site: verify total stays at or near 5000
- [ ] `-t website -p 100`: no regression, still stops at 100
- [ ] `-t sitemap -p 100`: no regression, still stops at 100

🤖 Generated with [Claude Code](https://claude.com/claude-code)
