### PR TITLE
Fix/windows crawlee lock race

### DIFF
--- a/src/combine.ts
+++ b/src/combine.ts
@@ -96,6 +96,13 @@ const combineRun = async (details: Data, deviceToScan: string) => {
       consoleLogger.info(`Suppressed Playwright post-close connection error: ${err.message}`);
       return;
     }
+    // Suppress EPERM errors from Crawlee's async lock-file operations that fire
+    // after a crawl phase finishes. On Windows, the sitemap phase's async lock
+    // cleanup can race with the domain phase starting in the same directory.
+    if (err.message?.includes('EPERM') && err.message?.includes('.json.lock')) {
+      consoleLogger.info(`Suppressed Crawlee lock-file EPERM (stale async cleanup): ${err.message}`);
+      return;
+    }
     throw err;
   };
   process.on('uncaughtException', psTreeHandler);

--- a/src/crawlers/commonCrawlerFunc.ts
+++ b/src/crawlers/commonCrawlerFunc.ts
@@ -1135,10 +1135,9 @@ export const createCrawleeSubFolders = async (
   randomToken: string,
 ): Promise<{ dataset: Dataset; requestQueue: RequestQueue }> => {
 
-  const crawleeDir = path.join(getStoragePath(randomToken),"crawlee");
-
-  const dataset = await Dataset.open(crawleeDir);
-  const requestQueue = await RequestQueue.open(crawleeDir);
+  const baseDir = path.join(getStoragePath(randomToken), "crawlee");
+  const dataset = await Dataset.open(baseDir);
+  const requestQueue = await RequestQueue.open(`${baseDir}_rq`);
   return { dataset, requestQueue };
 };
 

--- a/src/mergeAxeResults.ts
+++ b/src/mergeAxeResults.ts
@@ -1110,7 +1110,7 @@ const generateArtifacts = async (
   }
 
   try {
-    const requestQueue = await RequestQueue.open(crawleeDir);
+    const requestQueue = await RequestQueue.open(`${crawleeDir}_rq`);
     await requestQueue.drop();
   } catch (error) {
     consoleLogger.info(`RequestQueue drop: ${error.message}`);
@@ -1120,6 +1120,7 @@ const generateArtifacts = async (
   const crawleePath = path.join(storagePath, 'crawlee');
   try {
     await fs.promises.rm(crawleePath, { recursive: true, force: true });
+    await fs.promises.rm(`${crawleePath}_rq`, { recursive: true, force: true });
   } catch {
     // Best-effort; storage was already dropped via API
   }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -418,13 +418,14 @@ export const cleanUp = async (randomToken?: string, isError: boolean = false): P
       const crawleeDir = path.join(storagePath, 'crawlee');
       const dataset = await Dataset.open(crawleeDir);
       await dataset.drop();
-      const requestQueue = await RequestQueue.open(crawleeDir);
+      const requestQueue = await RequestQueue.open(`${crawleeDir}_rq`);
       await requestQueue.drop();
     } catch (error) {
       consoleLogger.info(`Crawlee storage drop in cleanUp: ${error.message}`);
     }
     try {
       fs.rmSync(path.join(storagePath, 'crawlee'), { recursive: true, force: true });
+      fs.rmSync(path.join(storagePath, 'crawlee_rq'), { recursive: true, force: true });
     } catch (error) {
       consoleLogger.warn(`Unable to force remove crawlee folder: ${error.message}`);
     }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -425,9 +425,13 @@ export const cleanUp = async (randomToken?: string, isError: boolean = false): P
     }
     try {
       fs.rmSync(path.join(storagePath, 'crawlee'), { recursive: true, force: true });
-      fs.rmSync(path.join(storagePath, 'crawlee_rq'), { recursive: true, force: true });
     } catch (error) {
       consoleLogger.warn(`Unable to force remove crawlee folder: ${error.message}`);
+    }
+    try {
+      fs.rmSync(path.join(storagePath, 'crawlee_rq'), { recursive: true, force: true });
+    } catch (error) {
+      consoleLogger.warn(`Unable to force remove crawlee_rq folder: ${error.message}`);
     }
 
     try {


### PR DESCRIPTION
## Summary

- Separate Dataset and RequestQueue into distinct storage directories to eliminate `proper-lockfile` race condition on Windows during intelligent sitemap crawls
- Add defense-in-depth `uncaughtException` handler for stale `.json.lock` EPERM errors

## Problem

In the intelligent crawl flow, `crawlSitemap` finishes writing scan results then `crawlDomain` starts immediately after. Both phases shared the **same on-disk directory** for Dataset and RequestQueue storage because `createCrawleeSubFolders` opened both with an identical absolute path name — and Crawlee's `path.resolve(base, absolutePath)` ignores the base, collapsing them to the same folder.

On Windows, `proper-lockfile` creates `.lock` directories for each JSON write. The sitemap phase's async lock cleanup can race with the domain phase's new writes in the same directory, causing an `EPERM` that crashes the scan.

## Fix

1. **Root cause fix**: Give the RequestQueue a separate storage path (`crawlee_rq`) so it no longer shares a directory with the Dataset
2. **Defense-in-depth**: Suppress `EPERM` errors on `.json.lock` paths in the `uncaughtException` handler (non-fatal stale lock artifacts)
3. **Cleanup alignment**: Updated `mergeAxeResults` and `utils.ts` cleanup paths to also remove the new `crawlee_rq` directory

## Test plan

- [ ] Run intelligent sitemap scan on Windows — verify no EPERM crash between sitemap and domain phases
- [ ] Run intelligent sitemap scan on macOS/Linux — verify no regression
- [ ] Verify `results/<token>/crawlee_rq/` directory is created during scan and cleaned up after
- [ ] Verify scan results are complete (no missing pages from either phase)
