### PR TITLE
fix: exclude crawlee* directories from zip output

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1027,9 +1027,10 @@ export const zipResults = async (zipName: string, resultsPath: string): Promise<
   if (!stats.isDirectory()) {
     throw new Error(`resultsPath is not a directory: ${resultsPath}`);
   }
-  async function addFolderToZip(folderPath: string, zipFolder: JSZip): Promise<void> {
+  async function addFolderToZip(folderPath: string, zipFolder: JSZip, isRoot = false): Promise<void> {
     const items = await fs.readdir(folderPath);
     for (const item of items) {
+      if (isRoot && item.startsWith('crawlee')) continue;
       const fullPath = path.join(folderPath, item);
       const stats = await fs.stat(fullPath);
       if (stats.isDirectory()) {
@@ -1043,7 +1044,7 @@ export const zipResults = async (zipName: string, resultsPath: string): Promise<
   }
 
   const zip = new JSZip();
-  await addFolderToZip(resultsPath, zip);
+  await addFolderToZip(resultsPath, zip, true);
 
   const zipStream = zip.generateNodeStream({
     type: 'nodebuffer',


### PR DESCRIPTION
## Summary

- Exclude `crawlee*` intermediate storage directories from the zip output as a safety net when cleanup fails on Windows

## Problem

The `zipResults` function zips everything in the results folder. If the Crawlee storage cleanup fails (e.g. due to EBUSY/EPERM from locked files on Windows), the `crawlee/` and `crawlee_rq/` directories would be included in the final `oobee-scan-results.zip` — bloating the artifact with intermediate data that users don't need.

## Fix

Added a `startsWith('crawlee')` check in `addFolderToZip` that skips any root-level directory matching the prefix. This covers `crawlee`, `crawlee_rq`, and any future variants without needing to maintain an explicit list.

## Test plan

- [ ] Run a scan and verify `crawlee*/` folders are not present in the output zip
- [ ] Verify all expected report files (HTML, JSON, screenshots) are still included in the zip
