### PR TITLE
Fix/403 retry storm

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -144,6 +144,8 @@ The `constants` default export object holds runtime state:
 | `OOBEE_SCAN_PRODUCT` | Adds `scanProduct` tag to Sentry events |
 | `OOBEE_CONSECUTIVE_MAX_RETRIES` | Max consecutive HTTP failures before circuit breaker aborts crawl (default 100) |
 | `OOBEE_VALIDATE_URL` | If set, exit after URL validation without scanning |
+| `OOBEE_SAVE_DOM` | `1` or `true` = save full-page DOM HTML to `page-doms/` in results directory. Supported scan types: Website, Sitemap, Intelligent, LocalFile, Custom |
+| `OOBEE_SAVE_PAGE_SCREENSHOT` | `1` or `true` = save full-page desktop + mobile viewport screenshots to `page-doms/desktop-page-screenshots/` and `page-doms/mobile-page-screenshots/`. Mobile viewport uses iPhone 11 width programmatically. Supported scan types: Website, Sitemap, Intelligent, LocalFile, Custom |
 | `HTTP_PROXY` / `HTTPS_PROXY` / `ALL_PROXY` | Proxy configuration |
 | `NO_PROXY` / `INCLUDE_PROXY` | Proxy bypass/include lists |
 
@@ -352,5 +354,17 @@ When making changes, validate these areas which have well-established edge cases
 ├── scanPagesDetail.json    # Per-page breakdown
 ├── scanPagesSummary.json   # Page-level summary
 ├── sitemap.xml             # Discovered URLs
-└── screenshots/            # Violation screenshots (if enabled)
+├── screenshots/            # Violation screenshots (if enabled)
+└── page-doms/              # Page capture (if OOBEE_SAVE_DOM or OOBEE_SAVE_PAGE_SCREENSHOT)
+    ├── {hash}-{truncated_path}.html          # Full DOM (OOBEE_SAVE_DOM)
+    ├── dom-manifest.json                     # Maps URLs → hash, file paths, errors
+    ├── desktop-page-screenshots/             # Desktop viewport PNGs (OOBEE_SAVE_PAGE_SCREENSHOT)
+    │   └── {hash}-{truncated_path}.png
+    └── mobile-page-screenshots/              # Mobile viewport PNGs (OOBEE_SAVE_PAGE_SCREENSHOT)
+        └── {hash}-{truncated_path}.png
 ```
+
+- `{hash}` is a 7-character SHA-256 of the page URL (consistent per URL, like git short hashes)
+- `{truncated_path}` is the URL path with `/` replaced by `_`, max 80 characters
+- If filename collisions occur, a `-2`, `-3` etc. suffix is added before the extension
+- `dom-manifest.json` is written when either env var is enabled, containing URL-to-file mappings

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -144,8 +144,8 @@ The `constants` default export object holds runtime state:
 | `OOBEE_SCAN_PRODUCT` | Adds `scanProduct` tag to Sentry events |
 | `OOBEE_CONSECUTIVE_MAX_RETRIES` | Max consecutive HTTP failures before circuit breaker aborts crawl (default 100) |
 | `OOBEE_VALIDATE_URL` | If set, exit after URL validation without scanning |
-| `OOBEE_SAVE_DOM` | `1` or `true` = save full-page DOM HTML to `page-doms/` in results directory. Supported scan types: Website, Sitemap, Intelligent, LocalFile, Custom |
-| `OOBEE_SAVE_PAGE_SCREENSHOT` | `1` or `true` = save full-page desktop + mobile viewport screenshots to `page-doms/desktop-page-screenshots/` and `page-doms/mobile-page-screenshots/`. Mobile viewport uses iPhone 11 width programmatically. Supported scan types: Website, Sitemap, Intelligent, LocalFile, Custom |
+| `OOBEE_SAVE_DOM` | `1` or `true` = save full-page DOM HTML to `pageDOMs/` in results directory. Supported scan types: Website, Sitemap, Intelligent, LocalFile, Custom |
+| `OOBEE_SAVE_PAGE_SCREENSHOT` | `1` or `true` = save full-page desktop + mobile viewport screenshots to `pageDOMs/desktopPageScreenshots/` and `pageDOMs/mobilePageScreenshots/`. Mobile viewport uses iPhone 11 width programmatically. Supported scan types: Website, Sitemap, Intelligent, LocalFile, Custom |
 | `HTTP_PROXY` / `HTTPS_PROXY` / `ALL_PROXY` | Proxy configuration |
 | `NO_PROXY` / `INCLUDE_PROXY` | Proxy bypass/include lists |
 
@@ -355,16 +355,16 @@ When making changes, validate these areas which have well-established edge cases
 ├── scanPagesSummary.json   # Page-level summary
 ├── sitemap.xml             # Discovered URLs
 ├── screenshots/            # Violation screenshots (if enabled)
-└── page-doms/              # Page capture (if OOBEE_SAVE_DOM or OOBEE_SAVE_PAGE_SCREENSHOT)
+└── pageDOMs/              # Page capture (if OOBEE_SAVE_DOM or OOBEE_SAVE_PAGE_SCREENSHOT)
     ├── {hash}-{truncated_path}.html          # Full DOM (OOBEE_SAVE_DOM)
-    ├── dom-manifest.json                     # Maps URLs → hash, file paths, errors
-    ├── desktop-page-screenshots/             # Desktop viewport PNGs (OOBEE_SAVE_PAGE_SCREENSHOT)
+    ├── domManifest.json                     # Maps URLs → hash, file paths, errors
+    ├── desktopPageScreenshots/             # Desktop viewport PNGs (OOBEE_SAVE_PAGE_SCREENSHOT)
     │   └── {hash}-{truncated_path}.png
-    └── mobile-page-screenshots/              # Mobile viewport PNGs (OOBEE_SAVE_PAGE_SCREENSHOT)
+    └── mobilePageScreenshots/              # Mobile viewport PNGs (OOBEE_SAVE_PAGE_SCREENSHOT)
         └── {hash}-{truncated_path}.png
 ```
 
 - `{hash}` is a 7-character SHA-256 of the page URL (consistent per URL, like git short hashes)
 - `{truncated_path}` is the URL path with `/` replaced by `_`, max 80 characters
 - If filename collisions occur, a `-2`, `-3` etc. suffix is added before the extension
-- `dom-manifest.json` is written when either env var is enabled, containing URL-to-file mappings
+- `domManifest.json` is written when either env var is enabled, containing URL-to-file mappings

--- a/README.md
+++ b/README.md
@@ -100,6 +100,8 @@ verapdf --version
 | OOBEE_SCAN_METADATA | Overrides the `entryUrl` tag sent to telemetry. | |
 | OOBEE_SCAN_PRODUCT | Adds a `scanProduct` tag to telemetry events. | |
 | OOBEE_CONSECUTIVE_MAX_RETRIES | Max consecutive HTTP failures before the circuit breaker aborts the crawl. | `100` |
+| OOBEE_SAVE_DOM | Set to `1` or `true` to save full-page DOM HTML for each scanned page to the results directory. Works with all scan types (Website, Sitemap, Intelligent, LocalFile, Custom). | |
+| OOBEE_SAVE_PAGE_SCREENSHOT | Set to `1` or `true` to save full-page desktop and mobile viewport screenshots for each scanned page. Mobile viewport width is determined from iPhone 11 device profile. Works with all scan types (Website, Sitemap, Intelligent, LocalFile, Custom). | |
 | HTTP_PROXY | URL of the proxy server to be used for HTTP requests (e.g. `http://proxy.example.com:8080`). | |
 | HTTPS_PROXY | URL of the proxy server to be used for HTTPS requests (e.g. `https://proxy.example.com:8080`). | |
 | ALL_PROXY | URL of the proxy server to be used for all requests, typically used for SOCKS5 proxies (e.g. `socks5://proxy.example.com:1080`. Note: IPv6 direct connections may still continue even though socks5 proxy is specified due to a known issue with Chrome/Chromium. (Recommended workaround is to turn off IPv6 at host-level). | |

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@govtechsg/oobee",
   "main": "dist/npmIndex.js",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "type": "module",
   "author": "Government Technology Agency <info@tech.gov.sg>",
   "bin": {

--- a/src/combine.ts
+++ b/src/combine.ts
@@ -18,7 +18,7 @@ import {
   getS3UploadPrefix,
   uploadFolderToS3,
 } from './services/s3Uploader.js';
-import { writeManifest, resetCaptureEntries } from './crawlers/pageCapture.js';
+import { writeManifest, resetCaptureEntries, isPageCaptureEnabled } from './crawlers/pageCapture.js';
 
 // Class exports
 export class ViewportSettingsClass {
@@ -75,6 +75,10 @@ const combineRun = async (details: Data, deviceToScan: string) => {
   process.env.CRAWLEE_LOG_LEVEL = 'ERROR';
   process.env.CRAWLEE_STORAGE_DIR = randomToken;
   constants.sitemapFetchedLinks = null;
+
+  if (isPageCaptureEnabled() && !process.env.OOBEE_SCAN_PRODUCT) {
+    process.env.OOBEE_SCAN_PRODUCT = 'U&A';
+  }
 
   if (process.env.CRAWLEE_SYSTEM_INFO_V2 === undefined) {
     // Set the environment variable to enable system info v2

--- a/src/combine.ts
+++ b/src/combine.ts
@@ -18,6 +18,7 @@ import {
   getS3UploadPrefix,
   uploadFolderToS3,
 } from './services/s3Uploader.js';
+import { writeManifest, resetCaptureEntries } from './crawlers/pageCapture.js';
 
 // Class exports
 export class ViewportSettingsClass {
@@ -285,6 +286,8 @@ const combineRun = async (details: Data, deviceToScan: string) => {
   if (scanDetails.urlsCrawled) {
     if (scanDetails.urlsCrawled.scanned.length > 0) {
       await createAndUpdateResultsFolders(randomToken);
+      await writeManifest(randomToken);
+      resetCaptureEntries();
       const pagesNotScanned = [
         ...urlsCrawledObj.error,
         ...urlsCrawledObj.invalid,

--- a/src/crawlers/crawlDomain.ts
+++ b/src/crawlers/crawlDomain.ts
@@ -41,6 +41,7 @@ import {
 } from './pdfScanFunc.js';
 import { consoleLogger, guiInfoLog } from '../logs.js';
 import { ViewportSettingsClass } from '../combine.js';
+import { capturePageData } from './pageCapture.js';
 
 const isBlacklisted = (url: string, blacklistedPatterns: string[]) => {
   if (!blacklistedPatterns) {
@@ -660,6 +661,8 @@ const crawlDomain = async ({
             }
 
             const results = await runAxeScript({ includeScreenshots, page, randomToken, ruleset });
+
+            await capturePageData(page, actualUrl, randomToken);
 
             // Detect JS redirects that fire during/after axe scan.
             // Listen for navigation, then give a brief window for pending redirects to complete.

--- a/src/crawlers/crawlDomain.ts
+++ b/src/crawlers/crawlDomain.ts
@@ -400,7 +400,7 @@ const crawlDomain = async ({
         launcher: constants.launcher,
         launchOptions: getPlaywrightLaunchOptions(browser),
       },
-      retryOnBlocked: true,
+      retryOnBlocked: false,
       browserPoolOptions: {
         useFingerprints: false,
         retireBrowserAfterPageCount: 500,
@@ -424,7 +424,6 @@ const crawlDomain = async ({
       },
       requestQueue,
       maxRequestRetries: 3,
-      maxSessionRotations: 1,
       preNavigationHooks: [
         ...preNavigationHooks(extraHTTPHeaders),
         async ({ request }) => {
@@ -645,6 +644,21 @@ const crawlDomain = async ({
             }
 
             const responseStatus = response?.status();
+            if (responseStatus === 403) {
+              rateController.onFailure(responseStatus, activeCrawler.autoscaledPool);
+              guiInfoLog(guiInfoStatusTypes.SKIPPED, {
+                numScanned: urlsCrawled.scanned.length,
+                urlScanned: request.url,
+              });
+              urlsCrawled.userExcluded.push({
+                url: request.url,
+                pageTitle: request.url,
+                actualUrl,
+                metadata: STATUS_CODE_METADATA[403] || STATUS_CODE_METADATA[599],
+                httpStatusCode: 403,
+              });
+              return;
+            }
             if (responseStatus && responseStatus >= 300) {
               guiInfoLog(guiInfoStatusTypes.SKIPPED, {
                 numScanned: urlsCrawled.scanned.length,
@@ -844,12 +858,9 @@ const crawlDomain = async ({
         const status = response?.status();
 
         // Re-enqueue rate-limited (403) URLs once for a retry after concurrency recovers.
-        // Without this, URLs that fail during a rate-limit burst are permanently lost
-        // even though the site is accessible at lower concurrency.
-        // Don't call onFailure here — the re-enqueued request will get a fresh attempt.
-        // If it fails again (rateLimitRetried=true), it falls through to the normal
-        // onFailure + circuit breaker path below.
+        // Call onFailure to reduce concurrency immediately on rate-limit detection.
         if (status === 403 && !request.userData?.rateLimitRetried) {
+          rateController.onFailure(status, crawler.autoscaledPool);
           try {
             await requestQueue.addRequest({
               url: request.url,

--- a/src/crawlers/crawlLocalFile.ts
+++ b/src/crawlers/crawlLocalFile.ts
@@ -21,6 +21,7 @@ import { runPdfScan, mapPdfScanResults, doPdfScreenshots } from './pdfScanFunc.j
 import { guiInfoLog } from '../logs.js';
 import crawlSitemap from './crawlSitemap.js';
 import { getPdfStoragePath, getStoragePath, register } from '../utils.js';
+import { capturePageData } from './pageCapture.js';
 
 export const crawlLocalFile = async ({
   url,
@@ -185,6 +186,8 @@ export const crawlLocalFile = async ({
     const results = await runAxeScript({ includeScreenshots, page, randomToken, ruleset });
 
     const actualUrl = page.url() || request.loadedUrl || url;
+
+    await capturePageData(page, actualUrl, randomToken);
 
     guiInfoLog(guiInfoStatusTypes.SCANNED, {
       numScanned: urlsCrawled.scanned.length,

--- a/src/crawlers/crawlSitemap.ts
+++ b/src/crawlers/crawlSitemap.ts
@@ -38,6 +38,7 @@ import {
 } from './pdfScanFunc.js';
 import { consoleLogger, guiInfoLog } from '../logs.js';
 import { ViewportSettingsClass } from '../combine.js';
+import { capturePageData } from './pageCapture.js';
 
 const crawlSitemap = async ({
   sitemapUrl,
@@ -363,6 +364,8 @@ const crawlSitemap = async ({
             }
 
             const results = await runAxeScript({ includeScreenshots, page, randomToken, ruleset });
+
+            await capturePageData(page, actualUrl, randomToken);
 
             // Detect JS redirects that fire during/after axe scan.
             // Listen for navigation, then give a brief window for pending redirects to complete.

--- a/src/crawlers/crawlSitemap.ts
+++ b/src/crawlers/crawlSitemap.ts
@@ -150,7 +150,7 @@ const crawlSitemap = async ({
         launcher: constants.launcher,
         launchOptions: getPlaywrightLaunchOptions(browser),
       },
-      retryOnBlocked: true,
+      retryOnBlocked: false,
       browserPoolOptions: {
         useFingerprints: false,
         retireBrowserAfterPageCount: 500,
@@ -174,7 +174,6 @@ const crawlSitemap = async ({
       requestList,
       requestQueue,
       maxRequestRetries: 3,
-      maxSessionRotations: 1,
       postNavigationHooks: [
         async ({ page }) => {
           try {
@@ -319,6 +318,22 @@ const crawlSitemap = async ({
 
           const contentType = response?.headers?.()['content-type'] || '';
           const status = response ? response.status() : 0;
+
+          if (status === 403) {
+            rateController.onFailure(status, crawler.autoscaledPool);
+            guiInfoLog(guiInfoStatusTypes.SKIPPED, {
+              numScanned: urlsCrawled.scanned.length,
+              urlScanned: request.url,
+            });
+            urlsCrawled.userExcluded.push({
+              url: request.url,
+              pageTitle: request.url,
+              actualUrl,
+              metadata: STATUS_CODE_METADATA[403] || STATUS_CODE_METADATA[599],
+              httpStatusCode: 403,
+            });
+            return;
+          }
 
           if (isScanHtml && status < 300 && isWhitelistedContentType(contentType)) {
             const isRedirected = !areLinksEqual(page.url(), request.url);
@@ -536,9 +551,9 @@ const crawlSitemap = async ({
         const status = response?.status();
 
         // Re-enqueue rate-limited (403) URLs once for a retry after concurrency recovers.
-        // Don't call onFailure here — the re-enqueued request gets a fresh attempt.
-        // If it fails again (rateLimitRetried=true), it falls through to the normal path.
+        // Call onFailure to reduce concurrency immediately on rate-limit detection.
         if (status === 403 && !request.userData?.rateLimitRetried) {
+          rateController.onFailure(status, crawler.autoscaledPool);
           try {
             await requestQueue.addRequest({
               url: request.url,

--- a/src/crawlers/custom/utils.ts
+++ b/src/crawlers/custom/utils.ts
@@ -4,6 +4,7 @@
 import path from 'path';
 import { getDomain } from 'tldts';
 import { runAxeScript } from '../commonCrawlerFunc.js';
+import { capturePageData } from '../pageCapture.js';
 import { consoleLogger, guiInfoLog, silentLogger } from '../../logs.js';
 import { guiInfoStatusTypes } from '../../constants/constants.js';
 import { isSkippedUrl, validateCustomFlowLabel } from '../../constants/common.js';
@@ -158,6 +159,8 @@ export const runAxeScan = async (
   urlsCrawled,
 ) => {
   const result = await runAxeScript({ includeScreenshots, page, randomToken, customFlowDetails });
+
+  await capturePageData(page, page.url(), randomToken);
 
   await dataset.pushData(result);
 

--- a/src/crawlers/pageCapture.ts
+++ b/src/crawlers/pageCapture.ts
@@ -1,0 +1,172 @@
+import fs from 'fs-extra';
+import path from 'path';
+import crypto from 'crypto';
+import { Page, devices } from 'playwright';
+import { getStoragePath } from '../utils.js';
+
+const MOBILE_VIEWPORT_WIDTH = devices['iPhone 11'].viewport.width;
+const MOBILE_VIEWPORT_HEIGHT = devices['iPhone 11'].viewport.height;
+
+export interface PageCaptureEntry {
+  url: string;
+  hash: string;
+  domFile?: string;
+  desktopScreenshot?: string;
+  mobileScreenshot?: string;
+  errors: string[];
+}
+
+const captureEntries: Map<string, PageCaptureEntry> = new Map();
+
+export function getUrlHash(url: string): string {
+  return crypto.createHash('sha256').update(url).digest('hex').slice(0, 7);
+}
+
+function getTruncatedPath(url: string): string {
+  try {
+    const parsed = new URL(url);
+    let pathStr = parsed.pathname + (parsed.search || '');
+    pathStr = pathStr.replace(/^\//, '').replace(/\//g, '_').replace(/[^a-zA-Z0-9\-_.]/g, '_');
+    if (pathStr.length > 80) {
+      pathStr = pathStr.slice(0, 80);
+    }
+    return pathStr || 'index';
+  } catch {
+    return 'unknown';
+  }
+}
+
+function getPageDomsDir(randomToken: string): string {
+  const storagePath = getStoragePath(randomToken);
+  return path.join(storagePath, 'page-doms');
+}
+
+async function getUniqueFilePath(dir: string, baseName: string, ext: string): Promise<string> {
+  let candidate = path.join(dir, `${baseName}${ext}`);
+  if (!await fs.pathExists(candidate)) return candidate;
+
+  let counter = 2;
+  while (await fs.pathExists(candidate)) {
+    candidate = path.join(dir, `${baseName}-${counter}${ext}`);
+    counter++;
+  }
+  return candidate;
+}
+
+function getRelativeName(filePath: string, baseDir: string): string {
+  return path.relative(baseDir, filePath).replace(/\\/g, '/');
+}
+
+export function isSaveDomEnabled(): boolean {
+  return process.env.OOBEE_SAVE_DOM === '1' || process.env.OOBEE_SAVE_DOM === 'true';
+}
+
+export function isSavePageScreenshotEnabled(): boolean {
+  return (
+    process.env.OOBEE_SAVE_PAGE_SCREENSHOT === '1' ||
+    process.env.OOBEE_SAVE_PAGE_SCREENSHOT === 'true'
+  );
+}
+
+export function isPageCaptureEnabled(): boolean {
+  return isSaveDomEnabled() || isSavePageScreenshotEnabled();
+}
+
+export async function capturePageData(
+  page: Page,
+  url: string,
+  randomToken: string,
+): Promise<void> {
+  if (!isPageCaptureEnabled()) return;
+
+  const hash = getUrlHash(url);
+  const truncatedPath = getTruncatedPath(url);
+  const fileName = `${hash}-${truncatedPath}`;
+  const pageDomsDir = getPageDomsDir(randomToken);
+
+  const entry: PageCaptureEntry = {
+    url,
+    hash,
+    errors: [],
+  };
+
+  if (isSaveDomEnabled()) {
+    try {
+      await fs.ensureDir(pageDomsDir);
+      const domContent = await page.content();
+      const domFilePath = await getUniqueFilePath(pageDomsDir, fileName, '.html');
+      await fs.writeFile(domFilePath, domContent, 'utf-8');
+      entry.domFile = `page-doms/${getRelativeName(domFilePath, pageDomsDir)}`;
+    } catch (err) {
+      entry.errors.push(`DOM save failed: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
+
+  if (isSavePageScreenshotEnabled()) {
+    const desktopDir = path.join(pageDomsDir, 'desktop-page-screenshots');
+    const mobileDir = path.join(pageDomsDir, 'mobile-page-screenshots');
+
+    try {
+      await fs.ensureDir(desktopDir);
+      const desktopPath = await getUniqueFilePath(desktopDir, fileName, '.png');
+      await page.screenshot({ path: desktopPath, fullPage: true });
+      entry.desktopScreenshot = `page-doms/desktop-page-screenshots/${getRelativeName(desktopPath, desktopDir)}`;
+    } catch (err) {
+      entry.errors.push(
+        `Desktop screenshot failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+
+    try {
+      await fs.ensureDir(mobileDir);
+      const currentViewport = page.viewportSize();
+
+      await page.setViewportSize({
+        width: MOBILE_VIEWPORT_WIDTH,
+        height: MOBILE_VIEWPORT_HEIGHT,
+      });
+      await page.waitForTimeout(500);
+
+      const mobilePath = await getUniqueFilePath(mobileDir, fileName, '.png');
+      await page.screenshot({ path: mobilePath, fullPage: true });
+      entry.mobileScreenshot = `page-doms/mobile-page-screenshots/${getRelativeName(mobilePath, mobileDir)}`;
+
+      if (currentViewport) {
+        await page.setViewportSize(currentViewport);
+      }
+    } catch (err) {
+      entry.errors.push(
+        `Mobile screenshot failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+
+  captureEntries.set(url, entry);
+}
+
+export async function writeManifest(randomToken: string): Promise<void> {
+  if (!isPageCaptureEnabled()) return;
+  if (captureEntries.size === 0) return;
+
+  const pageDomsDir = getPageDomsDir(randomToken);
+  await fs.ensureDir(pageDomsDir);
+
+  const manifest = {
+    generatedAt: new Date().toISOString(),
+    pages: Array.from(captureEntries.values()).map(entry => ({
+      url: entry.url,
+      hash: entry.hash,
+      ...(entry.domFile && { domFile: entry.domFile }),
+      ...(entry.desktopScreenshot && { desktopScreenshot: entry.desktopScreenshot }),
+      ...(entry.mobileScreenshot && { mobileScreenshot: entry.mobileScreenshot }),
+      errors: entry.errors,
+    })),
+  };
+
+  const manifestPath = path.join(pageDomsDir, 'dom-manifest.json');
+  await fs.writeFile(manifestPath, JSON.stringify(manifest, null, 2), 'utf-8');
+}
+
+export function resetCaptureEntries(): void {
+  captureEntries.clear();
+}

--- a/src/crawlers/pageCapture.ts
+++ b/src/crawlers/pageCapture.ts
@@ -38,7 +38,7 @@ function getTruncatedPath(url: string): string {
 
 function getPageDomsDir(randomToken: string): string {
   const storagePath = getStoragePath(randomToken);
-  return path.join(storagePath, 'page-doms');
+  return path.join(storagePath, 'pageDOMs');
 }
 
 async function getUniqueFilePath(dir: string, baseName: string, ext: string): Promise<string> {
@@ -96,21 +96,21 @@ export async function capturePageData(
       const domContent = await page.content();
       const domFilePath = await getUniqueFilePath(pageDomsDir, fileName, '.html');
       await fs.writeFile(domFilePath, domContent, 'utf-8');
-      entry.domFile = `page-doms/${getRelativeName(domFilePath, pageDomsDir)}`;
+      entry.domFile = `pageDOMs/${getRelativeName(domFilePath, pageDomsDir)}`;
     } catch (err) {
       entry.errors.push(`DOM save failed: ${err instanceof Error ? err.message : String(err)}`);
     }
   }
 
   if (isSavePageScreenshotEnabled()) {
-    const desktopDir = path.join(pageDomsDir, 'desktop-page-screenshots');
-    const mobileDir = path.join(pageDomsDir, 'mobile-page-screenshots');
+    const desktopDir = path.join(pageDomsDir, 'desktopPageScreenshots');
+    const mobileDir = path.join(pageDomsDir, 'mobilePageScreenshots');
 
     try {
       await fs.ensureDir(desktopDir);
       const desktopPath = await getUniqueFilePath(desktopDir, fileName, '.png');
       await page.screenshot({ path: desktopPath, fullPage: true });
-      entry.desktopScreenshot = `page-doms/desktop-page-screenshots/${getRelativeName(desktopPath, desktopDir)}`;
+      entry.desktopScreenshot = `pageDOMs/desktopPageScreenshots/${getRelativeName(desktopPath, desktopDir)}`;
     } catch (err) {
       entry.errors.push(
         `Desktop screenshot failed: ${err instanceof Error ? err.message : String(err)}`,
@@ -129,7 +129,7 @@ export async function capturePageData(
 
       const mobilePath = await getUniqueFilePath(mobileDir, fileName, '.png');
       await page.screenshot({ path: mobilePath, fullPage: true });
-      entry.mobileScreenshot = `page-doms/mobile-page-screenshots/${getRelativeName(mobilePath, mobileDir)}`;
+      entry.mobileScreenshot = `pageDOMs/mobilePageScreenshots/${getRelativeName(mobilePath, mobileDir)}`;
 
       if (currentViewport) {
         await page.setViewportSize(currentViewport);
@@ -163,7 +163,7 @@ export async function writeManifest(randomToken: string): Promise<void> {
     })),
   };
 
-  const manifestPath = path.join(pageDomsDir, 'dom-manifest.json');
+  const manifestPath = path.join(pageDomsDir, 'domManifest.json');
   await fs.writeFile(manifestPath, JSON.stringify(manifest, null, 2), 'utf-8');
 }
 


### PR DESCRIPTION
## Summary

Fixes a scan stall where 403 rate-limited URLs take ~8 minutes each to process silently, causing scans to appear stuck for 20+ minutes with no log output.

**Root cause**: `retryOnBlocked: true` intercepts HTTP 403 responses before they reach the request handler, treating them as CAPTCHA/blocked pages. It then performs futile session rotations + Crawlee's own retry mechanism (4 attempts × 2 navigations × 30s timeout = ~4 min), followed by a silent re-enqueue that repeats the cycle (~8 min total per URL). At reduced concurrency (3), dozens of rate-limited URLs create 40+ minutes of no visible progress.

**Fix**: Disable `retryOnBlocked` so 403 responses reach the request handler directly. Add explicit 403 handling that immediately reduces concurrency and classifies the URL (~30s per URL instead of ~8 min). Re-add `onFailure()` to the failedRequestHandler 403 path for immediate concurrency reduction.

## Changes

- `crawlSitemap.ts` / `crawlDomain.ts`:
  - Set `retryOnBlocked: false` (session rotation doesn't help IP-based rate limiting)
  - Remove `maxSessionRotations: 1` (no longer needed)
  - Add 403 detection in requestHandler with `onFailure()` for concurrency backoff
  - Re-add `onFailure()` to failedRequestHandler's 403 re-enqueue path
- Bump version to 0.11.1

## Per-URL timing comparison

| Scenario | Before | After |
|----------|--------|-------|
| 403 rate limit | ~8 min (silent) | ~30s (logged immediately) |
| Transient network error | ~120s (4 retries) | ~120s (unchanged) |
| True CAPTCHA/block | ~60s futile rotation | ~30s (same practical outcome) |

## Test plan

- [ ] Run intelligent scan against a site that rate-limits (e.g., cpf.gov.sg)
- [ ] Verify "reducing concurrency to X" logs appear promptly on 403s
- [ ] Verify scan completes within reasonable time (no 20+ min stalls)
- [ ] Run normal sitemap scan — confirm 403 pages are classified as skipped
- [ ] Run website crawl — confirm same behavior
- [ ] Verify non-403 errors (network timeouts) still retry 3 times correctly
