### PR TITLE
fix: unblock Safe Browsing DB warmup in Docker/BuildKit builds and npm publish manually

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,8 +1,11 @@
 name: Publish Package to npmjs
 on:
   workflow_dispatch:
-  release:
-    types: [published]
+    inputs:
+      release_tag:
+        description: 'Git tag or ref to publish (e.g. 0.11.4). The commit at this ref will be built and published; its package.json version is what lands on npm.'
+        required: true
+        type: string
 permissions:
   contents: write
 jobs:
@@ -10,6 +13,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.release_tag }}
       # Setup .npmrc file to publish to npm
       - uses: actions/setup-node@v3
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -69,7 +69,7 @@ RUN npm run build || true # true exits with code 0 - workaround for TS errors
 # root without --no-sandbox, which we intentionally dropped from the warmup args.
 RUN ARCH="$(dpkg --print-architecture)"; \
     if [ "$ARCH" = "amd64" ] || [ "$ARCH" = "arm64" ]; then \
-      GOOGLE_SAFE_BROWSING=1 OOBEE_VERBOSE=1 SB_PROFILE_DIR=/data/chrome-profile node scripts/warmup-safe-browsing.mjs --timeout 1200000; \
+      GOOGLE_SAFE_BROWSING=1 SB_PROFILE_DIR=/data/chrome-profile node scripts/warmup-safe-browsing.mjs --timeout 1200000; \
     else \
       echo "NOTICE: Skipping Safe Browsing warmup (unsupported architecture: $ARCH)"; \
     fi

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@govtechsg/oobee",
-  "version": "0.11.3",
+  "version": "0.11.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@govtechsg/oobee",
-      "version": "0.11.3",
+      "version": "0.11.4",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1049.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@govtechsg/oobee",
   "main": "dist/npmIndex.js",
-  "version": "0.11.3",
+  "version": "0.11.4",
   "type": "module",
   "author": "Government Technology Agency <info@tech.gov.sg>",
   "bin": {

--- a/src/safeBrowsingProfile.ts
+++ b/src/safeBrowsingProfile.ts
@@ -164,14 +164,30 @@ async function spawnChromeForWarmup(): Promise<void> {
     '--no-first-run',
     '--no-default-browser-check',
     '--ignore-certificate-errors',
-    ...(process.platform === 'linux' ? ['--disable-dev-shm-usage', '--disable-gpu', '--no-zygote'] : []),
+    // Warmup only visits google.com/generate_204 to trigger a DB download into
+    // a throwaway profile — no untrusted content. --no-sandbox is safe here and
+    // is required inside BuildKit / restricted containers where Chrome's
+    // setuid/namespace sandbox can't initialise (SIGABRT during zygote setup).
+    // Runtime scanning Chrome (launched via Playwright, not this code path)
+    // keeps the sandbox on.
+    ...(process.platform === 'linux' ? ['--no-sandbox', '--disable-dev-shm-usage', '--disable-gpu'] : []),
   ];
 
+  const chromeStdio: 'ignore' | 'inherit' = SB_DEBUG ? 'inherit' : 'ignore';
+  sbDebug(`[SafeBrowsing] Spawning Chrome: ${exe}`);
+  sbDebug(`[SafeBrowsing] Chrome args: ${[...baseArgs, '--headless=new', '--disable-gpu', 'https://www.google.com/generate_204'].join(' ')}`);
   const chrome = spawn(
     exe,
     [...baseArgs, '--headless=new', '--disable-gpu', 'https://www.google.com/generate_204'],
-    { stdio: 'ignore', detached: true },
+    { stdio: chromeStdio, detached: true },
   );
+  sbDebug(`[SafeBrowsing] Chrome PID: ${chrome.pid}`);
+  chrome.on('exit', (code, signal) => {
+    consoleLogger.info(`[SafeBrowsing] Chrome exited early: code=${code} signal=${signal}`);
+  });
+  chrome.on('error', err => {
+    consoleLogger.info(`[SafeBrowsing] Chrome spawn error: ${err}`);
+  });
 
   const maxWait = DB_DOWNLOAD_TIMEOUT_MS;
   const pollInterval = 5_000;
@@ -180,7 +196,13 @@ async function spawnChromeForWarmup(): Promise<void> {
     await new Promise(r => setTimeout(r, pollInterval));
     waited += pollInterval;
     if (waited % 15_000 === 0) {
-      sbDebug(`[SafeBrowsing] Waiting for hash-prefix DB... (${waited / 1000}s)`);
+      let sbListing = '(missing)';
+      try {
+        sbListing = fs.existsSync(SB_DIR) ? fs.readdirSync(SB_DIR).join(', ') || '(empty)' : '(missing)';
+      } catch (e) {
+        sbListing = `(read error: ${e})`;
+      }
+      consoleLogger.info(`[SafeBrowsing] Waiting for hash-prefix DB... (${waited / 1000}s) SB_DIR contents: ${sbListing}`);
     }
   }
 


### PR DESCRIPTION
## Summary

- Fix the build-time Google Safe Browsing (GSB) DB warmup, which was silently timing out under Docker/BuildKit and shipping images without a pre-populated local hash-prefix database.
- Drop `--no-zygote` and add `--no-sandbox` (warmup only) so Chrome will actually launch inside restricted container build environments.
- Surface diagnostic output during the warmup — Chrome stderr (opt-in via `GOOGLE_SAFE_BROWSING_DEBUG`), spawn/exit signals, and a 15s heartbeat listing `SB_DIR` contents.
- Bump package to **0.11.4**.
- Make npm publish manual-only: drop the `release: published` auto-trigger and require an explicit `release_tag` input on `workflow_dispatch`.

## Background

The GSB warmup step in the Dockerfile (`node scripts/warmup-safe-browsing.mjs`) launches Chrome once during image build so the resulting image ships with pre-downloaded threat databases. This avoids each concurrent scan triggering its own ~10 min warmup (or fighting over the lock) at runtime.

On recent multi-arch builds this step was hanging until timeout and printing:

```
WARNING: Safe Browsing DB did not populate in 600s. Protection may be reduced.
```

Debugging revealed three overlapping problems.

## Root causes

### 1. `--no-zygote` without `--no-sandbox`

Chrome rejects this combination outright:

```
ERROR:content/app/content_main_runner_impl.cc:348] Zygote cannot be disabled
if sandbox is enabled. Use --no-zygote together with --no-sandbox
```

Chrome exits with code 1 immediately, and the poll loop then waits for a DB that will never arrive.

### 2. Chrome's sandbox can't initialise in BuildKit

Even after removing `--no-zygote`, Chrome aborts during sandbox setup:

```
ERROR:content/zygote/zygote_linux.cc:662] write: Broken pipe (32)
Chrome exited: signal=SIGABRT
```

BuildKit's build sandbox does not grant the kernel capabilities Chrome's setuid/user-namespace sandbox needs.

### 3. Chrome stderr was fully suppressed

`spawn(exe, args, { stdio: 'ignore' })` meant none of the above errors ever surfaced. The warmup appeared to hang for the entire configured timeout with no signal at all — we only saw the initial "Downloading Safe Browsing threat database..." banner.

## What this PR changes

### `src/safeBrowsingProfile.ts`

- **Drop `--no-zygote`, add `--no-sandbox` on Linux for the warmup args.** The warmup only visits `google.com/generate_204` in a throwaway profile purely to trigger a DB download. There is no untrusted content in scope, so disabling the sandbox here is a safe, targeted choice. Runtime scanning Chrome (launched by Playwright via a different code path) keeps its sandbox on.
- **Gate Chrome stdio on `GOOGLE_SAFE_BROWSING_DEBUG`.** By default we still discard Chrome stderr (avoiding noise like DBus/GCM/TensorFlow warnings during normal builds), but a single env var flip surfaces everything for future diagnosis — no code changes needed next time.
- **Add lifecycle logs regardless of debug mode:** Chrome PID on spawn, spawn errors, and early exit with code+signal. These are low-volume, high-signal.
- **Change the 15s progress log from gated `sbDebug` to unconditional `consoleLogger.info`, and include a listing of `SB_DIR`.** This distinguishes "Chrome is dead" from "Chrome is running but the DB hasn't landed yet" — key for the very first minute of a warmup where nothing else is happening.

### `Dockerfile`

- Drop `OOBEE_VERBOSE=1` from the warmup command. The new heartbeat is sufficient; the extra verbose logs are no longer needed by default.

### `package.json` / `package-lock.json`

- Version bumped `0.11.3 → 0.11.4` via `npm version 0.11.4 --no-git-tag-version`.

### `.github/workflows/publish.yml` (npm publish)

- **Removed the `release: published` trigger.** Publishing a GitHub release no longer implicitly pushes a package to npmjs. This decouples the two so a release can be cut for GHCR/Docker without triggering an npm publish.
- **Added a required `release_tag` `workflow_dispatch` input.** Operators must explicitly type the git tag/ref they want to publish (e.g. `0.11.4`). The workflow checks out that ref, so the `package.json` version at that commit is what lands on npm — no ambiguity about "which commit did this publish come from".

## Testing

Built locally on Apple Silicon (`--platform linux/arm64`) against `mcr.microsoft.com/playwright:v1.61.1-noble`:

- Before this PR: Chrome exits within ~1s with SIGABRT; warmup loops silently for the full 1200s and the image ships without a populated DB.
- After this PR: Chrome stays alive; `SB_DIR` populates within the first minute; final log line reads `Google Safe Browsing enabled (local hash-prefix DB active)`.

## Test plan

- [ ] `docker buildx build --platform linux/arm64 --load .` succeeds without hitting the warmup timeout.
- [ ] `docker buildx build --platform linux/amd64 --load .` succeeds without hitting the warmup timeout.
- [ ] `docker run --rm -e GOOGLE_SAFE_BROWSING=1 <image> ls "/data/chrome-profile/Safe Browsing"` lists `UrlSoceng.store.*` / `UrlMalware.store.*` files.
- [ ] The GHCR workflow (`.github/workflows/docker-push-ghcr.yml`) completes for a `linux/amd64,linux/arm64` build and pushes both tags.
- [ ] Setting `GOOGLE_SAFE_BROWSING_DEBUG=1` at build time surfaces Chrome stderr in the RUN log.
- [ ] Cutting a GitHub release does **not** trigger the npm publish workflow.
- [ ] Running the npm publish workflow via "Run workflow" with `release_tag: 0.11.4` publishes `@govtechsg/oobee@0.11.4` to npmjs.
