### PR TITLE
Restore native constructors before running axe

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@govtechsg/oobee",
-  "version": "0.11.4",
+  "version": "0.11.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@govtechsg/oobee",
-      "version": "0.11.4",
+      "version": "0.11.5",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1049.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@govtechsg/oobee",
   "main": "dist/npmIndex.js",
-  "version": "0.11.4",
+  "version": "0.11.5",
   "type": "module",
   "author": "Government Technology Agency <info@tech.gov.sg>",
   "bin": {

--- a/src/crawlers/commonCrawlerFunc.ts
+++ b/src/crawlers/commonCrawlerFunc.ts
@@ -875,6 +875,38 @@ export const runAxeScript = async ({
   const browserContext: BrowserContext = page.context();
   const requestUrl = page.url();
 
+  // Some pages replace native constructors (Set, Map, WeakMap, ...) with
+  // incomplete polyfills. axe-core and even Playwright's own return-value
+  // serialization use these natives internally and blow up with unhelpful
+  // errors like `r.has is not a function` or `i.forEach is not a function`.
+  // Restore pristine constructors by stealing them from a fresh same-origin
+  // iframe (whose Realm the page hasn't touched) before doing any evaluation.
+  try {
+    await page.evaluate(() => {
+      const iframe = document.createElement('iframe');
+      iframe.style.display = 'none';
+      iframe.setAttribute('aria-hidden', 'true');
+      document.documentElement.appendChild(iframe);
+      const w = iframe.contentWindow as unknown as Record<string, unknown>;
+      if (!w) return;
+      for (const name of [
+        'Set', 'Map', 'WeakSet', 'WeakMap',
+        'Array', 'Object', 'Promise', 'Symbol',
+        'Number', 'String', 'Boolean', 'RegExp', 'Date',
+        'JSON', 'Math',
+      ]) {
+        try {
+          (window as unknown as Record<string, unknown>)[name] = w[name];
+        } catch {}
+      }
+      // Intentionally leave the iframe in the DOM — removing it invalidates
+      // its Realm and the constructors we just copied become dead references.
+    });
+  } catch {
+    // Page may not be ready or the eval itself may fail on hostile pages;
+    // best effort — continue with axe injection regardless.
+  }
+
   let pageTitle: string | null = null;
   try {
     pageTitle = await page.evaluate(() => document.title);

--- a/src/crawlers/commonCrawlerFunc.ts
+++ b/src/crawlers/commonCrawlerFunc.ts
@@ -116,6 +116,17 @@ type FilteredResults = {
   axeScanFailed?: boolean;
 };
 
+// Playwright surfaces transient teardown as errors we must NOT convert into
+// axeScanFailed — rethrowing lets Crawlee's retry (maxRequestRetries) recover
+// on a fresh browser/context. Long crawls hit these on browser retirement
+// (retireBrowserAfterPageCount) and idle-close boundaries.
+const isTransientPageTeardown = (e: unknown): boolean => {
+  const msg = (e as Error)?.message ?? '';
+  return /Target (page, context or browser has been closed|closed)|Execution context was destroyed|page (has been |was )closed|Browser has been closed|Navigation failed because page (was|has been) closed/i.test(
+    msg,
+  );
+};
+
 const truncateHtml = (html: string, maxBytes = 1024, suffix = '…'): string => {
   const encoder = new TextEncoder();
   if (encoder.encode(html).length <= maxBytes) return html;
@@ -887,6 +898,7 @@ export const runAxeScript = async ({
       const iframe = document.createElement('iframe');
       iframe.style.display = 'none';
       iframe.setAttribute('aria-hidden', 'true');
+      iframe.setAttribute('data-oobee-realm-restore', '1');
       document.documentElement.appendChild(iframe);
       const w = iframe.contentWindow as unknown as Record<string, unknown>;
       if (!w) return;
@@ -997,6 +1009,12 @@ export const runAxeScript = async ({
   try {
     await playwrightUtils.injectFile(page, axeScript);
   } catch (e) {
+    if (isTransientPageTeardown(e)) {
+      consoleLogger.info(
+        `axe injection aborted (page/browser closed) for ${requestUrl}; letting Crawlee retry: ${(e as Error)?.message ?? e}`,
+      );
+      throw e;
+    }
     consoleLogger.error(`axe injection failed for ${requestUrl}: ${(e as Error)?.message ?? e}`);
     return {
       url: requestUrl,
@@ -1065,8 +1083,15 @@ export const runAxeScript = async ({
         // removed needsReview condition
         const defaultResultTypes: resultGroups[] = ['violations', 'passes', 'incomplete'];
 
+        // Exclude the realm-restore iframe (see runAxeScript preamble) so it
+        // doesn't inflate the "passed" tally with rules like aria-hidden-focus.
+        const axeContext: any = { exclude: [['[data-oobee-realm-restore]']] };
+        if (Array.isArray(selectors) && selectors.length > 0) {
+          axeContext.include = selectors;
+        }
+
         return axe
-          .run(selectors, {
+          .run(axeContext, {
             resultTypes: defaultResultTypes,
           })
           .then(async results => {
@@ -1170,6 +1195,12 @@ export const runAxeScript = async ({
     },
   );
   } catch (e) {
+    if (isTransientPageTeardown(e)) {
+      consoleLogger.info(
+        `axe.run aborted (page/browser closed) for ${requestUrl}; letting Crawlee retry: ${(e as Error)?.message ?? e}`,
+      );
+      throw e;
+    }
     consoleLogger.error(`axe.run failed for ${requestUrl}: ${(e as Error)?.message ?? e}`);
     return {
       url: requestUrl,

--- a/src/crawlers/commonCrawlerFunc.ts
+++ b/src/crawlers/commonCrawlerFunc.ts
@@ -113,6 +113,7 @@ type FilteredResults = {
   needsReview: ResultCategory;
   passed: ResultCategory;
   actualUrl?: string;
+  axeScanFailed?: boolean;
 };
 
 const truncateHtml = (html: string, maxBytes = 1024, suffix = '…'): string => {
@@ -993,9 +994,25 @@ export const runAxeScript = async ({
 
   const gradingReadabilityFlag = await extractAndGradeText(page); // Ensure flag is obtained before proceeding
 
-  await playwrightUtils.injectFile(page, axeScript);
+  try {
+    await playwrightUtils.injectFile(page, axeScript);
+  } catch (e) {
+    consoleLogger.error(`axe injection failed for ${requestUrl}: ${(e as Error)?.message ?? e}`);
+    return {
+      url: requestUrl,
+      pageTitle: pageTitle ?? requestUrl,
+      totalItems: 0,
+      mustFix: { totalItems: 0, rules: {} },
+      goodToFix: { totalItems: 0, rules: {} },
+      needsReview: { totalItems: 0, rules: {} },
+      passed: { totalItems: 0, rules: {} },
+      axeScanFailed: true,
+    };
+  }
 
-  const results = await page.evaluate(
+  let results;
+  try {
+    results = await page.evaluate(
     async ({
       selectors,
       saflyIconSelector,
@@ -1152,6 +1169,19 @@ export const runAxeScript = async ({
       xPathToCssFunctionString: xPathToCss.toString(),
     },
   );
+  } catch (e) {
+    consoleLogger.error(`axe.run failed for ${requestUrl}: ${(e as Error)?.message ?? e}`);
+    return {
+      url: requestUrl,
+      pageTitle: pageTitle ?? requestUrl,
+      totalItems: 0,
+      mustFix: { totalItems: 0, rules: {} },
+      goodToFix: { totalItems: 0, rules: {} },
+      needsReview: { totalItems: 0, rules: {} },
+      passed: { totalItems: 0, rules: {} },
+      axeScanFailed: true,
+    };
+  }
 
   await enrichViolationMessages(results, page);
   await enrichColorContrastDOMContext(results.violations, page);

--- a/src/crawlers/commonCrawlerFunc.ts
+++ b/src/crawlers/commonCrawlerFunc.ts
@@ -895,6 +895,27 @@ export const runAxeScript = async ({
   // iframe (whose Realm the page hasn't touched) before doing any evaluation.
   try {
     await page.evaluate(() => {
+      // Probe first — only pay the iframe cost when the page has actually
+      // clobbered a native collection constructor. On clean pages this is a
+      // no-op that saves ~10ms per scan.
+      try {
+        const s = new Set();
+        const m = new Map();
+        const ws = new WeakSet();
+        const wm = new WeakMap();
+        if (
+          typeof s.has === 'function' &&
+          typeof s.add === 'function' &&
+          typeof m.has === 'function' &&
+          typeof m.get === 'function' &&
+          typeof ws.has === 'function' &&
+          typeof wm.has === 'function'
+        ) {
+          return;
+        }
+      } catch {
+        // fall through to restore
+      }
       const iframe = document.createElement('iframe');
       iframe.style.display = 'none';
       iframe.setAttribute('aria-hidden', 'true');

--- a/src/crawlers/crawlDomain.ts
+++ b/src/crawlers/crawlDomain.ts
@@ -698,6 +698,21 @@ const crawlDomain = async ({
 
             const results = await runAxeScript({ includeScreenshots, page, randomToken, ruleset });
 
+            if (results.axeScanFailed) {
+              guiInfoLog(guiInfoStatusTypes.ERROR, {
+                numScanned: urlsCrawled.scanned.length,
+                urlScanned: request.url,
+              });
+              urlsCrawled.error.push({
+                url: request.url,
+                pageTitle: results.pageTitle,
+                actualUrl,
+                metadata: STATUS_CODE_METADATA[2],
+                httpStatusCode: 2,
+              });
+              return;
+            }
+
             await capturePageData(page, actualUrl, randomToken);
 
             // Detect JS redirects that fire during/after axe scan.

--- a/src/crawlers/crawlLocalFile.ts
+++ b/src/crawlers/crawlLocalFile.ts
@@ -188,6 +188,22 @@ export const crawlLocalFile = async ({
 
     const actualUrl = page.url() || request.loadedUrl || url;
 
+    if (results.axeScanFailed) {
+      guiInfoLog(guiInfoStatusTypes.ERROR, {
+        numScanned: urlsCrawled.scanned.length,
+        urlScanned: url,
+      });
+      urlsCrawled.error.push({
+        url,
+        pageTitle: results.pageTitle,
+        actualUrl,
+        metadata: STATUS_CODE_METADATA[2],
+        httpStatusCode: 2,
+      });
+      await browserContext.close().catch(() => {});
+      return { urlsCrawled, durationExceeded };
+    }
+
     await capturePageData(page, actualUrl, randomToken);
 
     guiInfoLog(guiInfoStatusTypes.SCANNED, {

--- a/src/crawlers/crawlSitemap.ts
+++ b/src/crawlers/crawlSitemap.ts
@@ -401,6 +401,21 @@ const crawlSitemap = async ({
 
             const results = await runAxeScript({ includeScreenshots, page, randomToken, ruleset });
 
+            if (results.axeScanFailed) {
+              guiInfoLog(guiInfoStatusTypes.ERROR, {
+                numScanned: urlsCrawled.scanned.length,
+                urlScanned: request.url,
+              });
+              urlsCrawled.error.push({
+                url: request.url,
+                pageTitle: results.pageTitle,
+                actualUrl,
+                metadata: STATUS_CODE_METADATA[2],
+                httpStatusCode: 2,
+              });
+              return;
+            }
+
             await capturePageData(page, actualUrl, randomToken);
 
             // Detect JS redirects that fire during/after axe scan.

--- a/src/crawlers/custom/utils.ts
+++ b/src/crawlers/custom/utils.ts
@@ -6,7 +6,7 @@ import { getDomain } from 'tldts';
 import { runAxeScript } from '../commonCrawlerFunc.js';
 import { capturePageData } from '../pageCapture.js';
 import { consoleLogger, guiInfoLog, silentLogger } from '../../logs.js';
-import { guiInfoStatusTypes } from '../../constants/constants.js';
+import { guiInfoStatusTypes, STATUS_CODE_METADATA } from '../../constants/constants.js';
 import { isSkippedUrl, validateCustomFlowLabel } from '../../constants/common.js';
 
 declare global {
@@ -159,6 +159,21 @@ export const runAxeScan = async (
   urlsCrawled,
 ) => {
   const result = await runAxeScript({ includeScreenshots, page, randomToken, customFlowDetails });
+
+  if (result.axeScanFailed) {
+    guiInfoLog(guiInfoStatusTypes.ERROR, {
+      numScanned: urlsCrawled.scanned.length,
+      urlScanned: page.url(),
+    });
+    urlsCrawled.error.push({
+      url: page.url(),
+      pageTitle: result.pageTitle,
+      actualUrl: page.url(),
+      metadata: STATUS_CODE_METADATA[2],
+      httpStatusCode: 2,
+    });
+    return;
+  }
 
   await capturePageData(page, page.url(), randomToken);
 


### PR DESCRIPTION
# Restore native constructors before running axe

## Summary
- Some pages replace built-in constructors like `Set`, `Map`, `WeakMap` with incomplete polyfills. axe-core (and Playwright's own return-value serialization) rely on these natives internally, so on such pages `axe.run()` throws `TypeError: r.has is not a function` from minified internals and the page is scanned with zero results.
- As a runner-side workaround, `runAxeScript` now steals pristine constructors from a fresh same-origin iframe (whose Realm the page hasn't touched) before any `page.evaluate` or axe injection.
- Iframe is intentionally left in the DOM — removing it invalidates its Realm and the copied constructors become dead references. It's `display:none` + `aria-hidden`, so axe skips it.
- The restore is **gated behind a probe** — a page that still has functional `Set`/`Map`/`WeakSet`/`WeakMap` (i.e. every clean page) skips the iframe injection entirely. Only pages that fail the probe pay for the restore.

## Background
On a real-world page, `axe.run()` failed with:

```
page.evaluate: TypeError: r.has is not a function
    at eval (eval at evaluate (:303:30), <anonymous>:12:1433)
    at ee (eval at evaluate (:303:30), <anonymous>:12:1644)
    ...
```

`r.has is not a function` means axe-core constructed what it expected to be a native `Set`/`Map` and called `.has(...)` on the result, but the page had replaced the constructor with a shim that lacks that method. Corroborating symptom on the same page: an unrelated `page.evaluate` returning a plain array literal came back as `undefined` on the Node side — Playwright's own serialization was also tripping over the polluted globals.

Reduced repro (also fixed by this PR):

```html
<script>
  window.Set = function BadSet() { return Object.create(null); };
</script>
<script src="https://unpkg.com/axe-core/axe.min.js"></script>
<script>
  axe.run().then(r => console.log('OK', r), e => console.error('FAIL', e));
</script>
```

## Probe-gated restore
Before injecting the iframe, an in-page probe constructs `new Set()`, `new Map()`, `new WeakSet()`, `new WeakMap()` and checks that `.has`/`.add`/`.get` are still functions. On clean pages this returns immediately — no iframe, no DOM mutation, no constructor swap. Only when the probe throws or reports a missing method does the restore run. This keeps per-page overhead to a single fast `page.evaluate` on healthy pages.

## Excluding the restore iframe from axe results
Even though the iframe is `display:none` + `aria-hidden`, axe still audits it for structural rules like `aria-hidden-focus` and records a *pass* against it. Verified by scanning the same minimal page with and without the iframe injected: passes went from 13 → 14, with the extra entry targeting `iframe`. To keep the "passed elements" tally faithful to the real page, the iframe is tagged with `data-oobee-realm-restore="1"` and axe is invoked with `{ exclude: [['[data-oobee-realm-restore]']] }`. After the fix, passes match baseline exactly and no result references the iframe.

## Fail-fast on unrecoverable axe failures
If the iframe restore doesn't help (page re-clobbers globals, hostile CSP prevents the steal, injection itself fails), `runAxeScript` no longer throws into Crawlee's retry loop. Instead it returns a sentinel `{ axeScanFailed: true, ... }` and each caller (`crawlDomain`, `crawlSitemap`, `crawlLocalFile`, `custom/utils`) records the URL as **Web Crawler Errored** (`STATUS_CODE_METADATA[2]`) with `guiInfoLog(ERROR, ...)` and returns without pushing to the dataset. This avoids:
- 3 wasted Crawlee retries on deterministic axe failures
- silent "scanned with 0 results" entries that hide the failure
- duplicate URL entries in `urlsCrawled.error` vs `urlsCrawled.scanned` when retries race

## Distinguish transient browser teardown from real axe failures
Playwright surfaces long-crawl teardown as errors like `Target page, context or browser has been closed` and `Execution context was destroyed`. These are triggered by `retireBrowserAfterPageCount` (500), idle-close timers, and per-request timeouts — they're not axe failures, and a retry on a fresh browser usually succeeds.

The initial hardening above caught these alongside real axe failures, so a URL that would previously have been retried and passed was permanently recorded as "Web Crawler Errored". This was reproducible on `cpf.gov.sg` sitemap crawls (~954 URLs): two article URLs consistently failed only under load, with the log line `axe.run failed for <url>: page.evaluate: Target page, context or browser has been closed`. Scanned in isolation, the same URLs passed.

Fix: both catch blocks in `runAxeScript` now check `isTransientPageTeardown(e)` and **rethrow** matching errors so Crawlee's `maxRequestRetries: 3` can retry on a fresh browser. Only genuine axe failures on a still-alive page are converted into `axeScanFailed`.

## Test plan
- [ ] `test.html` reproducer (which overrides `window.Set` with a broken shim) scans successfully instead of failing with `TypeError: i.forEach is not a function`
- [ ] Real-world page that previously reported "No pages were scanned" now produces axe results
- [ ] Existing scans against clean pages produce identical results (no new violations from the hidden iframe, and the iframe isn't injected at all — verified via DOM inspection)
- [ ] A page that still fails axe post-fix is reported as "Web Crawler Errored" in the summary, not silently skipped
- [ ] Full `cpf.gov.sg` sitemap crawl completes with the two previously-failing article URLs scanned successfully (no `Target page, context or browser has been closed` errors surfaced as "Web Crawler Errored")

## Risks
- `instanceof` checks against the page's original constructors won't match objects we create — low impact since axe doesn't hand values back to the page.
- The iframe stays in the DOM permanently (removing it invalidates the Realm). It's `display:none` + `aria-hidden`, so axe should skip it, but worth spot-checking clean pages.
- If the offending page re-clobbers globals *after* our patch (e.g. lazy-loaded scripts), axe will fail again on the same page load — but now the page is recorded as "Web Crawler Errored" rather than silently returning 0 results.
