### PR TITLE
fix: parse embedded userinfo from proxy env URLs

### DIFF
--- a/src/proxyService.ts
+++ b/src/proxyService.ts
@@ -53,6 +53,42 @@ export type ProxyResolution =
 function stripScheme(u: string): string {
   return u.replace(/^[a-zA-Z][a-zA-Z0-9+.-]*:\/\//, '');
 }
+/**
+ * Extract userinfo (username/password) from a proxy URL value.
+ * Accepts either full URL ("http://user:pass@host:port") or scheme-less ("user:pass@host:port").
+ * Returns the value with userinfo removed (scheme preserved if present) plus decoded creds.
+ * Playwright's proxy.server option rejects embedded credentials, so they must be split out.
+ */
+function splitUserinfo(value: string): {
+  value: string;
+  username?: string;
+  password?: string;
+} {
+  if (!value) return { value };
+  const schemeMatch = value.match(/^([a-zA-Z][a-zA-Z0-9+.-]*:\/\/)(.*)$/);
+  const scheme = schemeMatch ? schemeMatch[1] : '';
+  const rest = schemeMatch ? schemeMatch[2] : value;
+
+  // userinfo ends at the first '@' before any '/'
+  const pathStart = rest.indexOf('/');
+  const searchEnd = pathStart === -1 ? rest.length : pathStart;
+  const atIdx = rest.lastIndexOf('@', searchEnd - 1);
+  if (atIdx === -1) return { value };
+
+  const userinfo = rest.slice(0, atIdx);
+  const remainder = rest.slice(atIdx + 1);
+  const colonIdx = userinfo.indexOf(':');
+  const rawUser = colonIdx === -1 ? userinfo : userinfo.slice(0, colonIdx);
+  const rawPass = colonIdx === -1 ? '' : userinfo.slice(colonIdx + 1);
+
+  const decode = (s: string) => {
+    try { return decodeURIComponent(s); } catch { return s; }
+  };
+  const username = rawUser ? decode(rawUser) : undefined;
+  const password = rawPass ? decode(rawPass) : undefined;
+
+  return { value: `${scheme}${remainder}`, username, password };
+}
 function semiJoin(arr?: string[]): string | undefined {
   if (!arr) return undefined;
   const cleaned = arr.map(s => s.trim()).filter(Boolean);
@@ -88,13 +124,36 @@ function parseEnvProxyCommon(): ProxyInfo | null {
   const noProxy = process.env.NO_PROXY || process.env.no_proxy || '';
 
   const info: ProxyInfo = {};
-  if (http) info.http = stripScheme(http);
-  if (https) info.https = stripScheme(https);
-  if (socks) info.socks = socks; // keep original scheme so proxyInfoToResolution can use the right protocol
+  // Collect creds embedded in URL userinfo; env vars still win over them below.
+  let urlUser: string | undefined;
+  let urlPass: string | undefined;
+  const captureCreds = (u?: string, p?: string) => {
+    if (u && !urlUser) urlUser = u;
+    if (p && !urlPass) urlPass = p;
+  };
+
+  if (http) {
+    const parsed = splitUserinfo(http);
+    captureCreds(parsed.username, parsed.password);
+    info.http = stripScheme(parsed.value);
+  }
+  if (https) {
+    const parsed = splitUserinfo(https);
+    captureCreds(parsed.username, parsed.password);
+    info.https = stripScheme(parsed.value);
+  }
+  if (socks) {
+    const parsed = splitUserinfo(socks);
+    captureCreds(parsed.username, parsed.password);
+    info.socks = parsed.value; // keep original scheme so proxyInfoToResolution can use the right protocol
+  }
   if (noProxy) info.bypassList = semiJoin(noProxy.split(/[,;]/));
 
   const { username, password } = readCredsFromEnv();
-  if (username && password) { info.username = username; info.password = password; }
+  const finalUser = username || urlUser;
+  const finalPass = password || urlPass;
+  if (finalUser) info.username = finalUser;
+  if (finalPass) info.password = finalPass;
 
   return (info.http || info.https || info.socks || info.bypassList) ? info : null;
 }


### PR DESCRIPTION
HTTP_PROXY, HTTPS_PROXY, and ALL_PROXY of the form "scheme://user:pass@host:port" were passed to Playwright with credentials still embedded in proxy.server, which Playwright rejects. Extract userinfo into separate username/password fields (URL-decoded) so Playwright receives proxy auth correctly. Env-var creds (PROXY_USERNAME/PROXY_PASSWORD) still take precedence over URL-embedded creds.

This PR adds... <!-- A brief description of what your PR does -->

<!-- This checklist is just a guideline.-->
<!-- If any of the following does not apply to your PR, please leave them unchecked and explain in the PR -->

- [ ] I've kept this PR as small as possible (~500 lines) by splitting it into PRs with manageable chunks of code
- [ ] I've requested reviews from 1 reviewer
- [ ] I've tested existing features (website scan, sitemap, custom flow) in both node index and cli
- [ ] I've synced this fork with GovTechSG repo
- [ ] I've added/updated unit tests
- [ ] I've added/updated any necessary dependencies in `package[-lock].json` `npm audit`, portable installation on GitHub Actions
