### PR TITLE
Add Trivy container scan workflow and remediate image CVEs

### DIFF
--- a/.github/workflows/docker-trivy-scan.yml
+++ b/.github/workflows/docker-trivy-scan.yml
@@ -51,7 +51,7 @@ jobs:
           output: trivy-report.txt
           severity: CRITICAL,HIGH,MEDIUM,LOW
           exit-code: '0'
-          ignore-unfixed: false
+          ignore-unfixed: true
           vuln-type: os,library
 
       - name: Run Trivy vulnerability scan (SARIF)
@@ -62,7 +62,7 @@ jobs:
           output: trivy-report.sarif
           severity: CRITICAL,HIGH,MEDIUM,LOW
           exit-code: '0'
-          ignore-unfixed: false
+          ignore-unfixed: true
           vuln-type: os,library
 
       - name: Publish Trivy report to job summary

--- a/.github/workflows/docker-trivy-scan.yml
+++ b/.github/workflows/docker-trivy-scan.yml
@@ -44,7 +44,7 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Run Trivy vulnerability scan (table report)
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@v0.35.0
         with:
           image-ref: ${{ steps.repo.outputs.name }}:${{ env.RELEASE_TAG }}
           format: table
@@ -55,7 +55,7 @@ jobs:
           vuln-type: os,library
 
       - name: Run Trivy vulnerability scan (SARIF)
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@v0.35.0
         with:
           image-ref: ${{ steps.repo.outputs.name }}:${{ env.RELEASE_TAG }}
           format: sarif

--- a/.github/workflows/docker-trivy-scan.yml
+++ b/.github/workflows/docker-trivy-scan.yml
@@ -65,6 +65,38 @@ jobs:
           ignore-unfixed: false
           vuln-type: os,library
 
+      - name: Publish Trivy report to job summary
+        if: always()
+        run: |
+          if [ ! -f trivy-report.txt ]; then
+            echo "No Trivy report was generated." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          # Severity counts, derived by grepping the fixed-width Severity column
+          # of the trivy table report. Fragile if the table format changes, but
+          # good enough for an at-a-glance summary.
+          count() { grep -c "│ $1 " trivy-report.txt || true; }
+          {
+            echo "## Trivy vulnerability scan"
+            echo ""
+            echo "Image: \`${{ steps.repo.outputs.name }}:${{ env.RELEASE_TAG }}\`"
+            echo ""
+            echo "| Severity | Count |"
+            echo "|----------|-------|"
+            echo "| CRITICAL | $(count 'CRITICAL') |"
+            echo "| HIGH     | $(count 'HIGH    ') |"
+            echo "| MEDIUM   | $(count 'MEDIUM  ') |"
+            echo "| LOW      | $(count 'LOW     ') |"
+            echo ""
+            echo "<details><summary>Full vulnerability table (click to expand)</summary>"
+            echo ""
+            echo '```'
+            cat trivy-report.txt
+            echo '```'
+            echo ""
+            echo "</details>"
+          } >> "$GITHUB_STEP_SUMMARY"
+
       - name: Upload Trivy report artifact
         if: always()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/docker-trivy-scan.yml
+++ b/.github/workflows/docker-trivy-scan.yml
@@ -1,0 +1,76 @@
+name: Docker Trivy Scan
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: 'Tag to label the scanned image (e.g. 0.10.87)'
+        required: false
+        default: 'scan'
+        type: string
+  pull_request:
+    branches: [master]
+  push:
+    branches: [master]
+
+permissions:
+  contents: read
+
+jobs:
+  build-and-scan:
+    runs-on: ubuntu-24.04-arm
+    env:
+      RELEASE_TAG: ${{ inputs.release_tag || github.sha }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Lowercase repository name
+        id: repo
+        run: echo "name=${GITHUB_REPOSITORY,,}" >> "$GITHUB_OUTPUT"
+
+      - name: Build image (load, no push)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/arm64
+          push: false
+          load: true
+          tags: ${{ steps.repo.outputs.name }}:${{ env.RELEASE_TAG }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Run Trivy vulnerability scan (table report)
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          image-ref: ${{ steps.repo.outputs.name }}:${{ env.RELEASE_TAG }}
+          format: table
+          output: trivy-report.txt
+          severity: CRITICAL,HIGH,MEDIUM,LOW
+          exit-code: '0'
+          ignore-unfixed: false
+          vuln-type: os,library
+
+      - name: Run Trivy vulnerability scan (SARIF)
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          image-ref: ${{ steps.repo.outputs.name }}:${{ env.RELEASE_TAG }}
+          format: sarif
+          output: trivy-report.sarif
+          severity: CRITICAL,HIGH,MEDIUM,LOW
+          exit-code: '0'
+          ignore-unfixed: false
+          vuln-type: os,library
+
+      - name: Upload Trivy report artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: trivy-report-${{ env.RELEASE_TAG }}
+          path: |
+            trivy-report.txt
+            trivy-report.sarif
+          retention-days: 30

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,7 +52,7 @@ RUN apt-get update && \
       'libde265-0' 'libopenexr*' 'libwavpack*' \
       'libx264-*' 'libvo-amrwbenc*' 'libopenh264-*' \
       'libzvbi0*' 'libsndfile1' \
-      'libsoup-3.0-*' 'libavahi-*' 'libduktape*' \
+      'libsoup-3.0-*' 'libduktape*' \
       || true; \
     rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,9 +49,9 @@ RUN apt-get update && \
       'libavcodec*' 'libavformat*' 'libavfilter*' 'libavutil*' \
       'libswresample*' 'libswscale*' 'libpostproc*' \
       'gstreamer1.0-plugins-bad' \
-      'libde265-0' 'libopenexr-3-1-30' 'libwavpack1' \
-      'libx264-164' 'libvo-amrwbenc0' 'libopenh264-8' \
-      'libzvbi0t64' 'libsndfile1' \
+      'libde265-0' 'libopenexr*' 'libwavpack*' \
+      'libx264-*' 'libvo-amrwbenc*' 'libopenh264-*' \
+      'libzvbi0*' 'libsndfile1' \
       || true; \
     rm -rf /var/lib/apt/lists/*
 
@@ -65,6 +65,11 @@ RUN npm install -g npm@latest && npm cache clean --force
 # Environment variables for node and Playwright
 ENV NODE_ENV=production
 ENV PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD="true"
+# npm >=12 changed the default of `allow-git` from "all" to "none" as a
+# hardening. Oobee has one legitimate git dep (pdfjs-dist -> veraPDF fork), so
+# opt back in with "root" — only git deps declared in this project's own
+# package.json are permitted; transitive git deps remain blocked.
+ENV NPM_CONFIG_ALLOW_GIT=root
 
 # Add non-privileged user before app copy so ownership can be set during COPY.
 # Also pre-create the Safe Browsing profile directory owned by `purple` so the

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,10 +48,11 @@ RUN apt-get update && \
     apt-get purge -y --auto-remove \
       'libavcodec*' 'libavformat*' 'libavfilter*' 'libavutil*' \
       'libswresample*' 'libswscale*' 'libpostproc*' \
-      'gstreamer1.0-plugins-bad' \
+      'libgstreamer-plugins-bad*' 'gstreamer1.0-plugins-bad*' \
       'libde265-0' 'libopenexr*' 'libwavpack*' \
       'libx264-*' 'libvo-amrwbenc*' 'libopenh264-*' \
       'libzvbi0*' 'libsndfile1' \
+      'libsoup-3.0-*' 'libavahi-*' 'libduktape*' \
       || true; \
     rm -rf /var/lib/apt/lists/*
 
@@ -87,6 +88,14 @@ USER purple
 # Install dependencies first (cached unless package.json/package-lock.json change)
 COPY --chown=purple:purple package.json package-lock.json ./
 RUN npm install --omit=dev
+
+# git is only needed at build time to resolve the pdfjs-dist git dependency
+# above. Removing it after `npm install` drops CVE-2024-52005 (sideband payload)
+# without affecting runtime — oobee does not shell out to git.
+USER root
+RUN apt-get purge -y --auto-remove git git-man || true; \
+    rm -rf /var/lib/apt/lists/*
+USER purple
 
 # Install Playwright browsers no longer needed since we are using Google Chrome for Safe Browsing
 # RUN npx playwright install chromium

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,11 @@
 FROM mcr.microsoft.com/playwright:v1.61.1-noble
 
 
-# Installation of packages for oobee
-RUN apt-get update && apt-get install -y --no-install-recommends \
+# Installation of packages for oobee.
+# Also upgrade all pre-installed packages from the Playwright base image to pick
+# up security fixes available in the Ubuntu archive (remediates the bulk of
+# category-A CVEs surfaced by Trivy).
+RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
     git \
     unzip \
     zip \
@@ -32,6 +35,30 @@ RUN ARCH="$(dpkg --print-architecture)"; \
     else \
       echo "NOTICE: Skipping Chrome install (Safe Browsing unavailable on $ARCH)"; \
     fi
+
+# =============================================================================
+# Purge unused media / codec stacks pulled in by the Playwright base image.
+# Oobee scans with Chrome (bundled codecs) and does not use Playwright's video
+# recorder or ffmpeg pipeline, so these libraries are dead weight and account
+# for roughly half of the CVEs surfaced by Trivy (incl. the sole HIGH from
+# gstreamer-plugins-bad, CVE-2025-3887). "|| true" so a missing package on a
+# future base image bump doesn't fail the build.
+# =============================================================================
+RUN apt-get update && \
+    apt-get purge -y --auto-remove \
+      'libavcodec*' 'libavformat*' 'libavfilter*' 'libavutil*' \
+      'libswresample*' 'libswscale*' 'libpostproc*' \
+      'gstreamer1.0-plugins-bad' \
+      'libde265-0' 'libopenexr-3-1-30' 'libwavpack1' \
+      'libx264-164' 'libvo-amrwbenc0' 'libopenh264-8' \
+      'libzvbi0t64' 'libsndfile1' \
+      || true; \
+    rm -rf /var/lib/apt/lists/*
+
+# Update system npm to the latest release. The bundled npm under
+# /usr/lib/node_modules/npm ships older copies of tar, undici, brace-expansion,
+# and sigstore that Trivy flags; upgrading npm replaces all of them in one shot.
+RUN npm install -g npm@latest && npm cache clean --force
 
 # --- App code (changes here don't invalidate Chrome layers above) ---
 


### PR DESCRIPTION
## Summary

Adds a Trivy vulnerability scan pipeline for the Docker image and reworks the
Dockerfile to remediate the majority of findings the scan surfaces.

## What changed

### New workflow: `.github/workflows/docker-trivy-scan.yml`

- Runs on `push`/`pull_request` against `master` and via `workflow_dispatch`.
- Executes on the native `ubuntu-24.04-arm` runner (no QEMU emulation) since
  production images are pulled on arm64 hosts.
- Builds the image locally (`push: false`, `load: true`), scans it with
  `aquasecurity/trivy-action@v0.35.0`, and uploads both a human-readable
  `trivy-report.txt` and a `trivy-report.sarif` as workflow artifacts with a
  30-day retention.
- Publishes results directly to the GitHub Actions job summary: a small
  severity-count table (CRITICAL / HIGH / MEDIUM / LOW) followed by the full
  vulnerability table inside a collapsible `<details>` block, so reviewers
  can see the counts at a glance from the run page without downloading the
  artifact.
- Report is generated but never gates the build (`exit-code: '0'`) — the intent
  is visibility, not blocking merges.

### Dockerfile remediations

Baseline scan against `mcr.microsoft.com/playwright:v1.61.1-noble` returned
**576 Ubuntu CVEs + 18 Node CVEs**. The changes below target the fixable and
purgeable portions of that tail.

1. **`apt-get upgrade -y`** — pulls in every noble-updates / noble-security fix
   available in the Ubuntu archive at build time. Single-line change,
   remediates the bulk of "fix available" category-A CVEs.

2. **Purge unused media / codec stacks.** Playwright's base image ships the
   full ffmpeg + gstreamer-bad + libx264 + libopenh264 + libde265 + libopenexr
   + libwavpack + libzvbi + libsndfile stack for its video-recording feature.
   Oobee scans with Chrome (which brings its own bundled codecs) and never
   uses Playwright's recorder, so these are dead weight. This alone removes
   roughly half of the reported CVEs, including the sole HIGH
   (`CVE-2025-3887` in `libgstreamer-plugins-bad1.0-0`).

3. **Purge unused desktop / networking stacks.** `libsoup-3.0-*` (10 CVEs)
   and `libduktape*` (1 CVE) are pulled in by GTK/GNOME transitive deps but
   not used by headless Chrome. Purge is guarded with `|| true` so a future
   base-image rename does not fail the build. **`libavahi-*` was
   deliberately left in place**: it is a hard runtime dependency of
   `libcups2t64` (CUPS's client library for print preview), which is in
   turn loaded by both Google Chrome and Playwright's Chromium at launch —
   purging avahi cascaded via `--auto-remove` and removed libcups too,
   crashing both browsers with `error while loading shared libraries:
   libcups.so.2`. The three avahi CVEs left behind are unfixed upstream
   anyway.

4. **Update system npm to latest.** The bundled npm under
   `/usr/lib/node_modules/npm` ships older copies of `tar`, `undici`,
   `brace-expansion`, and `sigstore` that Trivy flags. Upgrading the system
   npm replaces all of them in one shot. `NPM_CONFIG_ALLOW_GIT=root` is set
   to re-enable git dependency fetching for the project's own `pdfjs-dist`
   dep after npm 12 flipped the default to `none`.

5. **Purge `git` after `npm install --omit=dev`.** `git` is only needed at
   build time to resolve the `pdfjs-dist` git URL. Removing it post-install
   drops `CVE-2024-52005` without affecting runtime — oobee does not shell
   out to git.

The app-level `brace-expansion: ^5.0.7` override in `package.json` was
already present, so no `package.json` change is required.

## What is NOT fixed (and hidden from the report)

Roughly 60 CVEs remain with `Status: affected` and empty `Fixed Version` —
packages where Ubuntu has not yet released a patch (`glibc`, `util-linux`,
`systemd`, `libpixman`, `libcairo*`, `libexpat1`, `libgcrypt20`, `libicu74`,
`libharfbuzz*`, `libp11-kit0`, `libelf1t64`, etc.). Verified against Ubuntu
Security Tracker — both `noble` (24.04) and `resolute` (26.04) are marked
vulnerable for the representative util-linux CVE, so a base-image bump would
not remove them either.

The workflow sets `ignore-unfixed: true` on both Trivy scan steps so these
rows are suppressed from the report. This is a Trivy shorthand for
`--ignore-status affected,will_not_fix,fix_deferred,end_of_life` — the
report now only shows CVEs where there is an actionable fix version to
upgrade to. If upstream releases patches later, they will re-appear
automatically.

## Test plan

- [ ] `docker-trivy-scan.yml` runs green on this PR
- [ ] Job summary panel on the workflow run shows the severity-count table
      and the collapsible full vulnerability table renders correctly
- [ ] Downloaded `trivy-report.txt` artifact no longer contains
      `CVE-2025-3887` (gstreamer-plugins-bad HIGH)
- [ ] Downloaded `trivy-report.txt` artifact no longer contains any row for
      `libsoup-3.0-*`, `libavahi-*`, `libduktape*`, `git`, `git-man`, or any
      `libav*` / `libsw*` / `libx264*` / `libopenh264*` / `libopenexr*` /
      `libwavpack*` / `libzvbi*` / `libsndfile*` package
- [ ] Total CVE count materially lower than the ~594 baseline
- [x] Image still runs a normal oobee scan end-to-end (Chrome launches,
      Safe Browsing warmup succeeds, TypeScript build completes) — verified
      locally against `https://www.tech.gov.sg`
- [ ] `docker-push-ghcr.yml` still succeeds on next release (unchanged in
      this PR, but verifies the Dockerfile changes are multi-arch clean)
