### PR TITLE
fix: make `waitForPageLoaded` actually wait for the DOM to be ready

### DIFF
--- a/src/constants/common.ts
+++ b/src/constants/common.ts
@@ -2307,7 +2307,7 @@ export const getPlaywrightLaunchOptions = (browser?: string): LaunchOptions => {
   return options;
 };
 
-export const waitForPageLoaded = async (page: Page, timeout = 10000) => {
+export const waitForPageLoaded = async (page: Page, timeout = 30000) => {
   const OBSERVER_TIMEOUT = timeout; // Ensure observer timeout does not exceed the main timeout
 
   return Promise.race([

--- a/src/constants/common.ts
+++ b/src/constants/common.ts
@@ -2311,9 +2311,7 @@ export const waitForPageLoaded = async (page: Page, timeout = 10000) => {
   const OBSERVER_TIMEOUT = timeout; // Ensure observer timeout does not exceed the main timeout
 
   return Promise.race([
-    // Intentionally NOT racing page.waitForLoadState('load'): on JS-heavy
-    // sites the `load` event fires before hydration/SPA rendering, and
-    // Promise.race would resolve prematurely against a half-built DOM.
+    page.waitForLoadState('load'), // Ensure page load completes
     page.waitForLoadState('networkidle'), // Wait for network requests to settle
     new Promise(resolve => setTimeout(resolve, timeout)), // Hard timeout as a fallback
     page.evaluate(OBSERVER_TIMEOUT => {

--- a/src/constants/common.ts
+++ b/src/constants/common.ts
@@ -2307,7 +2307,7 @@ export const getPlaywrightLaunchOptions = (browser?: string): LaunchOptions => {
   return options;
 };
 
-export const waitForPageLoaded = async (page: Page, timeout = 30000) => {
+export const waitForPageLoaded = async (page: Page, timeout = 10000) => {
   const OBSERVER_TIMEOUT = timeout; // Ensure observer timeout does not exceed the main timeout
 
   return Promise.race([

--- a/src/constants/common.ts
+++ b/src/constants/common.ts
@@ -2311,7 +2311,9 @@ export const waitForPageLoaded = async (page: Page, timeout = 30000) => {
   const OBSERVER_TIMEOUT = timeout; // Ensure observer timeout does not exceed the main timeout
 
   return Promise.race([
-    page.waitForLoadState('load'), // Ensure page load completes
+    // Intentionally NOT racing page.waitForLoadState('load'): on JS-heavy
+    // sites the `load` event fires before hydration/SPA rendering, and
+    // Promise.race would resolve prematurely against a half-built DOM.
     page.waitForLoadState('networkidle'), // Wait for network requests to settle
     new Promise(resolve => setTimeout(resolve, timeout)), // Hard timeout as a fallback
     page.evaluate(OBSERVER_TIMEOUT => {

--- a/src/constants/common.ts
+++ b/src/constants/common.ts
@@ -2332,10 +2332,10 @@ export const waitForPageLoaded = async (page: Page, timeout = 10000) => {
         let timeout: NodeJS.Timeout;
         let mutationCount = 0;
         const MAX_MUTATIONS = 500;
-        const mutationHash: Record<string, number> = {};
+        const NOVELTY_THRESHOLD = 3;
+        const signatureCounts = new WeakMap<Element, Map<string, number>>();
 
         const observer = new MutationObserver(mutationsList => {
-          clearTimeout(timeout);
           mutationCount++;
           if (mutationCount > MAX_MUTATIONS) {
             observer.disconnect();
@@ -2343,27 +2343,37 @@ export const waitForPageLoaded = async (page: Page, timeout = 10000) => {
             return;
           }
 
+          // Only reset the quiet timer for novel mutations. Repeated mutations on
+          // the same (element, attribute) — e.g. a dropdown flipping class during
+          // page init — are treated as churn, not as a signal the DOM is still
+          // loading. See related discussion for background.
+          let sawNovel = false;
           for (const mutation of mutationsList) {
-            if (mutation.target instanceof Element) {
-              for (const attr of Array.from(mutation.target.attributes)) {
-                const key = `${mutation.target.nodeName}-${attr.name}`;
-                mutationHash[key] = (mutationHash[key] || 0) + 1;
-                if (mutationHash[key] >= 10) {
-                  observer.disconnect();
-                  resolve(`Repeated mutation detected for ${key}, exiting.`);
-                  return;
-                }
-              }
+            if (!(mutation.target instanceof Element)) continue;
+            const key =
+              mutation.type === 'attributes'
+                ? `attr:${mutation.attributeName}`
+                : mutation.type;
+            let perElement = signatureCounts.get(mutation.target);
+            if (!perElement) {
+              perElement = new Map<string, number>();
+              signatureCounts.set(mutation.target, perElement);
             }
+            const count = (perElement.get(key) || 0) + 1;
+            perElement.set(key, count);
+            if (count <= NOVELTY_THRESHOLD) sawNovel = true;
           }
 
+          if (!sawNovel) return;
+
+          clearTimeout(timeout);
           timeout = setTimeout(() => {
             observer.disconnect();
             resolve('DOM stabilized after mutations.');
           }, 1000);
         });
 
-        // Final timeout to avoid infinite waiting
+        // Initial timeout: fires if the page never mutates.
         timeout = setTimeout(() => {
           observer.disconnect();
           resolve('Observer timeout reached, exiting.');

--- a/src/constants/common.ts
+++ b/src/constants/common.ts
@@ -2307,86 +2307,106 @@ export const getPlaywrightLaunchOptions = (browser?: string): LaunchOptions => {
   return options;
 };
 
-export const waitForPageLoaded = async (page: Page, timeout = 10000) => {
-  const OBSERVER_TIMEOUT = timeout; // Ensure observer timeout does not exceed the main timeout
+export const waitForPageLoaded = async (page: Page) => {
+  // Budgets are stacked (load, then stability), not shared, so a slow-loading
+  // page still gets a fresh window to hydrate. Overridable via env vars for
+  // environments with CPU contention (e.g. busy Docker containers) where the
+  // defaults may be too tight.
+  const loadTimeout      = Number(process.env.OOBEE_LOAD_TIMEOUT_MS)      || 10000;
+  const stabilityTimeout = Number(process.env.OOBEE_STABILITY_TIMEOUT_MS) || 5000;
+  const quietMs          = Number(process.env.OOBEE_QUIET_MS)             || 750;
 
+  // Phase 1 — wait for the `load` event (or its own hard deadline).
+  //
+  // Previously `load` was raced against the mutation observer inside a single
+  // Promise.race, which meant `load` almost always won and the observer never
+  // got to see hydration mutations. That produced intermittent findings like
+  // aria-required-children on tablists whose role="tab" children are injected
+  // client-side after load.
+  await Promise.race([
+    page.waitForLoadState('load').catch(() => {}),
+    new Promise(resolve => setTimeout(resolve, loadTimeout)),
+  ]);
+
+  // Phase 2 — wait for the DOM to stabilize OR networkidle OR the stability
+  // budget. This is the window that closes hydration-timing false positives.
   return Promise.race([
-    page.waitForLoadState('load'), // Ensure page load completes
-    page.waitForLoadState('networkidle'), // Wait for network requests to settle
-    new Promise(resolve => setTimeout(resolve, timeout)), // Hard timeout as a fallback
-    page.evaluate(OBSERVER_TIMEOUT => {
-      return new Promise<string>(resolve => {
-        // Skip mutation check for PDFs
-        if (document.contentType === 'application/pdf') {
-          resolve('Skipping DOM mutation check for PDF.');
-          return;
-        }
-
-        const root = document.documentElement || document.body;
-        if (!(root instanceof Node)) {
-          // Not a valid DOM root—treat as loaded
-          resolve('No valid root to observe; treating as loaded.');
-          return;
-        }
-
-        let timeout: NodeJS.Timeout;
-        let mutationCount = 0;
-        const MAX_MUTATIONS = 500;
-        const NOVELTY_THRESHOLD = 3;
-        const signatureCounts = new WeakMap<Element, Map<string, number>>();
-
-        const observer = new MutationObserver(mutationsList => {
-          mutationCount++;
-          if (mutationCount > MAX_MUTATIONS) {
-            observer.disconnect();
-            resolve('Too many mutations detected, exiting.');
+    page.waitForLoadState('networkidle').catch(() => {}),
+    new Promise(resolve => setTimeout(resolve, stabilityTimeout)),
+    page.evaluate(
+      ({ stabilityTimeout: OBSERVER_TIMEOUT, quietMs: QUIET_MS }) => {
+        return new Promise<string>(resolve => {
+          if (document.contentType === 'application/pdf') {
+            resolve('Skipping DOM mutation check for PDF.');
             return;
           }
 
-          // Only reset the quiet timer for novel mutations. Repeated mutations on
-          // the same (element, attribute) — e.g. a dropdown flipping class during
-          // page init — are treated as churn, not as a signal the DOM is still
-          // loading. See related discussion for background.
-          let sawNovel = false;
-          for (const mutation of mutationsList) {
-            if (!(mutation.target instanceof Element)) continue;
-            const key =
-              mutation.type === 'attributes'
-                ? `attr:${mutation.attributeName}`
-                : mutation.type;
-            let perElement = signatureCounts.get(mutation.target);
-            if (!perElement) {
-              perElement = new Map<string, number>();
-              signatureCounts.set(mutation.target, perElement);
-            }
-            const count = (perElement.get(key) || 0) + 1;
-            perElement.set(key, count);
-            if (count <= NOVELTY_THRESHOLD) sawNovel = true;
+          const root = document.documentElement || document.body;
+          if (!(root instanceof Node)) {
+            resolve('No valid root to observe; treating as loaded.');
+            return;
           }
 
-          if (!sawNovel) return;
+          let timeout: ReturnType<typeof setTimeout>;
+          let mutationCount = 0;
+          const MAX_MUTATIONS = 500;
+          const NOVELTY_THRESHOLD = 3;
+          const signatureCounts = new WeakMap<Element, Map<string, number>>();
 
-          clearTimeout(timeout);
+          const observer = new MutationObserver(mutationsList => {
+            mutationCount++;
+            if (mutationCount > MAX_MUTATIONS) {
+              observer.disconnect();
+              resolve('Too many mutations detected, exiting.');
+              return;
+            }
+
+            // Only reset the quiet timer for novel mutations. Repeated mutations on
+            // the same (element, attribute) — e.g. a dropdown flipping class during
+            // page init — are treated as churn, not as a signal the DOM is still
+            // loading.
+            let sawNovel = false;
+            for (const mutation of mutationsList) {
+              if (!(mutation.target instanceof Element)) continue;
+              const key =
+                mutation.type === 'attributes'
+                  ? `attr:${mutation.attributeName}`
+                  : mutation.type;
+              let perElement = signatureCounts.get(mutation.target);
+              if (!perElement) {
+                perElement = new Map<string, number>();
+                signatureCounts.set(mutation.target, perElement);
+              }
+              const count = (perElement.get(key) || 0) + 1;
+              perElement.set(key, count);
+              if (count <= NOVELTY_THRESHOLD) sawNovel = true;
+            }
+
+            if (!sawNovel) return;
+
+            clearTimeout(timeout);
+            timeout = setTimeout(() => {
+              observer.disconnect();
+              resolve('DOM stabilized after mutations.');
+            }, QUIET_MS);
+          });
+
+          // Initial quiet window: even if no mutations fire, hold for QUIET_MS
+          // after load so hydration that starts slightly late still gets caught.
           timeout = setTimeout(() => {
             observer.disconnect();
-            resolve('DOM stabilized after mutations.');
-          }, 1000);
-        });
+            resolve('Initial quiet window elapsed.');
+          }, Math.min(QUIET_MS, OBSERVER_TIMEOUT));
 
-        // Initial timeout: fires if the page never mutates.
-        timeout = setTimeout(() => {
-          observer.disconnect();
-          resolve('Observer timeout reached, exiting.');
-        }, OBSERVER_TIMEOUT);
-
-        // Only observe if root is a Node
-        observer.observe(root, {
-          childList: true,
-          subtree: true,
-          attributes: true,
+          observer.observe(root, {
+            childList: true,
+            subtree: true,
+            attributes: true,
+          });
         });
-      });
-    }, OBSERVER_TIMEOUT), // Pass OBSERVER_TIMEOUT dynamically to the browser context
+      },
+      { stabilityTimeout, quietMs },
+    ),
   ]);
 };
 

--- a/src/crawlers/crawlDomain.ts
+++ b/src/crawlers/crawlDomain.ts
@@ -521,7 +521,7 @@ const crawlDomain = async ({
       }) => {
         const browserContext: BrowserContext = page.context();
         try {
-          await waitForPageLoaded(page, 10000);
+          await waitForPageLoaded(page);
           let actualUrl = page.url() || request.loadedUrl || request.url;
 
           if (page.url() !== 'about:blank') {

--- a/src/crawlers/crawlDomain.ts
+++ b/src/crawlers/crawlDomain.ts
@@ -521,7 +521,7 @@ const crawlDomain = async ({
       }) => {
         const browserContext: BrowserContext = page.context();
         try {
-          await waitForPageLoaded(page, 10000);
+          await waitForPageLoaded(page, 30000);
           let actualUrl = page.url() || request.loadedUrl || request.url;
 
           if (page.url() !== 'about:blank') {

--- a/src/crawlers/crawlDomain.ts
+++ b/src/crawlers/crawlDomain.ts
@@ -521,7 +521,7 @@ const crawlDomain = async ({
       }) => {
         const browserContext: BrowserContext = page.context();
         try {
-          await waitForPageLoaded(page, 30000);
+          await waitForPageLoaded(page, 10000);
           let actualUrl = page.url() || request.loadedUrl || request.url;
 
           if (page.url() !== 'about:blank') {

--- a/src/crawlers/crawlLocalFile.ts
+++ b/src/crawlers/crawlLocalFile.ts
@@ -17,6 +17,7 @@ import {
   convertLocalFileToPath,
   convertPathToLocalFile,
   launchPersistentSafeContext,
+  waitForPageLoaded,
 } from '../constants/common.js';
 import { runPdfScan, mapPdfScanResults, doPdfScreenshots } from './pdfScanFunc.js';
 import { guiInfoLog } from '../logs.js';
@@ -176,6 +177,7 @@ export const crawlLocalFile = async ({
     const page = await browserContext.newPage();
     url = convertPathToLocalFile(url);
     await page.goto(url);
+    await waitForPageLoaded(page);
 
     if (shouldAbort) {
       console.warn('Scan aborted due to timeout before page scan.');

--- a/src/crawlers/crawlSitemap.ts
+++ b/src/crawlers/crawlSitemap.ts
@@ -277,7 +277,7 @@ const crawlSitemap = async ({
         }
 
         try {
-          await waitForPageLoaded(page, 10000);
+          await waitForPageLoaded(page);
 
           const actualUrl = page.url() || request.loadedUrl || request.url;
 

--- a/src/crawlers/crawlSitemap.ts
+++ b/src/crawlers/crawlSitemap.ts
@@ -277,7 +277,7 @@ const crawlSitemap = async ({
         }
 
         try {
-          await waitForPageLoaded(page, 10000);
+          await waitForPageLoaded(page, 30000);
 
           const actualUrl = page.url() || request.loadedUrl || request.url;
 

--- a/src/crawlers/crawlSitemap.ts
+++ b/src/crawlers/crawlSitemap.ts
@@ -277,7 +277,7 @@ const crawlSitemap = async ({
         }
 
         try {
-          await waitForPageLoaded(page, 30000);
+          await waitForPageLoaded(page, 10000);
 
           const actualUrl = page.url() || request.loadedUrl || request.url;
 


### PR DESCRIPTION
## Summary

`waitForPageLoaded` was returning before the DOM was ready to scan, in two independent ways:

1. **The mutation-observer heuristic misinterpreted repeated attribute mutations** (e.g. a nav dropdown flipping `class` on its parent during init) as a "DOM settled" signal, resolving the promise while the page was still hydrating.
2. **The `Promise.race` let `load` win before the observer could see hydration.** `page.waitForLoadState('load')` almost always resolved first, so the observer never got a chance to catch client-side hydration mutations. This produced intermittent findings like `aria-required-children` on `role="tablist"` elements whose `role="tab"` children are injected by post-load JS (observed on `mom.gov.sg/about-us/accolades`: finding present at 0–200ms after load, resolves by ~350ms).

## Changes

### Novelty-tracked mutation observer ([src/constants/common.ts](src/constants/common.ts))

Previously the observer bucketed mutations by `${nodeName}-${attributeName}`, incremented that bucket for every attribute on the target (not just the one that changed), and — once any bucket hit 10 — resolved the promise as if the DOM had stabilised. This misread churn as settledness.

New logic:

- Track signature counts in a `WeakMap<Element, Map<string, number>>`, keyed by the specific element identity + `mutation.attributeName` (or `"childList"` for structural changes).
- Reset the quiet-period timer **only** for novel mutations — signatures whose count is still ≤ `NOVELTY_THRESHOLD` (3). Repeated hits on the same signature are observed but no longer keep the quiet timer alive.
- Delete the "repeated mutation → resolve as loaded" early-exit branch entirely. Churn is no longer misinterpreted as settled; it's just filtered out of the settled-signal.
- `MAX_MUTATIONS = 500` remains as a backstop for pathological cases.

### Stacked load + stability phases ([src/constants/common.ts](src/constants/common.ts))

Replaced the four-way `Promise.race` with two sequential phases so the observer actually gets a chance to run:

1. **Phase 1** — `await` the `load` event (or its own hard deadline). Baseline network + initial parse.
2. **Phase 2** — race `networkidle` vs. the mutation observer's quiet-window heuristic vs. the stability deadline. This is the window that closes hydration-timing false positives.

Budgets are **stacked, not shared**: a slow-loading page still gets a fresh stability window to hydrate.

### Env-configurable budgets

Introduces three env vars so operators can tune per environment (busy Docker containers with CPU contention may need larger windows than a workstation):

| Env var | Default | Purpose |
|---|---|---|
| `OOBEE_LOAD_TIMEOUT_MS` | `10000` | Phase 1 hard deadline for the `load` event |
| `OOBEE_STABILITY_TIMEOUT_MS` | `5000` | Phase 2 hard deadline for DOM stabilisation |
| `OOBEE_QUIET_MS` | `750` | Length of the mutation-free window that declares "stable" |

Worst-case wall-clock on defaults: **15s/page** (10s + 5s), bounded.

`QUIET_MS = 750ms` (up from the previous implicit 1000ms in the old code, and above the ~350ms hydration window observed on `mom.gov.sg`) gives ~2× margin on typical hydration while remaining cheap on fast static pages.

### Call sites simplified

[src/crawlers/crawlDomain.ts:524](src/crawlers/crawlDomain.ts#L524) and [src/crawlers/crawlSitemap.ts:280](src/crawlers/crawlSitemap.ts#L280) no longer pass a hard-coded `10000`; both use the function default. The `timeout` positional argument has been removed entirely — configure via env vars instead.

[src/crawlers/crawlLocalFile.ts](src/crawlers/crawlLocalFile.ts) previously went straight from `page.goto` into `runAxeScript`, meaning saved HTML with client-side hydration hit the same race as the crawler paths. It now calls `waitForPageLoaded(page)` immediately after `page.goto`, so local file scans get the same hydration-safe treatment.

## Behaviour after the fix

- **Aria labels injected onto 40 buttons on load** → 40 distinct `(button, aria-label)` signatures, each novel → quiet timer keeps resetting → we correctly wait for the hydration.
- **Nav dropdown flipping `class` on its parent 20+ times during init** → single signature `(navDiv, class)` → after 3 hits, further toggles no longer reset the timer → quiet period fires and we exit correctly.
- **Tablist whose `role="tab"` children are injected client-side** (mom.gov.sg case) → Phase 2 stability window catches the hydration mutations that `load` used to short-circuit → `aria-required-children` finding no longer surfaces intermittently.
- **Genuine ongoing content injection into many elements** → many novel signatures → timer keeps resetting → we wait for real settling, capped by `stabilityTimeout`.
- **Pages that never mutate at all** → initial quiet window fires after `QUIET_MS`.
- **Pathological infinite animations across many elements** → bounded by `MAX_MUTATIONS` and the stability deadline.
- **Busy container / slow CPU** → operator bumps `OOBEE_STABILITY_TIMEOUT_MS` and/or `OOBEE_QUIET_MS` without a code change.

## Test plan

- [ ] Re-scan `mom.gov.sg/about-us/accolades` and confirm the `aria-required-children` finding on `.ui-toggle` no longer appears across ≥30 observations.
- [ ] Crawl a site with a nav dropdown that toggles classes during init and confirm the page is no longer reported as loaded prematurely (compare axe results before/after).
- [ ] Crawl a JS-heavy SPA that injects `aria-*` attributes post-load and confirm the crawler still waits for those attributes to appear.
- [ ] Crawl a PDF URL and confirm the PDF short-circuit still fires (`Skipping DOM mutation check for PDF.`).
- [ ] Confirm pages with genuine infinite animations exit within the stability budget instead of hanging.
- [ ] Confirm simple static pages still resolve quickly (via `load` → initial quiet window), not the full budget.
- [ ] Run a representative sitemap crawl and compare mean per-page duration to prior baseline — expect up to ~1s overhead on hydrated pages (the `QUIET_MS` floor).
- [ ] In a CPU-constrained container, verify `OOBEE_STABILITY_TIMEOUT_MS=15000 OOBEE_QUIET_MS=1500` produces stable results.
- [ ] Scan a saved local HTML file with client-side hydration (`--customFlowLabel` / local file input) and confirm hydration completes before axe runs.
