### PR TITLE
fix(crawler): use axe's stored sub-rect for target-size enrichment

### DIFF
--- a/src/crawlers/commonCrawlerFunc.ts
+++ b/src/crawlers/commonCrawlerFunc.ts
@@ -657,6 +657,17 @@ export const enrichViolationMessages = async (results: AxeResults, page: Page): 
       if (!cssSelector) continue;
 
       if (violation.id === 'target-size') {
+        // Axe's target-size check records the actual hit-area sub-rect it
+        // evaluated (partiallyObscured/largestInnerRect cases can be much
+        // smaller than the element's bounding box). Prefer those stored
+        // dimensions; re-measuring the element from the DOM reports the full
+        // size and misrepresents the violation.
+        const axeCheck = (node.any || []).find(c => c.id === 'target-size') as
+          | { data?: { width?: number; height?: number } }
+          | undefined;
+        const axeWidth = axeCheck?.data?.width;
+        const axeHeight = axeCheck?.data?.height;
+
         const ctx = await page
           .evaluate((sel: string) => {
             try {
@@ -678,25 +689,30 @@ export const enrichViolationMessages = async (results: AxeResults, page: Page): 
           }, cssSelector)
           .catch(() => null);
 
-        if (ctx) {
-          const spacingMatch = node.failureSummary?.match(/diameter of (\d+)px/);
-          const spacing = spacingMatch ? spacingMatch[1] : null;
+        const width = axeWidth !== undefined ? axeWidth : ctx?.renderedWidth;
+        const height = axeHeight !== undefined ? axeHeight : ctx?.renderedHeight;
 
-          let message = `Insufficient target size: ${ctx.renderedWidth}px by ${ctx.renderedHeight}px (box-sizing: ${ctx.boxSizing}).\n  Ensure it is at least 24px by 24px.`;
+        if (width === undefined || height === undefined) continue;
 
-          if (spacing) {
-            message += `\n  Target has insufficient space to its adjacent element of ${spacing}px. Ensure it has a safe clickable space of at least 24px.`;
-          }
+        const spacingMatch = node.failureSummary?.match(/diameter of (\d+)px/);
+        const spacing = spacingMatch ? spacingMatch[1] : null;
 
-          if (
-            ctx.boxSizing === 'border-box' &&
-            (ctx.inlineWidth !== null || ctx.inlineHeight !== null)
-          ) {
-            message += `\n  Current button style code snippet does not increase the hit area.\n  Remove the explicit width/height and use min-width: 24px; min-height: 24px instead.\n  Or place the visual content in a child <span> element.`;
-          }
+        const boxSizingLabel = ctx ? ` (box-sizing: ${ctx.boxSizing})` : '';
+        let message = `Insufficient target size: ${width}px by ${height}px${boxSizingLabel}.\n  Ensure it is at least 24px by 24px.`;
 
-          node.failureSummary = message;
+        if (spacing) {
+          message += `\n  Target has insufficient space to its adjacent element of ${spacing}px. Ensure it has a safe clickable space of at least 24px.`;
         }
+
+        if (
+          ctx &&
+          ctx.boxSizing === 'border-box' &&
+          (ctx.inlineWidth !== null || ctx.inlineHeight !== null)
+        ) {
+          message += `\n  Current button style code snippet does not increase the hit area.\n  Remove the explicit width/height and use min-width: 24px; min-height: 24px instead.\n  Or place the visual content in a child <span> element.`;
+        }
+
+        node.failureSummary = message;
       } else if (violation.id === 'valid-lang') {
         const ctx = await page
           .evaluate((sel: string) => {


### PR DESCRIPTION
## Summary
- `enrichViolationMessages` was reporting the element's full bounding-rect (e.g. 140×72px) for `target-size` violations, hiding the actual hit-area axe evaluated (e.g. 24×16px) when the element is partially obscured or has a smaller largest-inner-rect.
- Read `width`/`height` from the `target-size` check's stored data on `node.any` first; fall back to the DOM measurement only when axe didn't record dimensions.
- When both sources are unavailable, leave axe's original `failureSummary` in place rather than blanking the dimensions field.

## Details
Axe's `target-size` check calls `this.data({ ...toDecimalSize(largestInnerRect || nodeRect) })` (see `axe.js:24755-24795`), so the sub-rect it actually judged against is available on the check result. The previous enrichment discarded that and re-measured `getBoundingClientRect()`, which returns the full element size and misrepresents the violation to downstream consumers/LLMs.

The DOM re-query is still used for `boxSizing` / inline width/height hints, but the dimension line no longer depends on it.

## Test plan
- [ ] Trigger a `target-size` violation on a partially obscured element and confirm the enriched `failureSummary` reports the sub-rect dimensions (matching axe's own message), not the element's outer size.
- [ ] Trigger a `target-size` violation where the DOM `querySelector` returns null (e.g. detached element) and confirm axe's original `failureSummary` is preserved.
- [ ] Trigger a `target-size` violation with `box-sizing: border-box` and inline width/height and confirm the "remove explicit width/height" hint still appears.
- [ ] Existing `valid-lang` enrichment is unaffected.
