### PR TITLE
fix: accessible-label false positives, Details section for two ARIA rules, correct report title

### DIFF
--- a/src/combine.ts
+++ b/src/combine.ts
@@ -5,7 +5,7 @@ import crawlDomain from './crawlers/crawlDomain.js';
 import crawlLocalFile from './crawlers/crawlLocalFile.js';
 import crawlIntelligentSitemap from './crawlers/crawlIntelligentSitemap.js';
 import generateArtifacts from './mergeAxeResults.js';
-import { getHost, createAndUpdateResultsFolders, cleanUpAndExit, getStoragePath } from './utils.js';
+import { getHost, createAndUpdateResultsFolders, cleanUpAndExit, getStoragePath, getEntryPageTitle } from './utils.js';
 import constants, { ScannerTypes, UrlsCrawled } from './constants/constants.js';
 import { getBlackListedPatterns, submitForm } from './constants/common.js';
 import { consoleLogger, silentLogger } from './logs.js';
@@ -321,7 +321,7 @@ const combineRun = async (details: Data, deviceToScan: string) => {
 
       // Upload results to S3 if environment variables are set
       if (isS3UploadEnabled()) {
-        const siteName = (urlsCrawledObj.scanned[0]?.pageTitle ?? '')
+        const siteName = getEntryPageTitle(urlsCrawledObj.scanned, url)
           .replace(/^\d+\s*:\s*/, '')
           .trim();
         const scanMetadata = getS3MetadataFromEnv(siteName, durationExceeded);

--- a/src/crawlers/custom/flagUnlabelledClickableElements.ts
+++ b/src/crawlers/custom/flagUnlabelledClickableElements.ts
@@ -82,6 +82,35 @@ function hasPointerCursor(node: Node): boolean {
     return hasPointerStyle || hasOnClick || hasEventListeners || isClickableRole || isNativeClickableElement || hasTabIndex;
 }
 
+  // Returns true only when the element itself carries an interactive marker.
+  // Excludes signals that can be inherited or ambient (e.g. cursor:pointer
+  // inherited from an interactive ancestor), so decorative overlays and empty
+  // icon spans nested inside a labeled anchor are not treated as clickable.
+  function hasOwnInteractivity(node: Element): boolean {
+    if (!node || node.nodeType !== Node.ELEMENT_NODE) return false;
+    const el = node as HTMLElement;
+
+    const tag = el.nodeName.toLowerCase();
+    if (tag === 'button' || tag === 'input' || tag === 'select' || tag === 'textarea') return true;
+    if (tag === 'a' && el.hasAttribute('href')) return true;
+
+    if (el.hasAttribute('onclick')) return true;
+    if (el.hasAttribute('jsaction') || el.hasAttribute('jscontroller')) return true;
+
+    const tabindex = el.getAttribute('tabindex');
+    if (tabindex !== null && tabindex !== '-1') return true;
+
+    const role = el.getAttribute('role');
+    if (role && ['button', 'link', 'menuitem', 'tab', 'checkbox', 'radio', 'switch', 'option'].includes(role)) {
+      return true;
+    }
+
+    // Inline cursor:pointer is explicitly set on this element (not inherited).
+    if (el.style && el.style.cursor === 'pointer') return true;
+
+    return false;
+  }
+
 
   function isAccessibleText(value: string) {
     if (!value || value.trim().length === 0) {
@@ -90,10 +119,10 @@ function hasPointerCursor(node: Node): boolean {
 
     const trimmedValue = value.trim();
 
-    // Check if the text is a URL/link or a CSS url() pattern.
-    const linkRegex = /^(https?:\/\/|file:\/\/|[a-zA-Z]:[\\/]|\/)[^\s]+$/i;
+    // Treat CSS url() patterns as non-accessible. URL strings themselves are
+    // allowed to serve as accessible text (e.g. `<a><i>https://example.com</i></a>`).
     const cssUrlRegex = /^url\(.*\)$/i;
-    if (linkRegex.test(trimmedValue) || cssUrlRegex.test(trimmedValue)) {
+    if (cssUrlRegex.test(trimmedValue)) {
         return false;
     }
 
@@ -717,6 +746,30 @@ function hasPointerCursor(node: Node): boolean {
         if (!hasPointerCursor(element)) {
             customConsoleWarn("Empty div or span without accessible text and without pointer cursor, skipping flagging.");
             return false;
+        }
+
+        // Only flag when the element itself is interactive. Cursor:pointer
+        // inherits through the DOM, so a decorative overlay or icon span
+        // nested under a labeled interactive ancestor should not be flagged.
+        if (!hasOwnInteractivity(element)) {
+            customConsoleWarn("Empty div or span has only inherited cursor:pointer with no own interactive marker, skipping flagging.");
+            return false;
+        }
+
+        // Focusable scroll containers (tabindex=0 + overflow auto/scroll) are a
+        // legitimate keyboard-a11y pattern; do not flag them just for lacking
+        // a name.
+        {
+            const overflow = computedStyle.overflow;
+            const overflowX = computedStyle.overflowX;
+            const overflowY = computedStyle.overflowY;
+            const isScrollable = [overflow, overflowX, overflowY].some(
+                v => v === 'auto' || v === 'scroll'
+            );
+            if (isScrollable) {
+                customConsoleWarn("Empty scroll container, skipping flagging.");
+                return false;
+            }
         }
 
         // **New background-image check**

--- a/src/mergeAxeResults.ts
+++ b/src/mergeAxeResults.ts
@@ -27,6 +27,7 @@ import {
   zipResults,
   getIssuesPercentage,
   register,
+  getEntryPageTitle,
 } from './utils.js';
 import { consoleLogger } from './logs.js';
 import itemTypeDescription from './constants/itemTypeDescription.js';
@@ -821,7 +822,7 @@ const generateArtifacts = async (
       htmlETL: oobeeAiHtmlETL,
       rules: oobeeAiRules,
     },
-    siteName: (pagesScanned[0]?.pageTitle ?? '').replace(/^\d+\s*:\s*/, '').trim(),
+    siteName: getEntryPageTitle(pagesScanned, urlScanned).replace(/^\d+\s*:\s*/, '').trim(),
     startTime: scanDetails.startTime ? scanDetails.startTime : new Date(),
     endTime: scanDetails.endTime ? scanDetails.endTime : new Date(),
     urlScanned,

--- a/src/static/ejs/partials/scripts/ruleModal/itemCardRenderer.ejs
+++ b/src/static/ejs/partials/scripts/ruleModal/itemCardRenderer.ejs
@@ -240,7 +240,7 @@
           ${createElementSection(item)}
           ${
             (() => {
-              const showDetails = item.displayNeedsReview || ['color-contrast', 'color-contrast-enhanced', 'oobee-grading-text-contents', 'target-size', 'valid-lang', 'aria-valid-attr-value', 'aria-required-children'].includes(aiConfig.ruleInCategory.rule);
+              const showDetails = item.displayNeedsReview || ['color-contrast', 'color-contrast-enhanced', 'oobee-grading-text-contents', 'target-size', 'valid-lang', 'aria-valid-attr-value', 'aria-required-children', 'aria-prohibited-attr'].includes(aiConfig.ruleInCategory.rule);
               return showDetails && item.message
                 ? `<div class="d-flex justify-content-between g-one">
             <div class="fw-semibold page-item-card-section-title">Details</div>

--- a/src/static/ejs/partials/scripts/ruleModal/itemCardRenderer.ejs
+++ b/src/static/ejs/partials/scripts/ruleModal/itemCardRenderer.ejs
@@ -240,7 +240,7 @@
           ${createElementSection(item)}
           ${
             (() => {
-              const showDetails = item.displayNeedsReview || ['color-contrast', 'color-contrast-enhanced', 'oobee-grading-text-contents', 'target-size', 'valid-lang'].includes(aiConfig.ruleInCategory.rule);
+              const showDetails = item.displayNeedsReview || ['color-contrast', 'color-contrast-enhanced', 'oobee-grading-text-contents', 'target-size', 'valid-lang', 'aria-valid-attr-value', 'aria-required-children'].includes(aiConfig.ruleInCategory.rule);
               return showDetails && item.message
                 ? `<div class="d-flex justify-content-between g-one">
             <div class="fw-semibold page-item-card-section-title">Details</div>

--- a/src/static/ejs/partials/scripts/ruleModal/pageAccordionBuilder.ejs
+++ b/src/static/ejs/partials/scripts/ruleModal/pageAccordionBuilder.ejs
@@ -394,7 +394,7 @@
 
           ${
             (() => {
-              const showDetails = item.displayNeedsReview || ['color-contrast', 'color-contrast-enhanced', 'oobee-grading-text-contents', 'target-size', 'valid-lang'].includes(aiConfig.ruleInCategory.rule);
+              const showDetails = item.displayNeedsReview || ['color-contrast', 'color-contrast-enhanced', 'oobee-grading-text-contents', 'target-size', 'valid-lang', 'aria-valid-attr-value', 'aria-required-children'].includes(aiConfig.ruleInCategory.rule);
               return showDetails && item.message
                 ? `<div class="d-flex justify-content-between g-one modal-view">
             <div class="fw-semibold page-item-card-section-title">Details</div>

--- a/src/static/ejs/partials/scripts/ruleModal/pageAccordionBuilder.ejs
+++ b/src/static/ejs/partials/scripts/ruleModal/pageAccordionBuilder.ejs
@@ -394,7 +394,7 @@
 
           ${
             (() => {
-              const showDetails = item.displayNeedsReview || ['color-contrast', 'color-contrast-enhanced', 'oobee-grading-text-contents', 'target-size', 'valid-lang', 'aria-valid-attr-value', 'aria-required-children'].includes(aiConfig.ruleInCategory.rule);
+              const showDetails = item.displayNeedsReview || ['color-contrast', 'color-contrast-enhanced', 'oobee-grading-text-contents', 'target-size', 'valid-lang', 'aria-valid-attr-value', 'aria-required-children', 'aria-prohibited-attr'].includes(aiConfig.ruleInCategory.rule);
               return showDetails && item.message
                 ? `<div class="d-flex justify-content-between g-one modal-view">
             <div class="fw-semibold page-item-card-section-title">Details</div>

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -28,6 +28,37 @@ export const getVersion = () => {
 
 export const getHost = (url: string): string => new URL(url).host;
 
+// Pick the scanned page whose URL matches the entry URL the user provided,
+// so downstream siteName / report title reflects the requested page rather
+// than whichever page the crawler happened to process first (which for
+// intelligent-sitemap scans is often a deep sitemap entry).
+export const getEntryPageTitle = (
+  pagesScanned: Array<{ url?: string; actualUrl?: string; pageTitle?: string }> | undefined,
+  entryUrl: string | undefined,
+): string => {
+  if (!pagesScanned || pagesScanned.length === 0) return '';
+
+  const normalize = (raw?: string): string => {
+    if (!raw) return '';
+    try {
+      const parsed = new URL(raw);
+      const pathname = parsed.pathname.replace(/\/+$/, '') || '/';
+      return `${parsed.protocol}//${parsed.host.toLowerCase()}${pathname}${parsed.search}`;
+    } catch {
+      return raw;
+    }
+  };
+
+  const normEntry = normalize(entryUrl);
+  const match = normEntry
+    ? pagesScanned.find(
+        p => normalize(p.url) === normEntry || normalize(p.actualUrl) === normEntry,
+      )
+    : undefined;
+
+  return (match ?? pagesScanned[0])?.pageTitle ?? '';
+};
+
 export const getCurrentDate = () => {
   const date = new Date();
   return `${date.getFullYear()}-${date.getMonth() + 1}-${date.getDate()}`;


### PR DESCRIPTION
## Summary

Three related changes to the accessibility report:

- Tightens the `oobee-accessible-label` rule so it stops flagging four common patterns that are not real accessibility issues.
- Adds `aria-valid-attr-value`, `aria-required-children`, and `aria-prohibited-attr` to the `showDetails` allowlist in the rule offcanvas so their axe message (used as How To Fix guidance) is rendered.
- Fixes the report `siteName` (title) so intelligent-sitemap scans reflect the URL the user requested, not whichever page the crawler happened to process first.

### `oobee-accessible-label` false-positive shapes fixed

1. **Empty focusable scroll containers** — `<div tabindex="0" style="overflow:auto">` used as keyboard-accessible scroll wrappers.
2. **Decorative background-image overlays** — empty divs that inherit `cursor:pointer` from an interactive ancestor.
3. **Empty icon spans inside labeled anchors** — e.g. `<span class="icon-…">` nested inside an `<a aria-label="…">`, where the anchor already carries the accessible name.
4. **Anchors whose visible text is a URL** — e.g. `<a href="…"><i>https://example.com</i></a>`.

## Why

All four shapes were being flagged by `shouldFlagElement` in `src/crawlers/custom/flagUnlabelledClickableElements.ts`, but each is a false positive:

- **Scroll containers** (case 1) with `tabindex="0"` are a legitimate WCAG-compatible pattern for keyboard scrolling.
- **Inherited `cursor:pointer`** (cases 2 & 3) is not a reliable signal of interactivity — it propagates from an interactive ancestor to every descendant, so decorative children get treated as clickable.
- **URL text** (case 4) was being explicitly rejected by `isAccessibleText` via a `linkRegex`, which meant a link whose visible text *is* the URL got reported as unlabeled — even though the URL is the label.

## Changes

### `src/crawlers/custom/flagUnlabelledClickableElements.ts`

#### 1. `isAccessibleText` — accept URL strings

Dropped the `linkRegex` rejection. Only the CSS `url(...)` pattern is still filtered out (which is not visible text).

```diff
- const linkRegex = /^(https?:\/\/|file:\/\/|[a-zA-Z]:[\\/]|\/)[^\s]+$/i;
  const cssUrlRegex = /^url\(.*\)$/i;
- if (linkRegex.test(trimmedValue) || cssUrlRegex.test(trimmedValue)) {
+ if (cssUrlRegex.test(trimmedValue)) {
      return false;
  }
```

#### 2. New helper `hasOwnInteractivity`

Returns `true` only when the element itself carries an interactive marker — never when the marker is inherited or ambient. Signals considered "own":

- native clickable tag: `<button>`, `<input>`, `<select>`, `<textarea>`, or `<a>` **with `href`**
- `onclick`, `jsaction`, or `jscontroller` attribute on the element
- `tabindex` attribute set to any value other than `-1`
- `role` in `{button, link, menuitem, tab, checkbox, radio, switch, option}`
- inline `style="cursor: pointer"` set directly on the element

Notably **excludes** computed `cursor: pointer` (which inherits) and generic event-listener sniffing (which fires on any `on*`-prefixed property).

#### 3. Empty-div/span branch — new guard rails

Before falling into background-image detection and ancestor traversal, the empty-div/span branch now applies two extra skips:

- **Own-interactivity gate**: if the element only has `cursor:pointer` via inheritance and no own interactive marker, skip.
- **Scroll-container gate**: if `overflow` / `overflow-x` / `overflow-y` is `auto` or `scroll`, skip.

Case 1 (empty focusable scroll wrapper) is caught by the second gate. Cases 2 and 3 (decorative overlay, inherited-cursor icon span) are caught by the first.

### `src/static/ejs/partials/scripts/ruleModal/pageAccordionBuilder.ejs` & `itemCardRenderer.ejs`

Added `aria-valid-attr-value`, `aria-required-children`, and `aria-prohibited-attr` to the `showDetails` allowlist. These rules already run in oobee scans, but the offcanvas was hiding the axe message that explains what to fix, because the allowlist only contained a handful of rule ids (`color-contrast`, `target-size`, etc.). Users viewing an occurrence of any of these rules now see the "Details" section rendered with the standard axe guidance.

```diff
- const showDetails = item.displayNeedsReview || ['color-contrast', 'color-contrast-enhanced', 'oobee-grading-text-contents', 'target-size', 'valid-lang'].includes(aiConfig.ruleInCategory.rule);
+ const showDetails = item.displayNeedsReview || ['color-contrast', 'color-contrast-enhanced', 'oobee-grading-text-contents', 'target-size', 'valid-lang', 'aria-valid-attr-value', 'aria-required-children', 'aria-prohibited-attr'].includes(aiConfig.ruleInCategory.rule);
```

### Report `siteName` for intelligent-sitemap scans

For intelligent-sitemap scans that discover pages via a sitemap, the crawler often processes a deep sitemap entry before the URL the user actually asked for. `mergeAxeResults.ts` and `combine.ts` both computed `siteName` from `pagesScanned[0]?.pageTitle`, so a scan of `mom.gov.sg` would produce a report titled after e.g. `Renew, cancel or replace an LOC for DP holders of Overseas Networks & Expertise Pass`.

Introduced a shared helper `getEntryPageTitle(pagesScanned, entryUrl)` in `src/utils.ts`. It **does not fetch or visit any page** — it only filters the existing `pagesScanned` array that the crawler already produced:

- normalizes both the entry URL and each scanned page's URL (`url` and `actualUrl`) — lowercase host, trailing-slash-stripped pathname — and returns the matched page's `pageTitle`;
- if no page matches (e.g. the entry URL was never actually scanned by the intelligent-sitemap crawler), falls back to `pagesScanned[0]?.pageTitle` — the previous behavior;
- if `pagesScanned` is empty or the URL is malformed, returns `''` without throwing.

Both call sites (`mergeAxeResults.ts:824` and `combine.ts:324`) now go through the helper.

```diff
- siteName: (pagesScanned[0]?.pageTitle ?? '').replace(/^\d+\s*:\s*/, '').trim(),
+ siteName: getEntryPageTitle(pagesScanned, urlScanned).replace(/^\d+\s*:\s*/, '').trim(),
```

## Behavior comparison

| Example markup | Before | After |
|---|---|---|
| `<div tabindex="0" style="overflow:auto">&nbsp;</div>` | Flagged | **Not flagged** (scroll container) |
| `<div class="background-image-overlay">` | Flagged | **Not flagged** (inherited cursor, no own interactivity) |
| `<span class="icon-…">` inside labeled anchor | Flagged | **Not flagged** (inherited cursor, no own interactivity) |
| `<a href="…"><i>https://example.com</i></a>` | Flagged | **Not flagged** (URL text is accessible) |
| `<div tabindex="0">Actual empty focusable div (no overflow)</div>` | Flagged | Flagged (still a real WCAG 4.1.2 finding) |
| `<div onclick="…">` empty with no label | Flagged | Flagged (own `onclick`) |
| `<button></button>` empty | Flagged | Flagged (unchanged) |


