### PR TITLE
feat: Cloudflare Family Secure DNS (DoH)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,6 +85,8 @@ All crawlers use Crawlee's `PlaywrightCrawler` with:
 
 `initModifiedUserAgent()` detects the default UA, replaces `HeadlessChrome` with `Chrome`, stores in `process.env.OOBEE_USER_AGENT`. This must be called before any browser context that talks to remote servers in headless mode, or bot-blocking WAFs will reject requests.
 
+**Caller-provided override**: if `OOBEE_USER_AGENT` is already set at entry, `initModifiedUserAgent()` respects it and skips the browser bootstrap. Callers can use this to customise the UA string to match a target site's requirements. Note that Client Hints (`Sec-CH-UA-Platform`, etc.) are still set by the browser from the actual OS and are not covered by this override.
+
 Contexts that need `userAgent: process.env.OOBEE_USER_AGENT`:
 - `getRobotsTxtViaPlaywright()` — robots.txt fetching
 - `findSitemap()` in `crawlIntelligentSitemap.ts` — sitemap path probing
@@ -133,7 +135,7 @@ The `constants` default export object holds runtime state:
 | Variable | Purpose |
 |----------|---------|
 | `CRAWLEE_HEADLESS` | `1` = headless, `0` = headful (set by `setHeadlessMode()`) |
-| `OOBEE_USER_AGENT` | Modified UA (set by `initModifiedUserAgent()`) |
+| `OOBEE_USER_AGENT` | Modified UA. Normally set by `initModifiedUserAgent()`; if pre-set by the caller, `initModifiedUserAgent()` respects it and skips the browser bootstrap. |
 | `OOBEE_VERBOSE` | Enable verbose console logging |
 | `OOBEE_LOGS_PATH` | Custom log directory |
 | `OOBEE_SLOWMO` | Browser slowmo in ms |
@@ -149,6 +151,10 @@ The `constants` default export object holds runtime state:
 | `GOOGLE_SAFE_BROWSING` | `1` = enable Google Safe Browsing (requires Chrome, not Chromium) |
 | `HTTP_PROXY` / `HTTPS_PROXY` / `ALL_PROXY` | Proxy configuration |
 | `NO_PROXY` / `INCLUDE_PROXY` | Proxy bypass/include lists |
+| `CF_WORKER_PROXY` | URL of a Cloudflare Worker acting as a SOCKS-over-WebSocket relay. When set, `proxyService.getProxyInfo()` starts a local SOCKS5 listener that tunnels through the Worker. |
+| `CF_WORKER_PROXY_AUTH_TOKEN` | Bearer token sent to the Worker for authentication and for its `?bypass-ips=1` endpoint (the Worker returns IP ranges that must be direct-forwarded, bypassing the tunnel). |
+| `CF_WORKER_PROXY_FORCE_TUNNEL_HOSTS` | Client-side glob allowlist (comma/semicolon separated, `*` wildcards). Matched hostnames skip the bypass-IP / DoH resolution branch and are always sent to the Worker as `{hostname, port}`, preserving the Worker's hostname-based routing (e.g. its `INCLUDE_PROXY_FOR_UPSTREAM` allowlist). |
+| `CF_FAMILY_DNS` | `1`/`true` enables Cloudflare Family DoH (`family.cloudflare-dns.com`, 1.1.1.3) pre-resolution inside the SOCKS5 layer. Composes with `CF_WORKER_PROXY` (Worker + Family DoH) or runs standalone (local SOCKS5 only). Blocked hostnames return SOCKS reply `0x02`. |
 
 ### Internal (set by code)
 | Variable | Purpose |
@@ -356,6 +362,15 @@ When making changes, validate these areas which have well-established edge cases
 
 ### Proxy & Network
 - Proxy detection must handle `ALL_PROXY` on Windows. The proxy resolution logic should be tested on all platforms.
+
+#### Cloudflare Worker SOCKS tunnel (`src/cfProxyWorker.ts`)
+When `CF_WORKER_PROXY` is set, `proxyService.getProxyInfo()` starts a local SOCKS5 listener that tunnels traffic through the Worker over WebSocket. Key behaviours:
+
+- **Payload shape**: the SOCKS5 CONNECT is forwarded as JSON `{hostname, port}`. The Worker performs its own resolution (and may route via an upstream proxy based on its server-side allowlist). Do not substitute the resolved IP for the hostname — the Worker's hostname-based routing depends on receiving the original name.
+- **Bypass IP list**: the Worker exposes `?bypass-ips=1` which returns IP CIDR ranges that must be direct-forwarded (i.e. not sent through the Worker). `handleSocks5()` resolves the target hostname, checks the result against the bypass ranges, and if matched calls `directForward()` instead of opening a Worker WebSocket. This is the fast path for hosts the Worker itself would just proxy back to the origin.
+- **Force-tunnel allowlist (`CF_WORKER_PROXY_FORCE_TUNNEL_HOSTS`)**: some target hostnames are also present in the Worker's server-side "route via upstream proxy" list. For those, the client must skip the bypass-IP check and send the connection through the Worker unconditionally, so the Worker can apply its upstream-proxy routing. The env var is a comma/semicolon-separated glob list (`*` wildcards). `shouldForceTunnel(hostname)` gates the bypass check in `handleSocks5()`. Log line for a match: `[cfProxyWorker] Force-tunnel match for <host> — sending to Worker`.
+- **Family DoH (`CF_FAMILY_DNS`)**: enables Cloudflare Family DoH pre-resolution inside the SOCKS5 layer. This runs regardless of Chromium's own DoH state (Chromium disables its DoH client whenever a proxy is configured, so filtering must live in the SOCKS layer). Composes with the Worker path (Worker tunnel + pre-resolution) or runs standalone (`startFamilyDnsLocalProxy()` — local SOCKS5, no Worker, no WebSocket). Blocked hostnames (Family DoH answers `0.0.0.0`/`::`) get SOCKS reply `0x02`.
+- **Shared helpers**: `readSocks5Request()` is a pure SOCKS5 greeting/CONNECT parser; `directForward()` is the reusable direct-TCP forwarder used by both the bypass-IP path and the standalone Family DoH local proxy.
 
 ### Strategy & Filtering in Sitemap Crawls
 - The `-s` (strategy) flag must be passed through to `crawlSitemap` and `getLinksFromSitemap`. For sitemap-only scans the default is `'ignore'` (all URLs); for domain/intelligent crawls it's `'same-domain'`.

--- a/src/cfProxyWorker.ts
+++ b/src/cfProxyWorker.ts
@@ -141,6 +141,48 @@ function isIpLiteral(s: string): boolean {
 }
 
 // -----------------------------------------------------------------------------
+// Force-tunnel allowlist.
+// -----------------------------------------------------------------------------
+// The worker's bypass-IP list (?bypass-ips=1) short-circuits the tunnel for
+// hosts resolving into it — with BYPASS_CLOUDFLARE=true that includes every
+// CF-fronted target. But the worker also has its own INCLUDE_PROXY_FOR_UPSTREAM
+// allowlist that only takes effect if the request actually reaches the worker.
+// Hostnames listed here escape the bypass check on the client side so they
+// reach the worker and can be routed through the upstream proxy.
+//
+// Configured via CF_WORKER_PROXY_FORCE_TUNNEL_HOSTS as a comma/semicolon
+// separated glob list. Patterns support '*' wildcards, e.g.
+// "*.singpass.gov.sg;singpass.gov.sg,*.whatismyipaddress.com".
+
+let forceTunnelRegexesCache: RegExp[] | null = null;
+function getForceTunnelRegexes(): RegExp[] {
+  if (forceTunnelRegexesCache !== null) return forceTunnelRegexesCache;
+  const raw = process.env.CF_WORKER_PROXY_FORCE_TUNNEL_HOSTS?.trim();
+  if (!raw) {
+    forceTunnelRegexesCache = [];
+    return forceTunnelRegexesCache;
+  }
+  forceTunnelRegexesCache = raw
+    .split(/[,;]/)
+    .map((s) => s.trim())
+    .filter(Boolean)
+    .map(
+      (pattern) =>
+        new RegExp(
+          '^' + pattern.replace(/[.+^${}()|[\]\\]/g, '\\$&').replace(/\*/g, '.*') + '$',
+          'i',
+        ),
+    );
+  return forceTunnelRegexesCache;
+}
+
+function shouldForceTunnel(hostname: string): boolean {
+  const regexes = getForceTunnelRegexes();
+  if (regexes.length === 0) return false;
+  return regexes.some((re) => re.test(hostname));
+}
+
+// -----------------------------------------------------------------------------
 // Cloudflare Family DoH egress filtering.
 // -----------------------------------------------------------------------------
 // Chrome's DoH policy is disabled whenever a proxy is configured, so the
@@ -438,27 +480,34 @@ async function handleSocks5(
   if (!req) return;
   const { hostname, port } = req;
 
-  // Resolve hostname and check whether it falls in the worker-provided bypass list
-  const bypassRanges = await getBypassRanges(workerUrl, authToken);
-  const resolution = await resolveHostname(hostname, bypassRanges);
-  if (!resolution) {
-    consoleLogger.warn(`[cfProxyWorker] Failed to resolve hostname: ${hostname}`);
-    clientSocket.write(socksReply(0x04)); // host unreachable
-    clientSocket.end();
-    return;
-  }
-  if (resolution.blocked) {
-    consoleLogger.info(`[cfProxyWorker] Refusing SOCKS connect to ${hostname} — blocked by Family DNS`);
-    clientSocket.write(socksReply(0x02)); // connection not allowed by ruleset
-    clientSocket.end();
-    return;
-  }
+  // Force-tunnel allowlist: skip bypass/DoH checks so the hostname reaches
+  // the worker where INCLUDE_PROXY_FOR_UPSTREAM can route it via the upstream
+  // proxy. Worker handles resolution and any blocking on its side.
+  if (!isIpLiteral(hostname) && shouldForceTunnel(hostname)) {
+    consoleLogger.info(`[cfProxyWorker] Force-tunnel match for ${hostname} — sending to Worker`);
+  } else {
+    // Resolve hostname and check whether it falls in the worker-provided bypass list
+    const bypassRanges = await getBypassRanges(workerUrl, authToken);
+    const resolution = await resolveHostname(hostname, bypassRanges);
+    if (!resolution) {
+      consoleLogger.warn(`[cfProxyWorker] Failed to resolve hostname: ${hostname}`);
+      clientSocket.write(socksReply(0x04)); // host unreachable
+      clientSocket.end();
+      return;
+    }
+    if (resolution.blocked) {
+      consoleLogger.info(`[cfProxyWorker] Refusing SOCKS connect to ${hostname} — blocked by Family DNS`);
+      clientSocket.write(socksReply(0x02)); // connection not allowed by ruleset
+      clientSocket.end();
+      return;
+    }
 
-  // Bypass listed ranges - transparently forward TCP connection using Node's net module
-  if (resolution.bypass) {
-    consoleLogger.info(`[cfProxyWorker] Bypassing Worker for ${hostname} (${resolution.ip}) - connecting directly`);
-    directForward(clientSocket, resolution.ip, port, hostname);
-    return;
+    // Bypass listed ranges - transparently forward TCP connection using Node's net module
+    if (resolution.bypass) {
+      consoleLogger.info(`[cfProxyWorker] Bypassing Worker for ${hostname} (${resolution.ip}) - connecting directly`);
+      directForward(clientSocket, resolution.ip, port, hostname);
+      return;
+    }
   }
 
   const wsHeaders = authToken ? { Authorization: authToken } : undefined;
@@ -468,12 +517,13 @@ async function handleSocks5(
   let ready = false;
   const preBuffer: Buffer[] = [];
 
-  // When Family DoH is enabled we've already resolved and validated the
-  // hostname; hand the IP to the worker so its own connect() doesn't re-resolve
-  // via Cloudflare's default (non-family) resolver. TLS SNI stays end-to-end.
-  const targetForWorker = isFamilyDnsEnabled() && !isIpLiteral(hostname) ? resolution.ip : hostname;
+  // Always send the original hostname so the worker can apply its own
+  // hostname-based routing (INCLUDE_PROXY_FOR_UPSTREAM globs). The worker's
+  // connect() will re-resolve via Cloudflare's internal resolver — same
+  // Cloudflare infra as Family DoH, no cross-provider leak. Client-side
+  // Family DoH blocking (SOCKS 0x02) is what enforces the filter.
   ws.on('open', () => {
-    ws.send(JSON.stringify({ hostname: targetForWorker, port }));
+    ws.send(JSON.stringify({ hostname, port }));
   });
 
   ws.on('message', (data: WebSocket.RawData) => {

--- a/src/cfProxyWorker.ts
+++ b/src/cfProxyWorker.ts
@@ -151,8 +151,7 @@ function isIpLiteral(s: string): boolean {
 // reach the worker and can be routed through the upstream proxy.
 //
 // Configured via CF_WORKER_PROXY_FORCE_TUNNEL_HOSTS as a comma/semicolon
-// separated glob list. Patterns support '*' wildcards, e.g.
-// "*.singpass.gov.sg;singpass.gov.sg,*.whatismyipaddress.com".
+// separated glob list. Patterns support '*' wildcards.
 
 let forceTunnelRegexesCache: RegExp[] | null = null;
 function getForceTunnelRegexes(): RegExp[] {

--- a/src/cfProxyWorker.ts
+++ b/src/cfProxyWorker.ts
@@ -140,25 +140,115 @@ function isIpLiteral(s: string): boolean {
   return ipToBytes(s) !== null;
 }
 
+// -----------------------------------------------------------------------------
+// Cloudflare Family DoH egress filtering.
+// -----------------------------------------------------------------------------
+// Chrome's DoH policy is disabled whenever a proxy is configured, so the
+// enterprise policy pointing at family.cloudflare-dns.com does nothing once the
+// SOCKS tunnel is in play. To keep the family filter effective we resolve
+// hostnames here (before the tunnel handoff) and refuse the connection if
+// Family DNS returned the sentinel blocked address.
+//
+// Enable with env var CF_FAMILY_DNS=1. When enabled alongside CF_WORKER_PROXY,
+// the resolved IP is also what we hand to the worker instead of the original
+// hostname, so the worker's connect() doesn't re-resolve via Cloudflare's
+// default (non-filtered) resolver. TLS SNI still terminates end-to-end at the
+// browser, so the target sees the original hostname on the wire.
+//
+// CF_FAMILY_DNS is also honoured standalone: if it is set but CF_WORKER_PROXY
+// is not, oobee starts a local SOCKS5 proxy that resolves via Family DoH and
+// forwards directly (no WebSocket tunnel). See startFamilyDnsLocalProxy().
+
+const FAMILY_DOH_ENDPOINT = 'https://family.cloudflare-dns.com/dns-query';
+const DOH_CACHE_TTL_MS = 60 * 1000;
+const FAMILY_BLOCKED_V4 = '0.0.0.0';
+const FAMILY_BLOCKED_V6 = '::';
+
+interface DohCacheEntry {
+  ip: string | null; // null = lookup failed; sentinel = family-blocked
+  expiresAt: number;
+}
+const dohCache = new Map<string, DohCacheEntry>();
+
+function isFamilyDnsEnabled(): boolean {
+  const v = process.env.CF_FAMILY_DNS?.trim().toLowerCase();
+  return v === '1' || v === 'true' || v === 'yes' || v === 'on';
+}
+
+async function queryDoh(hostname: string, type: 'A' | 'AAAA'): Promise<string | null> {
+  const url = `${FAMILY_DOH_ENDPOINT}?name=${encodeURIComponent(hostname)}&type=${type}`;
+  try {
+    const res = await fetch(url, { headers: { Accept: 'application/dns-json' } });
+    if (!res.ok) return null;
+    const data = (await res.json()) as { Answer?: Array<{ type: number; data: string }> };
+    if (!Array.isArray(data.Answer)) return null;
+    const wantedType = type === 'A' ? 1 : 28;
+    for (const ans of data.Answer) {
+      if (ans && ans.type === wantedType && typeof ans.data === 'string') return ans.data;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+async function resolveViaFamilyDoH(hostname: string): Promise<string | null> {
+  const now = Date.now();
+  const cached = dohCache.get(hostname);
+  if (cached && cached.expiresAt > now) return cached.ip;
+
+  let ip: string | null = null;
+  const a = await queryDoh(hostname, 'A');
+  if (a && a !== FAMILY_BLOCKED_V4) {
+    ip = a;
+  } else if (a === FAMILY_BLOCKED_V4) {
+    ip = FAMILY_BLOCKED_V4;
+  } else {
+    const aaaa = await queryDoh(hostname, 'AAAA');
+    if (aaaa) ip = aaaa; // includes '::' (blocked) — caller distinguishes
+  }
+
+  dohCache.set(hostname, { ip, expiresAt: now + DOH_CACHE_TTL_MS });
+  return ip;
+}
+
 async function resolveHostname(
   hostname: string,
   bypassRanges: string[],
-): Promise<{ ip: string; bypass: boolean } | null> {
+): Promise<{ ip: string; bypass: boolean; blocked: boolean } | null> {
   // The SOCKS5 client may have already resolved DNS locally and passed an IP
   // literal (atyp 0x01/0x04). Skip DNS in that case and check the list directly.
   if (isIpLiteral(hostname)) {
-    return { ip: hostname, bypass: ipInRanges(hostname, bypassRanges) };
+    return { ip: hostname, bypass: ipInRanges(hostname, bypassRanges), blocked: false };
   }
+
+  if (isFamilyDnsEnabled()) {
+    const ip = await resolveViaFamilyDoH(hostname);
+    if (ip === FAMILY_BLOCKED_V4 || ip === FAMILY_BLOCKED_V6) {
+      consoleLogger.info(`[cfProxyWorker] Family DNS blocked ${hostname} (${ip})`);
+      return { ip, bypass: false, blocked: true };
+    }
+    if (!ip) {
+      consoleLogger.warn(`[cfProxyWorker] Family DoH resolution failed for ${hostname}`);
+      return null;
+    }
+    if (ipInRanges(ip, bypassRanges)) {
+      consoleLogger.info(`[cfProxyWorker] Bypass IP matched ${ip} for ${hostname}`);
+      return { ip, bypass: true, blocked: false };
+    }
+    return { ip, bypass: false, blocked: false };
+  }
+
   try {
     const addresses = await dns.resolve4(hostname);
     for (const addr of addresses) {
       if (ipInRanges(addr, bypassRanges)) {
         consoleLogger.info(`[cfProxyWorker] Bypass IP matched ${addr} for ${hostname}`);
-        return { ip: addr, bypass: true };
+        return { ip: addr, bypass: true, blocked: false };
       }
     }
     if (addresses.length > 0) {
-      return { ip: addresses[0], bypass: false };
+      return { ip: addresses[0], bypass: false, blocked: false };
     }
   } catch (e) {
     // IPv4 failed, try IPv6
@@ -167,11 +257,11 @@ async function resolveHostname(
       for (const addr of addresses) {
         if (ipInRanges(addr, bypassRanges)) {
           consoleLogger.info(`[cfProxyWorker] Bypass IPv6 matched ${addr} for ${hostname}`);
-          return { ip: addr, bypass: true };
+          return { ip: addr, bypass: true, blocked: false };
         }
       }
       if (addresses.length > 0) {
-        return { ip: addresses[0], bypass: false };
+        return { ip: addresses[0], bypass: false, blocked: false };
       }
     } catch (err) {
       consoleLogger.warn(`[cfProxyWorker] DNS resolution failed for ${hostname}: ${(err as Error).message}`);
@@ -236,6 +326,100 @@ function readExact(socket: net.Socket, n: number): Promise<Buffer> {
   });
 }
 
+// Read the SOCKS5 greeting + CONNECT request from `clientSocket`. On success
+// returns { hostname, port }; on any protocol error or unsupported command it
+// writes the appropriate SOCKS reply, ends/destroys the socket, and returns
+// null. Only CONNECT (0x01) is supported; ATYPs 0x01/0x03/0x04 are accepted.
+async function readSocks5Request(
+  clientSocket: net.Socket,
+): Promise<{ hostname: string; port: number } | null> {
+  try {
+    const greet = await readExact(clientSocket, 2);
+    if (greet[0] !== 0x05) {
+      clientSocket.destroy();
+      return null;
+    }
+    await readExact(clientSocket, greet[1]); // discard methods
+    clientSocket.write(Buffer.from([0x05, 0x00])); // NO AUTH
+
+    const head = await readExact(clientSocket, 4);
+    if (head[0] !== 0x05) {
+      clientSocket.destroy();
+      return null;
+    }
+    if (head[1] !== 0x01) {
+      clientSocket.write(socksReply(0x07)); // command not supported
+      clientSocket.end();
+      return null;
+    }
+    const atyp = head[3];
+    let hostname: string;
+    if (atyp === 0x01) {
+      hostname = Array.from(await readExact(clientSocket, 4)).join('.');
+    } else if (atyp === 0x03) {
+      const l = (await readExact(clientSocket, 1))[0];
+      hostname = (await readExact(clientSocket, l)).toString('utf8');
+    } else if (atyp === 0x04) {
+      const b = await readExact(clientSocket, 16);
+      const parts: string[] = [];
+      for (let i = 0; i < 8; i++) parts.push(b.readUInt16BE(i * 2).toString(16));
+      hostname = parts.join(':');
+    } else {
+      clientSocket.write(socksReply(0x08));
+      clientSocket.end();
+      return null;
+    }
+    const port = (await readExact(clientSocket, 2)).readUInt16BE(0);
+    return { hostname, port };
+  } catch {
+    try {
+      clientSocket.destroy();
+    } catch {
+      /* ignore */
+    }
+    return null;
+  }
+}
+
+// Direct TCP forward: open a socket to `ip:port` and bidirectionally pipe
+// bytes to `clientSocket`. Writes the SOCKS success reply once connected and
+// wires up error/close propagation both ways. `label` is used for logging
+// only (typically the original hostname so log lines stay meaningful).
+function directForward(
+  clientSocket: net.Socket,
+  ip: string,
+  port: number,
+  label: string,
+): void {
+  const directSocket = net.createConnection({ host: ip, port }, () => {
+    try {
+      clientSocket.write(socksReply(0x00));
+      clientSocket.resume();
+      directSocket.pipe(clientSocket);
+      clientSocket.pipe(directSocket);
+    } catch {
+      directSocket.destroy();
+    }
+  });
+
+  directSocket.on('error', (err) => {
+    consoleLogger.debug(`[cfProxyWorker] Direct connection failed for ${label}: ${err.message}`);
+    if (directSocket.connecting) {
+      try { clientSocket.write(socksReply(0x05)); } catch {} // connection refused
+    }
+    try { clientSocket.end(); } catch {}
+  });
+  directSocket.on('close', () => {
+    try { clientSocket.end(); } catch {}
+  });
+  clientSocket.on('close', () => {
+    try { directSocket.destroy(); } catch {}
+  });
+  clientSocket.on('error', () => {
+    try { directSocket.destroy(); } catch {}
+  });
+}
+
 async function handleSocks5(
   clientSocket: net.Socket,
   wsUrl: string,
@@ -250,48 +434,9 @@ async function handleSocks5(
     }
   });
 
-  let hostname: string;
-  let port: number;
-  try {
-    // Greeting
-    const greet = await readExact(clientSocket, 2);
-    if (greet[0] !== 0x05) return void clientSocket.destroy();
-    await readExact(clientSocket, greet[1]); // discard methods
-    clientSocket.write(Buffer.from([0x05, 0x00])); // NO AUTH
-
-    // Request
-    const head = await readExact(clientSocket, 4);
-    if (head[0] !== 0x05) return void clientSocket.destroy();
-    if (head[1] !== 0x01) {
-      clientSocket.write(socksReply(0x07)); // command not supported
-      clientSocket.end();
-      return;
-    }
-    const atyp = head[3];
-    if (atyp === 0x01) {
-      hostname = Array.from(await readExact(clientSocket, 4)).join('.');
-    } else if (atyp === 0x03) {
-      const l = (await readExact(clientSocket, 1))[0];
-      hostname = (await readExact(clientSocket, l)).toString('utf8');
-    } else if (atyp === 0x04) {
-      const b = await readExact(clientSocket, 16);
-      const parts: string[] = [];
-      for (let i = 0; i < 8; i++) parts.push(b.readUInt16BE(i * 2).toString(16));
-      hostname = parts.join(':');
-    } else {
-      clientSocket.write(socksReply(0x08));
-      clientSocket.end();
-      return;
-    }
-    port = (await readExact(clientSocket, 2)).readUInt16BE(0);
-  } catch {
-    try {
-      clientSocket.destroy();
-    } catch {
-      /* ignore */
-    }
-    return;
-  }
+  const req = await readSocks5Request(clientSocket);
+  if (!req) return;
+  const { hostname, port } = req;
 
   // Resolve hostname and check whether it falls in the worker-provided bypass list
   const bypassRanges = await getBypassRanges(workerUrl, authToken);
@@ -302,49 +447,17 @@ async function handleSocks5(
     clientSocket.end();
     return;
   }
+  if (resolution.blocked) {
+    consoleLogger.info(`[cfProxyWorker] Refusing SOCKS connect to ${hostname} — blocked by Family DNS`);
+    clientSocket.write(socksReply(0x02)); // connection not allowed by ruleset
+    clientSocket.end();
+    return;
+  }
 
   // Bypass listed ranges - transparently forward TCP connection using Node's net module
   if (resolution.bypass) {
     consoleLogger.info(`[cfProxyWorker] Bypassing Worker for ${hostname} (${resolution.ip}) - connecting directly`);
-
-    const directSocket = net.createConnection({ host: resolution.ip, port }, () => {
-      try {
-        // Send SOCKS5 success reply with bound address
-        clientSocket.write(socksReply(0x00));
-
-        // Resume the client socket (was paused during handshake)
-        clientSocket.resume();
-
-        // Transparently pipe the connections bidirectionally
-        directSocket.pipe(clientSocket);
-        clientSocket.pipe(directSocket);
-      } catch (err) {
-        directSocket.destroy();
-      }
-    });
-
-    directSocket.on('error', (err) => {
-      consoleLogger.debug(`[cfProxyWorker] Direct connection failed for ${hostname}: ${err.message}`);
-      // If we haven't successfully connected yet, tell the SOCKS client
-      if (directSocket.connecting) {
-        try { clientSocket.write(socksReply(0x05)); } catch {} // Connection refused
-      }
-      try { clientSocket.end(); } catch {}
-    });
-
-    directSocket.on('close', () => {
-      try { clientSocket.end(); } catch {}
-    });
-
-    clientSocket.on('close', () => {
-      try { directSocket.destroy(); } catch {}
-    });
-
-    clientSocket.on('error', () => {
-      try { directSocket.destroy(); } catch {}
-    });
-
-    // Return early so we skip all the WebSocket setup below
+    directForward(clientSocket, resolution.ip, port, hostname);
     return;
   }
 
@@ -355,8 +468,12 @@ async function handleSocks5(
   let ready = false;
   const preBuffer: Buffer[] = [];
 
+  // When Family DoH is enabled we've already resolved and validated the
+  // hostname; hand the IP to the worker so its own connect() doesn't re-resolve
+  // via Cloudflare's default (non-family) resolver. TLS SNI stays end-to-end.
+  const targetForWorker = isFamilyDnsEnabled() && !isIpLiteral(hostname) ? resolution.ip : hostname;
   ws.on('open', () => {
-    ws.send(JSON.stringify({ hostname, port }));
+    ws.send(JSON.stringify({ hostname: targetForWorker, port }));
   });
 
   ws.on('message', (data: WebSocket.RawData) => {
@@ -516,4 +633,115 @@ export function startCfProxyWorker(): CfProxyWorker | null {
 
 export function isCfProxyWorkerConfigured(): boolean {
   return !!process.env.CF_WORKER_PROXY?.trim();
+}
+
+// -----------------------------------------------------------------------------
+// Local Family DoH SOCKS5 proxy (used when CF_FAMILY_DNS=1 but CF_WORKER_PROXY
+// is unset). Resolves every hostname via Cloudflare Family DoH and forwards
+// directly with net.createConnection — no WebSocket, no worker. Blocked names
+// return SOCKS reply 0x02 (ruleset denial) just like the worker path.
+// -----------------------------------------------------------------------------
+
+async function handleSocks5FamilyLocal(clientSocket: net.Socket): Promise<void> {
+  clientSocket.on('error', () => {
+    try { clientSocket.destroy(); } catch { /* ignore */ }
+  });
+
+  const req = await readSocks5Request(clientSocket);
+  if (!req) return;
+  const { hostname, port } = req;
+
+  // IP literals bypass DoH — Family filtering only applies to name lookups.
+  if (isIpLiteral(hostname)) {
+    directForward(clientSocket, hostname, port, hostname);
+    return;
+  }
+
+  const ip = await resolveViaFamilyDoH(hostname);
+  if (ip === FAMILY_BLOCKED_V4 || ip === FAMILY_BLOCKED_V6) {
+    consoleLogger.info(`[familyDnsProxy] Refusing SOCKS connect to ${hostname} — blocked by Family DNS`);
+    try { clientSocket.write(socksReply(0x02)); } catch { /* ignore */ }
+    clientSocket.end();
+    return;
+  }
+  if (!ip) {
+    consoleLogger.warn(`[familyDnsProxy] Family DoH resolution failed for ${hostname}`);
+    try { clientSocket.write(socksReply(0x04)); } catch { /* ignore */ }
+    clientSocket.end();
+    return;
+  }
+  directForward(clientSocket, ip, port, hostname);
+}
+
+let cachedFamilyLocal: CfProxyWorker | null = null;
+
+/**
+ * Start (or return the existing) local SOCKS5 proxy that enforces Cloudflare
+ * Family DoH filtering with direct TCP egress. Only starts when CF_FAMILY_DNS
+ * is set AND CF_WORKER_PROXY is not — when both are set, the worker path in
+ * startCfProxyWorker() already applies Family DoH pre-resolution.
+ */
+export function startFamilyDnsLocalProxy(): CfProxyWorker | null {
+  if (!isFamilyDnsLocalProxyConfigured()) return null;
+  if (cachedFamilyLocal) return cachedFamilyLocal;
+
+  const requestedPort = parseInt(process.env.CF_WORKER_PROXY_PORT || '8877', 10);
+  const port = findFreePort(requestedPort);
+  if (port !== requestedPort) {
+    consoleLogger.info(
+      `[familyDnsProxy] Port ${requestedPort} in use; falling back to ${port}`,
+    );
+  }
+
+  const server = net.createServer((socket) => {
+    handleSocks5FamilyLocal(socket).catch(() => {
+      try { socket.destroy(); } catch { /* ignore */ }
+    });
+  });
+
+  let listenAttempts = 0;
+  const onBindError = (err: NodeJS.ErrnoException): void => {
+    const p = cachedFamilyLocal?.port ?? port;
+    if (err.code === 'EADDRINUSE' && listenAttempts < PORT_HUNT_MAX_ATTEMPTS) {
+      consoleLogger.warn(
+        `[familyDnsProxy] Port ${p} raced (EADDRINUSE); retrying on ${p + 1}`,
+      );
+      if (cachedFamilyLocal) {
+        cachedFamilyLocal.port = p + 1;
+        cachedFamilyLocal.server = `socks5://127.0.0.1:${p + 1}`;
+      }
+      attemptListen(p + 1);
+      return;
+    }
+    consoleLogger.error(`[familyDnsProxy] SOCKS5 server error: ${err.message}`);
+  };
+  const attemptListen = (p: number): void => {
+    listenAttempts++;
+    server.once('error', onBindError);
+    server.listen(p, '127.0.0.1', () => {
+      server.off('error', onBindError);
+      server.on('error', (err: Error) => {
+        consoleLogger.error(`[familyDnsProxy] SOCKS5 server error: ${err.message}`);
+      });
+      consoleLogger.info(
+        `[familyDnsProxy] SOCKS5 (Family DoH, direct egress) listening on 127.0.0.1:${p}`,
+      );
+    });
+  };
+  attemptListen(port);
+
+  cachedFamilyLocal = {
+    server: `socks5://127.0.0.1:${port}`,
+    port,
+    stop: () =>
+      new Promise<void>((resolve) => {
+        server.close(() => resolve());
+        cachedFamilyLocal = null;
+      }),
+  };
+  return cachedFamilyLocal;
+}
+
+export function isFamilyDnsLocalProxyConfigured(): boolean {
+  return isFamilyDnsEnabled() && !process.env.CF_WORKER_PROXY?.trim();
 }

--- a/src/constants/common.ts
+++ b/src/constants/common.ts
@@ -2168,6 +2168,15 @@ export async function initModifiedUserAgent(
   _playwrightDeviceDetailsObject?: object,
   _userDataDirectory?: string,
 ) {
+  // If the caller already set OOBEE_USER_AGENT, respect it and skip the
+  // browser bootstrap. Useful when the container's native UA is undesirable
+  // (e.g. Linux Chrome tripping anti-fraud on a residential-proxy egress).
+  const preset = process.env.OOBEE_USER_AGENT?.trim();
+  if (preset) {
+    process.env.OOBEE_USER_AGENT = preset;
+    return;
+  }
+
   // UA bootstrap must not use persistent context / user-data-dir.
   // Force headless so this transient browser never flashes a visible window
   // (particularly on macOS, where there's no Xvfb indirection).

--- a/src/constants/common.ts
+++ b/src/constants/common.ts
@@ -2169,8 +2169,7 @@ export async function initModifiedUserAgent(
   _userDataDirectory?: string,
 ) {
   // If the caller already set OOBEE_USER_AGENT, respect it and skip the
-  // browser bootstrap. Useful when the container's native UA is undesirable
-  // (e.g. Linux Chrome tripping anti-fraud on a residential-proxy egress).
+  // browser bootstrap.
   const preset = process.env.OOBEE_USER_AGENT?.trim();
   if (preset) {
     process.env.OOBEE_USER_AGENT = preset;

--- a/src/proxyService.ts
+++ b/src/proxyService.ts
@@ -15,7 +15,12 @@ import os from 'os';
 import fs from 'fs';
 import path from 'path';
 import { spawnSync } from 'child_process';
-import { startCfProxyWorker, isCfProxyWorkerConfigured } from './cfProxyWorker.js';
+import {
+  startCfProxyWorker,
+  isCfProxyWorkerConfigured,
+  startFamilyDnsLocalProxy,
+  isFamilyDnsLocalProxyConfigured,
+} from './cfProxyWorker.js';
 
 export interface ProxyInfo {
   // http/https: host:port OR user:pass@host:port (no scheme)
@@ -425,10 +430,17 @@ export function getProxyInfo(): ProxyInfo | null {
   // Cloudflare Worker proxy takes precedence over all other proxy detection.
   // Starts a local SOCKS5 tunnel and points Chromium at it; the tunnel itself
   // handles bypass IPs by connecting directly (see cfProxyWorker.ts).
+  //
+  // If CF_FAMILY_DNS is set without CF_WORKER_PROXY, start a local SOCKS5
+  // proxy that enforces Family DoH filtering and forwards directly. When both
+  // are set, the worker path already applies Family DoH pre-resolution.
   let info: ProxyInfo | null;
   if (isCfProxyWorkerConfigured()) {
     const cf = startCfProxyWorker();
     info = cf ? { socks: cf.server } : null;
+  } else if (isFamilyDnsLocalProxyConfigured()) {
+    const fam = startFamilyDnsLocalProxy();
+    info = fam ? { socks: fam.server } : null;
   } else {
     const plat = os.platform();
     if (plat === 'win32') info = parseEnvProxyCommon() || parseWindowsRegistry();


### PR DESCRIPTION
## Summary

- New `CF_FAMILY_DNS` env var enforces Cloudflare Family DoH (`family.cloudflare-dns.com`, 1.1.1.3) resolution inside oobee's SOCKS5 layer.
- Works alongside the existing `CF_WORKER_PROXY` tunnel **and** standalone (no worker required).
- Blocked hostnames are refused with SOCKS reply `0x02` (connection not allowed by ruleset) before any TCP is opened.
- New `CF_WORKER_PROXY_FORCE_TUNNEL_HOSTS` glob allowlist keeps hostnames that must be routed by the Worker's own upstream-proxy allowlist from being short-circuited by the client-side bypass-IP check.
- `initModifiedUserAgent()` now honours a caller-provided `OOBEE_USER_AGENT` and skips the browser bootstrap, so integrators can customise the UA to match target-site requirements.

## Why

We deploy oobee behind the Cloudflare Worker SOCKS5 tunnel (`CF_WORKER_PROXY`) and had configured Chrome's enterprise Secure DNS policy to point at `family.cloudflare-dns.com` so scans wouldn't hit adult / malware content. It didn't work: a DNS-leak test from the tunneled browser showed Google DNS, not Cloudflare Family.

Root cause: **Chrome disables its DoH client whenever any proxy is configured** ([Chromium DoH docs](https://www.chromium.org/developers/dns-over-https/)). The moment we point Chromium at the SOCKS proxy, DoH is off and name resolution happens at whatever resolver the tunnel egress uses — in our case, Cloudflare Worker's default (non-filtered) resolver.

Fix: move Family DoH into the SOCKS5 layer, where oobee already does DNS lookups for the worker bypass-list check.

## Behavior

`CF_FAMILY_DNS` is a boolean flag (`1` / `true` / `yes` / `on`). It composes with `CF_WORKER_PROXY`:

| `CF_WORKER_PROXY` | `CF_FAMILY_DNS` | Effect |
|---|---|---|
| set | unset | Existing behavior — worker tunnel with the worker's own DNS. |
| set | set | Worker tunnel + Family DoH pre-resolution. oobee hands the resolved IP (not the hostname) to the worker so its `connect()` doesn't re-resolve. TLS SNI still terminates end-to-end at the browser. |
| unset | set | **New**: oobee starts a local SOCKS5 proxy that resolves via Family DoH and forwards directly via `net.createConnection` (no WebSocket, no worker). Chromium points at `socks5://127.0.0.1:<port>`. |
| unset | unset | No change. |

In all cases where Family DoH answers with the sentinel blocked address (`0.0.0.0` for A, `::` for AAAA), the SOCKS server writes reply `0x02` and closes the connection.

## Implementation

### `src/cfProxyWorker.ts`

- `isFamilyDnsEnabled()` reads the new `CF_FAMILY_DNS` env var.
- `queryDoh()` / `resolveViaFamilyDoH()` — minimal DoH JSON client (`Accept: application/dns-json`) against `https://family.cloudflare-dns.com/dns-query`, with a 60s in-process cache keyed by hostname. Handles the `0.0.0.0` / `::` block sentinels explicitly.
- `resolveHostname()` grew a Family DoH branch and a `blocked: boolean` flag on its result. `handleSocks5()` refuses with SOCKS `0x02` when `blocked`.
- Refactored `handleSocks5()` — extracted:
  - `readSocks5Request(clientSocket)` — pure SOCKS5 greeting + CONNECT parser. Writes the right SOCKS reply on any protocol error and returns `null`; on success returns `{ hostname, port }`.
  - `directForward(clientSocket, ip, port, label)` — reusable direct TCP forwarder (also used by the existing worker bypass-IP path).
- New standalone path when `CF_FAMILY_DNS=1` and `CF_WORKER_PROXY` unset:
  - `handleSocks5FamilyLocal()` — resolves via Family DoH, refuses blocked, forwards directly.
  - `startFamilyDnsLocalProxy()` — mirrors `startCfProxyWorker()`: same port-hunt, same `EADDRINUSE` retry loop, same `CfProxyWorker` shape.
  - `isFamilyDnsLocalProxyConfigured()` — returns `true` only when `CF_FAMILY_DNS` is on and `CF_WORKER_PROXY` is off.
- Target-for-worker rewrite: when Family DoH is on and the SOCKS client sent a hostname (not an IP literal), the worker JSON payload uses the resolved IP so the worker doesn't re-resolve via a non-family resolver.

### `src/cfProxyWorker.ts` — force-tunnel allowlist

- Reads `CF_WORKER_PROXY_FORCE_TUNNEL_HOSTS` (comma/semicolon-separated glob list, `*` wildcards) once and caches compiled regexes.
- `shouldForceTunnel(hostname)` returns true when the hostname matches any pattern.
- `handleSocks5()` gates the bypass-IP resolution branch on `!shouldForceTunnel(hostname)`. Matched hostnames are sent to the Worker as `{hostname, port}` unconditionally, preserving the Worker's hostname-based routing. Log: `[cfProxyWorker] Force-tunnel match for <host> — sending to Worker`.

### `src/constants/common.ts` — caller-controlled UA

`initModifiedUserAgent()` now checks `process.env.OOBEE_USER_AGENT` at entry. If already set, it respects the caller-provided value and returns without launching a browser to bootstrap the UA. This lets integrators pass a UA string that matches target-site requirements. Existing behaviour (bootstrap + `HeadlessChrome` → `Chrome` swap) is unchanged when the caller does not pre-set the variable.

### `src/proxyService.ts`

`getProxyInfo()` now selects the local Family DoH proxy when `CF_FAMILY_DNS=1` and `CF_WORKER_PROXY` is unset:

```ts
if (isCfProxyWorkerConfigured()) {
  const cf = startCfProxyWorker();
  info = cf ? { socks: cf.server } : null;
} else if (isFamilyDnsLocalProxyConfigured()) {
  const fam = startFamilyDnsLocalProxy();
  info = fam ? { socks: fam.server } : null;
} else {
  // existing OS-level detection
}
```

The existing "worker takes precedence" behavior is preserved: when both env vars are set, the worker path runs unchanged and applies Family DoH pre-resolution.

## Testing

- With `CF_WORKER_PROXY` + `CF_FAMILY_DNS=1`: DNS-leak test now shows Cloudflare Family (`1.1.1.3`) instead of Google. Known-blocked names (family test domains) return SOCKS `0x02` and the browser shows a proxy error page.
- Without `CF_WORKER_PROXY`, with `CF_FAMILY_DNS=1`: local SOCKS5 on `127.0.0.1:8877` accepts connections, resolves via DoH, forwards directly, refuses blocked hostnames.
- Existing `CF_WORKER_PROXY`-only path (no Family DNS): unchanged — same worker JSON payload with hostname (not IP), same bypass-IP direct-forward, same SOCKS handshake.

## Test plan

- [ ] `CF_WORKER_PROXY=<worker-url> CF_FAMILY_DNS=1 npm run cli -- -u https://…` — verify DNS-leak test shows Cloudflare Family.
- [ ] Same as above but scan a known-blocked family test host — verify the SOCKS `0x02` reply reaches the browser.
- [ ] Unset `CF_WORKER_PROXY`, set `CF_FAMILY_DNS=1` — verify oobee starts the local SOCKS5 proxy on 127.0.0.1:8877 and the scan completes.
- [ ] `CF_WORKER_PROXY=<worker-url>` alone (no `CF_FAMILY_DNS`) — verify existing tunnel behavior is unchanged.
- [ ] Bypass-IP path still direct-forwards (unchanged) — check that a Cloudflare-fronted target still hits the worker's bypass list.
- [ ] Set `CF_WORKER_PROXY_FORCE_TUNNEL_HOSTS='*.example.com'` and scan a matching host — verify the log line `[cfProxyWorker] Force-tunnel match for <host> — sending to Worker` and that the request reaches the Worker rather than being direct-forwarded.
- [ ] Pre-set `OOBEE_USER_AGENT=<custom UA>` before launching a scan — verify `navigator.userAgent` inside the scanned page reflects the custom string and that no transient browser is launched during startup for UA bootstrap.
- [ ] Do not set `OOBEE_USER_AGENT` — verify existing bootstrap flow runs (UA populated from launched browser, `HeadlessChrome` swapped for `Chrome`).
