### PR TITLE
feat(cf-worker-proxy): publish upstream-host allowlist from worker

### DIFF
--- a/examples/cf-worker-proxy.example.js
+++ b/examples/cf-worker-proxy.example.js
@@ -357,8 +357,15 @@ export default {
     }
     if (url.searchParams.has('bypass-ips')) {
       const cfRanges = BYPASS_CLOUDFLARE ? await fetchCloudflareRanges() : [];
-      const combined = [...cfRanges, ...PRIVATE_RANGES, ...EXTRA_BYPASS_RANGES];
-      return new Response(JSON.stringify(combined), {
+      const bypassRanges = [...cfRanges, ...PRIVATE_RANGES, ...EXTRA_BYPASS_RANGES];
+      // Also publish the upstream-proxy hostname allowlist so the client can
+      // force-tunnel matching hosts (skip its bypass-IP short-circuit) without
+      // hardcoding the list on its side. Only meaningful when the worker is
+      // actually routing via an upstream proxy.
+      const upstreamHosts = USE_UPSTREAM_PROXY
+        ? INCLUDE_PROXY_FOR_UPSTREAM.filter((s) => typeof s === 'string' && s && s !== '*')
+        : [];
+      return new Response(JSON.stringify({ bypassRanges, upstreamHosts }), {
         status: 200,
         headers: { 'Content-Type': 'application/json' },
       });

--- a/src/cfProxyWorker.ts
+++ b/src/cfProxyWorker.ts
@@ -55,12 +55,18 @@ function findFreePort(startPort: number, maxAttempts: number = PORT_HUNT_MAX_ATT
   );
 }
 
-// Bypass IP ranges are maintained on the worker side (single source of truth)
-// and fetched lazily via `?bypass-ips=1`. Hosts resolving to any of these are
-// connected directly rather than tunneled through the worker.
-let bypassRangesPromise: Promise<string[]> | null = null;
+// Worker-side runtime config: bypass IP ranges + upstream-proxy hostname
+// allowlist. Both are maintained on the worker side as the single source of
+// truth and fetched lazily via `?bypass-ips=1`. The response shape is
+// `{ bypassRanges, upstreamHosts }`; a legacy array response (older worker
+// deploys) is treated as `{ bypassRanges: [...], upstreamHosts: [] }`.
+interface WorkerConfig {
+  bypassRanges: string[];
+  upstreamHosts: string[];
+}
+let workerConfigPromise: Promise<WorkerConfig> | null = null;
 
-async function fetchBypassRanges(workerUrl: string, authToken?: string): Promise<string[]> {
+async function fetchWorkerConfig(workerUrl: string, authToken?: string): Promise<WorkerConfig> {
   const httpUrl = new URL(workerUrl.replace(/^wss:/i, 'https:').replace(/^ws:/i, 'http:'));
   httpUrl.searchParams.set('bypass-ips', '1');
   const headers: Record<string, string> = {};
@@ -68,26 +74,43 @@ async function fetchBypassRanges(workerUrl: string, authToken?: string): Promise
   const res = await fetch(httpUrl.toString(), { headers });
   if (!res.ok) throw new Error(`HTTP ${res.status}`);
   const data = await res.json();
-  if (!Array.isArray(data)) throw new Error('response is not an array');
-  return data.filter((x): x is string => typeof x === 'string');
+  if (Array.isArray(data)) {
+    return {
+      bypassRanges: data.filter((x): x is string => typeof x === 'string'),
+      upstreamHosts: [],
+    };
+  }
+  if (data && typeof data === 'object') {
+    const obj = data as { bypassRanges?: unknown; upstreamHosts?: unknown };
+    const bypassRanges = Array.isArray(obj.bypassRanges)
+      ? obj.bypassRanges.filter((x): x is string => typeof x === 'string')
+      : [];
+    const upstreamHosts = Array.isArray(obj.upstreamHosts)
+      ? obj.upstreamHosts.filter((x): x is string => typeof x === 'string')
+      : [];
+    return { bypassRanges, upstreamHosts };
+  }
+  throw new Error('unexpected response shape');
 }
 
-function getBypassRanges(workerUrl: string, authToken?: string): Promise<string[]> {
-  if (!bypassRangesPromise) {
-    bypassRangesPromise = fetchBypassRanges(workerUrl, authToken)
-      .then((ranges) => {
-        consoleLogger.info(`[cfProxyWorker] Loaded ${ranges.length} bypass IP range(s) from worker`);
-        return ranges;
+function getWorkerConfig(workerUrl: string, authToken?: string): Promise<WorkerConfig> {
+  if (!workerConfigPromise) {
+    workerConfigPromise = fetchWorkerConfig(workerUrl, authToken)
+      .then((cfg) => {
+        consoleLogger.info(
+          `[cfProxyWorker] Loaded worker config: ${cfg.bypassRanges.length} bypass range(s), ${cfg.upstreamHosts.length} force-tunnel host pattern(s)`,
+        );
+        return cfg;
       })
       .catch((err) => {
         consoleLogger.warn(
-          `[cfProxyWorker] Failed to fetch bypass IP ranges from worker: ${(err as Error).message}`,
+          `[cfProxyWorker] Failed to fetch worker config: ${(err as Error).message}`,
         );
-        bypassRangesPromise = null; // allow retry on next connection
-        return [];
+        workerConfigPromise = null; // allow retry on next connection
+        return { bypassRanges: [], upstreamHosts: [] };
       });
   }
-  return bypassRangesPromise;
+  return workerConfigPromise;
 }
 
 function cidrMatch(ip: string, cidr: string): boolean {
@@ -147,22 +170,16 @@ function isIpLiteral(s: string): boolean {
 // hosts resolving into it — with BYPASS_CLOUDFLARE=true that includes every
 // CF-fronted target. But the worker also has its own INCLUDE_PROXY_FOR_UPSTREAM
 // allowlist that only takes effect if the request actually reaches the worker.
-// Hostnames listed here escape the bypass check on the client side so they
-// reach the worker and can be routed through the upstream proxy.
+// Hostnames matched here escape the client-side bypass check so they reach the
+// worker and can be routed through the upstream proxy.
 //
-// Configured via CF_WORKER_PROXY_FORCE_TUNNEL_HOSTS as a comma/semicolon
-// separated glob list. Patterns support '*' wildcards.
+// Source of truth: the worker publishes its INCLUDE_PROXY_FOR_UPSTREAM list in
+// the `?bypass-ips=1` response (`upstreamHosts`). CF_WORKER_PROXY_FORCE_TUNNEL_HOSTS
+// remains as an optional override (comma/semicolon separated glob list) — set
+// it to bypass the worker-supplied list for testing or emergencies.
 
-let forceTunnelRegexesCache: RegExp[] | null = null;
-function getForceTunnelRegexes(): RegExp[] {
-  if (forceTunnelRegexesCache !== null) return forceTunnelRegexesCache;
-  const raw = process.env.CF_WORKER_PROXY_FORCE_TUNNEL_HOSTS?.trim();
-  if (!raw) {
-    forceTunnelRegexesCache = [];
-    return forceTunnelRegexesCache;
-  }
-  forceTunnelRegexesCache = raw
-    .split(/[,;]/)
+function compileGlobs(patterns: string[]): RegExp[] {
+  return patterns
     .map((s) => s.trim())
     .filter(Boolean)
     .map(
@@ -172,11 +189,23 @@ function getForceTunnelRegexes(): RegExp[] {
           'i',
         ),
     );
-  return forceTunnelRegexesCache;
 }
 
-function shouldForceTunnel(hostname: string): boolean {
-  const regexes = getForceTunnelRegexes();
+let forceTunnelOverrideCache: RegExp[] | null | undefined;
+function getForceTunnelOverride(): RegExp[] | null {
+  if (forceTunnelOverrideCache !== undefined) return forceTunnelOverrideCache;
+  const raw = process.env.CF_WORKER_PROXY_FORCE_TUNNEL_HOSTS?.trim();
+  if (!raw) {
+    forceTunnelOverrideCache = null;
+    return null;
+  }
+  forceTunnelOverrideCache = compileGlobs(raw.split(/[,;]/));
+  return forceTunnelOverrideCache;
+}
+
+function shouldForceTunnel(hostname: string, upstreamHosts: string[]): boolean {
+  const override = getForceTunnelOverride();
+  const regexes = override ?? compileGlobs(upstreamHosts);
   if (regexes.length === 0) return false;
   return regexes.some((re) => re.test(hostname));
 }
@@ -479,15 +508,15 @@ async function handleSocks5(
   if (!req) return;
   const { hostname, port } = req;
 
+  const workerCfg = await getWorkerConfig(workerUrl, authToken);
+
   // Force-tunnel allowlist: skip bypass/DoH checks so the hostname reaches
   // the worker where INCLUDE_PROXY_FOR_UPSTREAM can route it via the upstream
   // proxy. Worker handles resolution and any blocking on its side.
-  if (!isIpLiteral(hostname) && shouldForceTunnel(hostname)) {
+  if (!isIpLiteral(hostname) && shouldForceTunnel(hostname, workerCfg.upstreamHosts)) {
     consoleLogger.info(`[cfProxyWorker] Force-tunnel match for ${hostname} — sending to Worker`);
   } else {
-    // Resolve hostname and check whether it falls in the worker-provided bypass list
-    const bypassRanges = await getBypassRanges(workerUrl, authToken);
-    const resolution = await resolveHostname(hostname, bypassRanges);
+    const resolution = await resolveHostname(hostname, workerCfg.bypassRanges);
     if (!resolution) {
       consoleLogger.warn(`[cfProxyWorker] Failed to resolve hostname: ${hostname}`);
       clientSocket.write(socksReply(0x04)); // host unreachable
@@ -622,8 +651,8 @@ export function startCfProxyWorker(): CfProxyWorker | null {
   }
   const wsUrl = buildWsUrl(workerUrl);
 
-  // Warm the bypass-ranges cache so the first connection doesn't pay the fetch latency.
-  void getBypassRanges(workerUrl, authToken);
+  // Warm the worker-config cache so the first connection doesn't pay the fetch latency.
+  void getWorkerConfig(workerUrl, authToken);
 
   const server = net.createServer(socket => {
     handleSocks5(socket, wsUrl, workerUrl, authToken).catch(() => {


### PR DESCRIPTION
## Summary

Move the force-tunnel hostname allowlist from a client-side env var
(`CF_WORKER_PROXY_FORCE_TUNNEL_HOSTS`) into the worker's own
`?bypass-ips=1` response. The worker's `INCLUDE_PROXY_FOR_UPSTREAM` list
is now the single source of truth — clients fetch it alongside the
bypass IP ranges and no longer need to be configured separately.

The client env var is retained as an optional override for testing /
emergencies, but is no longer required in normal operation.

## Why

Previously, the client needed a mirror of the worker's
`INCLUDE_PROXY_FOR_UPSTREAM` allowlist so its own bypass-IP
short-circuit wouldn't send matching hosts direct instead of through
the worker. Keeping the same list in two places (worker + every client
deploy) meant every allowlist change needed a coordinated redeploy.
Publishing the list from the worker eliminates the drift risk.

## Changes

### `examples/cf-worker-proxy.example.js`

- `?bypass-ips=1` response shape changes from a bare `string[]` to
  `{ bypassRanges: string[], upstreamHosts: string[] }`.
- `upstreamHosts` is `INCLUDE_PROXY_FOR_UPSTREAM` (with `'*'` filtered
  out) when `USE_UPSTREAM_PROXY` is `true`, else `[]`. Filtering `'*'`
  keeps the "route everything via upstream" server-side behaviour
  without forcing the client to tunnel every request.

### `src/cfProxyWorker.ts`

- `getBypassRanges` → `getWorkerConfig`; the single fetch returns both
  the bypass IP ranges and the upstream-host allowlist, cached together
  in one in-process promise.
- Response parser accepts both the new object shape and the legacy
  array shape, so client and worker can be rolled out in either order.
- `shouldForceTunnel(hostname, upstreamHosts)` now takes the
  worker-supplied list as its argument. `CF_WORKER_PROXY_FORCE_TUNNEL_HOSTS`
  is read only when set — it fully overrides the worker's list, useful
  for local testing.
- Startup warm-up call updated (`getWorkerConfig` instead of the
  old `getBypassRanges`).

## Behaviour matrix

| Env override set | Worker `upstreamHosts` | Effective force-tunnel list |
|---|---|---|
| yes | any | env override wins |
| no | non-empty | worker-supplied |
| no | empty / worker unreachable | none (regular bypass behaviour) |

## Compatibility

Rollout order does not matter:

- **New client + old worker** — old worker returns a bare array; client
  reads `bypassRanges` from it and treats `upstreamHosts` as empty.
  Force-tunnel only works if the env override is set (previous
  behaviour).
- **Old client + new worker** — old client only reads the array shape.
  Would fail because the new response is an object. Deploy client
  first, or set `CF_WORKER_PROXY_FORCE_TUNNEL_HOSTS` on old clients as
  a fallback.

Recommended: roll out the client change first (backwards-compatible
with existing workers), then update the worker's `?bypass-ips=1`
response.

## Test plan

- [ ] `curl -H "Authorization: $CF_WORKER_PROXY_AUTH_TOKEN" '$WORKER/?bypass-ips=1'`
  returns an object with `bypassRanges` and `upstreamHosts` keys.
- [ ] Scan a hostname in `INCLUDE_PROXY_FOR_UPSTREAM` — client logs
  `Force-tunnel match for <host> — sending to Worker` without
  `CF_WORKER_PROXY_FORCE_TUNNEL_HOSTS` set.
- [ ] Scan a Cloudflare-fronted hostname *not* in the allowlist —
  client logs `Bypassing Worker for <host>` and connects direct.
- [ ] Set `CF_WORKER_PROXY_FORCE_TUNNEL_HOSTS=example.com` and confirm
  it fully replaces the worker-supplied list (only `example.com`
  matches).
- [ ] Point a new client at an old worker (bare-array response) — no
  crash, `upstreamHosts` treated as empty.
- [ ] `npx tsc --noEmit` clean.
