### PR TITLE
Fix/Reduce hydration-timing false positives (target-size, color-contrast, aria-hidden-focus)

### DIFF
--- a/src/constants/common.ts
+++ b/src/constants/common.ts
@@ -2329,7 +2329,7 @@ export const waitForPageLoaded = async (page: Page) => {
   const stabilityTimeout = Number(process.env.OOBEE_STABILITY_TIMEOUT_MS) || 15000;
   const quietMs          = Number(process.env.OOBEE_QUIET_MS)             || 1500;
   const maxMutations     = Number(process.env.OOBEE_MAX_MUTATIONS)        || 5000;
-  const assetWaitMs      = Number(process.env.OOBEE_ASSET_WAIT_MS)        || 2000;
+  const assetWaitMs      = Number(process.env.OOBEE_ASSET_WAIT_MS)        || 5000;
 
   // Phase 1 — wait for the `load` event (or its own hard deadline).
   const phase1Start = Date.now();

--- a/src/constants/common.ts
+++ b/src/constants/common.ts
@@ -2325,13 +2325,10 @@ export const waitForPageLoaded = async (page: Page) => {
   // page still gets a fresh window to hydrate. Defaults are sized for busy
   // Docker containers under CPU contention; lower them locally via env vars
   // if crawl throughput matters more than tail-end hydration coverage.
-  const loadTimeout        = Number(process.env.OOBEE_LOAD_TIMEOUT_MS)             || 30000;
-  const stabilityTimeout   = Number(process.env.OOBEE_STABILITY_TIMEOUT_MS)        || 15000;
-  const quietMs            = Number(process.env.OOBEE_QUIET_MS)                    || 1500;
-  const maxMutations       = Number(process.env.OOBEE_MAX_MUTATIONS)               || 5000;
-  const layoutTimeout      = Number(process.env.OOBEE_LAYOUT_STABILITY_TIMEOUT_MS) || 3000;
-  const layoutStableFrames = Number(process.env.OOBEE_LAYOUT_STABLE_FRAMES)        || 4;
-  const layoutMaxTargets   = Number(process.env.OOBEE_LAYOUT_MAX_TARGETS)          || 200;
+  const loadTimeout      = Number(process.env.OOBEE_LOAD_TIMEOUT_MS)      || 30000;
+  const stabilityTimeout = Number(process.env.OOBEE_STABILITY_TIMEOUT_MS) || 15000;
+  const quietMs          = Number(process.env.OOBEE_QUIET_MS)             || 1500;
+  const maxMutations     = Number(process.env.OOBEE_MAX_MUTATIONS)        || 5000;
 
   // Phase 1 — wait for the `load` event (or its own hard deadline).
   const phase1Start = Date.now();
@@ -2440,123 +2437,23 @@ export const waitForPageLoaded = async (page: Page) => {
     ).catch(() => 'observer errored'),
   ]);
 
-  // Phase 3 — layout-stability probe. Phase 2 catches DOM mutations, but SPA
-  // frameworks (notably Salesforce Lightning) trigger late CSS-driven reflow
-  // that the novelty filter treats as churn: a class flip during hydration
-  // passes once, then a downstream media-query cascade or sticky-header swap
-  // resizes elements without new mutations. ResizeObserver on interactive +
-  // landmark elements catches those. Budget is intentionally short — on quiet
-  // pages this resolves in ~one rAF (few ms).
-  const phase3Start = Date.now();
-  const layoutReason = await Promise.race([
-    new Promise<string>(resolve =>
-      setTimeout(() => resolve('layout hard deadline'), layoutTimeout),
-    ),
-    page.evaluate(
-      ({ neededFrames, maxTargets }) => {
-        return new Promise<string>(resolve => {
-          if (typeof ResizeObserver === 'undefined') {
-            resolve('no ResizeObserver');
-            return;
-          }
-          // Focus on elements whose bounding rect drives axe geometry rules:
-          // interactive controls (target-size) + header/nav landmarks (sticky-
-          // header shifts). Deliberately exclude `main` and `footer` — on
-          // content-heavy SPAs those resize continuously as lazy images/
-          // components hydrate below the fold, which never lets the counter
-          // settle even though the header state is long stable. Cap to avoid
-          // pathological perf on huge pages.
-          const sel =
-            'a, button, input, select, textarea, [role="button"], [role="link"], ' +
-            'header, nav, [role="banner"]';
-          const nodes = document.querySelectorAll(sel);
-          const targets: Element[] = [];
-          for (let i = 0; i < nodes.length && targets.length < maxTargets; i++) {
-            targets.push(nodes[i]);
-          }
-          if (targets.length === 0) {
-            resolve('no targets');
-            return;
-          }
-
-          // Ignore sub-pixel jitter: browsers occasionally emit fractional
-          // ResizeObserver entries during scroll/zoom or on fractional device
-          // pixel ratios. Only deltas ≥ SIGNIFICANT_PX reset the stability
-          // counter. Below that, treat the element as unchanged.
-          const SIGNIFICANT_PX = 1;
-          const lastSize = new WeakMap<Element, { w: number; h: number }>();
-          let stableFrames = 0;
-          let done = false;
-          const ro = new ResizeObserver(entries => {
-            let significant = false;
-            for (const entry of entries) {
-              const rect = entry.contentRect;
-              const prev = lastSize.get(entry.target);
-              if (
-                !prev ||
-                Math.abs(rect.width - prev.w) >= SIGNIFICANT_PX ||
-                Math.abs(rect.height - prev.h) >= SIGNIFICANT_PX
-              ) {
-                significant = true;
-                lastSize.set(entry.target, { w: rect.width, h: rect.height });
-              }
-            }
-            if (significant) stableFrames = 0;
-          });
-          try {
-            targets.forEach(el => ro.observe(el));
-          } catch {
-            ro.disconnect();
-            resolve('observer errored');
-            return;
-          }
-
-          const tick = () => {
-            if (done) return;
-            stableFrames++;
-            if (stableFrames >= neededFrames) {
-              done = true;
-              ro.disconnect();
-              resolve('layout stabilized');
-              return;
-            }
-            requestAnimationFrame(tick);
-          };
-          requestAnimationFrame(tick);
-        });
-      },
-      { neededFrames: layoutStableFrames, maxTargets: layoutMaxTargets },
-    ).catch(() => 'layout probe errored'),
-  ]);
-
   const phase1Ms = phase2Start - phase1Start;
-  const phase2Ms = phase3Start - phase2Start;
-  const phase3Ms = Date.now() - phase3Start;
+  const phase2Ms = Date.now() - phase2Start;
   // Log at debug level so operators can spot pages that need bigger budgets
   // (i.e. pages resolving via a hard deadline rather than a stability signal).
-  // Emit warn when either the DOM-stability or layout-stability phase hits its
-  // hard deadline — those are the cases that most often produce intermittent
-  // hydration-timing findings.
+  // Emit warn only when we time out on stability — that's the case that most
+  // often produces the intermittent hydration-timing findings.
   if (stabilityReason === 'stability hard deadline') {
     consoleLogger.warn(
       `waitForPageLoaded: stability hard deadline hit after ${phase1Ms}ms load + ${phase2Ms}ms stability. ` +
         `Page may still be hydrating. Consider raising OOBEE_STABILITY_TIMEOUT_MS (current: ${stabilityTimeout}) ` +
         `or OOBEE_QUIET_MS (current: ${quietMs}).`,
     );
-  }
-  if (layoutReason === 'layout hard deadline') {
-    consoleLogger.warn(
-      `waitForPageLoaded: layout hard deadline hit after ${phase3Ms}ms. ` +
-        `Elements still resizing after DOM stabilized — likely late CSS-driven reflow ` +
-        `(e.g. Salesforce Lightning). Consider raising OOBEE_LAYOUT_STABILITY_TIMEOUT_MS ` +
-        `(current: ${layoutTimeout}) or OOBEE_LAYOUT_STABLE_FRAMES (current: ${layoutStableFrames}).`,
+  } else {
+    consoleLogger.debug(
+      `waitForPageLoaded: load="${loadReason}" (${phase1Ms}ms) stability="${stabilityReason}" (${phase2Ms}ms)`,
     );
   }
-  consoleLogger.debug(
-    `waitForPageLoaded: load="${loadReason}" (${phase1Ms}ms) ` +
-      `stability="${stabilityReason}" (${phase2Ms}ms) ` +
-      `layout="${layoutReason}" (${phase3Ms}ms)`,
-  );
 };
 
 function isValidHttpUrl(urlString: string) {

--- a/src/constants/common.ts
+++ b/src/constants/common.ts
@@ -2460,11 +2460,15 @@ export const waitForPageLoaded = async (page: Page) => {
             return;
           }
           // Focus on elements whose bounding rect drives axe geometry rules:
-          // interactive controls (target-size) + landmarks (region/sticky-
-          // header shifts). Cap to avoid pathological perf on huge pages.
+          // interactive controls (target-size) + header/nav landmarks (sticky-
+          // header shifts). Deliberately exclude `main` and `footer` — on
+          // content-heavy SPAs those resize continuously as lazy images/
+          // components hydrate below the fold, which never lets the counter
+          // settle even though the header state is long stable. Cap to avoid
+          // pathological perf on huge pages.
           const sel =
             'a, button, input, select, textarea, [role="button"], [role="link"], ' +
-            'header, nav, main, footer, [role="banner"], [role="navigation"]';
+            'header, nav, [role="banner"]';
           const nodes = document.querySelectorAll(sel);
           const targets: Element[] = [];
           for (let i = 0; i < nodes.length && targets.length < maxTargets; i++) {
@@ -2475,10 +2479,29 @@ export const waitForPageLoaded = async (page: Page) => {
             return;
           }
 
+          // Ignore sub-pixel jitter: browsers occasionally emit fractional
+          // ResizeObserver entries during scroll/zoom or on fractional device
+          // pixel ratios. Only deltas ≥ SIGNIFICANT_PX reset the stability
+          // counter. Below that, treat the element as unchanged.
+          const SIGNIFICANT_PX = 1;
+          const lastSize = new WeakMap<Element, { w: number; h: number }>();
           let stableFrames = 0;
           let done = false;
-          const ro = new ResizeObserver(() => {
-            stableFrames = 0;
+          const ro = new ResizeObserver(entries => {
+            let significant = false;
+            for (const entry of entries) {
+              const rect = entry.contentRect;
+              const prev = lastSize.get(entry.target);
+              if (
+                !prev ||
+                Math.abs(rect.width - prev.w) >= SIGNIFICANT_PX ||
+                Math.abs(rect.height - prev.h) >= SIGNIFICANT_PX
+              ) {
+                significant = true;
+                lastSize.set(entry.target, { w: rect.width, h: rect.height });
+              }
+            }
+            if (significant) stableFrames = 0;
           });
           try {
             targets.forEach(el => ro.observe(el));

--- a/src/constants/common.ts
+++ b/src/constants/common.ts
@@ -2325,10 +2325,13 @@ export const waitForPageLoaded = async (page: Page) => {
   // page still gets a fresh window to hydrate. Defaults are sized for busy
   // Docker containers under CPU contention; lower them locally via env vars
   // if crawl throughput matters more than tail-end hydration coverage.
-  const loadTimeout      = Number(process.env.OOBEE_LOAD_TIMEOUT_MS)      || 30000;
-  const stabilityTimeout = Number(process.env.OOBEE_STABILITY_TIMEOUT_MS) || 15000;
-  const quietMs          = Number(process.env.OOBEE_QUIET_MS)             || 1500;
-  const maxMutations     = Number(process.env.OOBEE_MAX_MUTATIONS)        || 5000;
+  const loadTimeout        = Number(process.env.OOBEE_LOAD_TIMEOUT_MS)             || 30000;
+  const stabilityTimeout   = Number(process.env.OOBEE_STABILITY_TIMEOUT_MS)        || 15000;
+  const quietMs            = Number(process.env.OOBEE_QUIET_MS)                    || 1500;
+  const maxMutations       = Number(process.env.OOBEE_MAX_MUTATIONS)               || 5000;
+  const layoutTimeout      = Number(process.env.OOBEE_LAYOUT_STABILITY_TIMEOUT_MS) || 3000;
+  const layoutStableFrames = Number(process.env.OOBEE_LAYOUT_STABLE_FRAMES)        || 4;
+  const layoutMaxTargets   = Number(process.env.OOBEE_LAYOUT_MAX_TARGETS)          || 200;
 
   // Phase 1 — wait for the `load` event (or its own hard deadline).
   const phase1Start = Date.now();
@@ -2437,23 +2440,100 @@ export const waitForPageLoaded = async (page: Page) => {
     ).catch(() => 'observer errored'),
   ]);
 
+  // Phase 3 — layout-stability probe. Phase 2 catches DOM mutations, but SPA
+  // frameworks (notably Salesforce Lightning) trigger late CSS-driven reflow
+  // that the novelty filter treats as churn: a class flip during hydration
+  // passes once, then a downstream media-query cascade or sticky-header swap
+  // resizes elements without new mutations. ResizeObserver on interactive +
+  // landmark elements catches those. Budget is intentionally short — on quiet
+  // pages this resolves in ~one rAF (few ms).
+  const phase3Start = Date.now();
+  const layoutReason = await Promise.race([
+    new Promise<string>(resolve =>
+      setTimeout(() => resolve('layout hard deadline'), layoutTimeout),
+    ),
+    page.evaluate(
+      ({ neededFrames, maxTargets }) => {
+        return new Promise<string>(resolve => {
+          if (typeof ResizeObserver === 'undefined') {
+            resolve('no ResizeObserver');
+            return;
+          }
+          // Focus on elements whose bounding rect drives axe geometry rules:
+          // interactive controls (target-size) + landmarks (region/sticky-
+          // header shifts). Cap to avoid pathological perf on huge pages.
+          const sel =
+            'a, button, input, select, textarea, [role="button"], [role="link"], ' +
+            'header, nav, main, footer, [role="banner"], [role="navigation"]';
+          const nodes = document.querySelectorAll(sel);
+          const targets: Element[] = [];
+          for (let i = 0; i < nodes.length && targets.length < maxTargets; i++) {
+            targets.push(nodes[i]);
+          }
+          if (targets.length === 0) {
+            resolve('no targets');
+            return;
+          }
+
+          let stableFrames = 0;
+          let done = false;
+          const ro = new ResizeObserver(() => {
+            stableFrames = 0;
+          });
+          try {
+            targets.forEach(el => ro.observe(el));
+          } catch {
+            ro.disconnect();
+            resolve('observer errored');
+            return;
+          }
+
+          const tick = () => {
+            if (done) return;
+            stableFrames++;
+            if (stableFrames >= neededFrames) {
+              done = true;
+              ro.disconnect();
+              resolve('layout stabilized');
+              return;
+            }
+            requestAnimationFrame(tick);
+          };
+          requestAnimationFrame(tick);
+        });
+      },
+      { neededFrames: layoutStableFrames, maxTargets: layoutMaxTargets },
+    ).catch(() => 'layout probe errored'),
+  ]);
+
   const phase1Ms = phase2Start - phase1Start;
-  const phase2Ms = Date.now() - phase2Start;
+  const phase2Ms = phase3Start - phase2Start;
+  const phase3Ms = Date.now() - phase3Start;
   // Log at debug level so operators can spot pages that need bigger budgets
   // (i.e. pages resolving via a hard deadline rather than a stability signal).
-  // Emit warn only when we time out on stability — that's the case that most
-  // often produces the intermittent hydration-timing findings.
+  // Emit warn when either the DOM-stability or layout-stability phase hits its
+  // hard deadline — those are the cases that most often produce intermittent
+  // hydration-timing findings.
   if (stabilityReason === 'stability hard deadline') {
     consoleLogger.warn(
       `waitForPageLoaded: stability hard deadline hit after ${phase1Ms}ms load + ${phase2Ms}ms stability. ` +
         `Page may still be hydrating. Consider raising OOBEE_STABILITY_TIMEOUT_MS (current: ${stabilityTimeout}) ` +
         `or OOBEE_QUIET_MS (current: ${quietMs}).`,
     );
-  } else {
-    consoleLogger.debug(
-      `waitForPageLoaded: load="${loadReason}" (${phase1Ms}ms) stability="${stabilityReason}" (${phase2Ms}ms)`,
+  }
+  if (layoutReason === 'layout hard deadline') {
+    consoleLogger.warn(
+      `waitForPageLoaded: layout hard deadline hit after ${phase3Ms}ms. ` +
+        `Elements still resizing after DOM stabilized — likely late CSS-driven reflow ` +
+        `(e.g. Salesforce Lightning). Consider raising OOBEE_LAYOUT_STABILITY_TIMEOUT_MS ` +
+        `(current: ${layoutTimeout}) or OOBEE_LAYOUT_STABLE_FRAMES (current: ${layoutStableFrames}).`,
     );
   }
+  consoleLogger.debug(
+    `waitForPageLoaded: load="${loadReason}" (${phase1Ms}ms) ` +
+      `stability="${stabilityReason}" (${phase2Ms}ms) ` +
+      `layout="${layoutReason}" (${phase3Ms}ms)`,
+  );
 };
 
 function isValidHttpUrl(urlString: string) {

--- a/src/constants/common.ts
+++ b/src/constants/common.ts
@@ -2329,6 +2329,7 @@ export const waitForPageLoaded = async (page: Page) => {
   const stabilityTimeout = Number(process.env.OOBEE_STABILITY_TIMEOUT_MS) || 15000;
   const quietMs          = Number(process.env.OOBEE_QUIET_MS)             || 1500;
   const maxMutations     = Number(process.env.OOBEE_MAX_MUTATIONS)        || 5000;
+  const assetWaitMs      = Number(process.env.OOBEE_ASSET_WAIT_MS)        || 2000;
 
   // Phase 1 — wait for the `load` event (or its own hard deadline).
   const phase1Start = Date.now();
@@ -2437,21 +2438,57 @@ export const waitForPageLoaded = async (page: Page) => {
     ).catch(() => 'observer errored'),
   ]);
 
+  // Phase 2.5 — wait for fonts and images (raster + SVG-as-<img>) to finish
+  // loading. Both are deterministic browser signals: font swap reflows every
+  // text-bearing element (color-contrast), and image/SVG load resolves the
+  // intrinsic dimensions that anchor tags depend on (target-size). MutationObserver
+  // in phase 2 doesn't catch these — a font swap or SVG paint doesn't necessarily
+  // produce a DOM mutation, but it does change measured geometry.
+  const phase25Start = Date.now();
+  const phase25Reason = await Promise.race([
+    new Promise<string>(resolve =>
+      setTimeout(() => resolve('asset hard deadline'), assetWaitMs),
+    ),
+    page
+      .evaluate(
+        () =>
+          Promise.all([
+            'fonts' in document && document.fonts?.ready
+              ? document.fonts.ready.then(() => undefined)
+              : Promise.resolve(),
+            Promise.all(
+              (Array.from(document.images) as HTMLImageElement[])
+                .filter(img => !img.complete)
+                .map(
+                  img =>
+                    new Promise<void>(res => {
+                      const done = () => res();
+                      img.addEventListener('load', done, { once: true });
+                      img.addEventListener('error', done, { once: true });
+                    }),
+                ),
+            ).then(() => undefined),
+          ]).then(() => 'assets loaded'),
+      )
+      .catch(() => 'asset probe errored'),
+  ]);
+
   const phase1Ms = phase2Start - phase1Start;
-  const phase2Ms = Date.now() - phase2Start;
+  const phase2Ms = phase25Start - phase2Start;
+  const phase25Ms = Date.now() - phase25Start;
   // Log at debug level so operators can spot pages that need bigger budgets
   // (i.e. pages resolving via a hard deadline rather than a stability signal).
   // Emit warn only when we time out on stability — that's the case that most
   // often produces the intermittent hydration-timing findings.
   if (stabilityReason === 'stability hard deadline') {
     consoleLogger.warn(
-      `waitForPageLoaded: stability hard deadline hit after ${phase1Ms}ms load + ${phase2Ms}ms stability. ` +
+      `waitForPageLoaded: stability hard deadline hit after ${phase1Ms}ms load + ${phase2Ms}ms stability + ${phase25Ms}ms assets. ` +
         `Page may still be hydrating. Consider raising OOBEE_STABILITY_TIMEOUT_MS (current: ${stabilityTimeout}) ` +
         `or OOBEE_QUIET_MS (current: ${quietMs}).`,
     );
   } else {
     consoleLogger.debug(
-      `waitForPageLoaded: load="${loadReason}" (${phase1Ms}ms) stability="${stabilityReason}" (${phase2Ms}ms)`,
+      `waitForPageLoaded: load="${loadReason}" (${phase1Ms}ms) stability="${stabilityReason}" (${phase2Ms}ms) assets="${phase25Reason}" (${phase25Ms}ms)`,
     );
   }
 };

--- a/src/crawlers/commonCrawlerFunc.ts
+++ b/src/crawlers/commonCrawlerFunc.ts
@@ -1132,83 +1132,164 @@ export const runAxeScript = async ({
             resultTypes: defaultResultTypes,
           })
           .then(async results => {
-            // Re-verify target-size violations against the live DOM. SPA
-            // frameworks (notably Salesforce Lightning, but also any site
-            // whose interactive elements get their final layout from async
-            // hydration or late CSS-driven reflow) can resize an anchor or
-            // button after axe measured boundingClientRect but before the
-            // finding is written. If the element's current rect meets the
-            // rule's minSize, treat axe's smaller measurement as stale and
-            // drop the finding. Scoped to the "element too small" cases
-            // (no messageKey, or contentOverflow — which only fires when
-            // the element itself is too small); partially-obscured findings
-            // depend on neighbor geometry and are left alone.
-            const targetSizeViolation = results.violations.find(
-              v => v.id === 'target-size',
-            );
-            if (targetSizeViolation) {
-              await new Promise(resolve => setTimeout(resolve, 0));
-              const DEFAULT_MIN_SIZE = 24;
-              targetSizeViolation.nodes = targetSizeViolation.nodes.filter(node => {
-                const selector = node.target && node.target[0];
-                if (typeof selector !== 'string') return true;
-                const axeCheck = (node.any || []).find(c => c.id === 'target-size') as
-                  | { data?: { minSize?: number; messageKey?: string } }
-                  | undefined;
-                const data = axeCheck && axeCheck.data;
-                if (!data) return true;
-                const mk = data.messageKey;
-                if (mk && mk !== 'contentOverflow') return true;
-                const minSize =
-                  typeof data.minSize === 'number' ? data.minSize : DEFAULT_MIN_SIZE;
-                try {
-                  const el = document.querySelector(selector);
-                  if (!el) return true;
-                  const rect = el.getBoundingClientRect();
-                  return !(rect.width >= minSize && rect.height >= minSize);
-                } catch {
-                  return true;
-                }
-              });
-              if (targetSizeViolation.nodes.length === 0) {
+            // ==== Re-verify select violations against the live DOM ====
+            //
+            // Some rules produce false positives when axe evaluates an
+            // element whose state hasn't finished settling (mid-hydration
+            // reflow, late aria-attribute injection, CSS-variable theme
+            // swap). For those rules we re-check each flagged node after a
+            // microtask yield and drop findings whose failure condition no
+            // longer holds. All logic below runs in the browser context.
+
+            // One yield lets any pending microtasks (post-axe layout /
+            // hydration continuations) flush before we re-inspect.
+            await new Promise(resolve => setTimeout(resolve, 0));
+
+            // ---- Shared helpers -----------------------------------------
+
+            // Extract axe's per-node selector (first entry of node.target).
+            const getSelector = (n: NodeResult): string | null => {
+              const s = n.target && n.target[0];
+              return typeof s === 'string' ? s : null;
+            };
+
+            // Extract check data (e.g. { minSize, messageKey }) for a given
+            // check id from an axe node result.
+            const getCheckData = <T>(n: NodeResult, checkId: string): T | null => {
+              const c = (n.any || []).find(x => x.id === checkId) as
+                | { data?: T }
+                | undefined;
+              return c && c.data != null ? c.data : null;
+            };
+
+            // Filter a violation's nodes with a keep predicate. If nodes
+            // empty out, remove the violation entirely.
+            const pruneViolation = (
+              ruleId: string,
+              keep: (n: NodeResult) => boolean,
+            ): void => {
+              const v = results.violations.find(x => x.id === ruleId);
+              if (!v) return;
+              v.nodes = v.nodes.filter(keep);
+              if (v.nodes.length === 0) {
                 results.violations = results.violations.filter(
-                  v => v.id !== 'target-size',
+                  x => x.id !== ruleId,
                 );
               }
-            }
+            };
 
-            // Re-verify aria-hidden-focus violations against the live DOM to
-            // handle race conditions with JS that sets tabindex="-1" after
-            // aria-hidden (common in carousel/slider libraries like slick)
-            const ariaHiddenViolation = results.violations.find(
-              v => v.id === 'aria-hidden-focus',
-            );
-            if (ariaHiddenViolation) {
-              await new Promise(resolve => setTimeout(resolve, 0));
-              ariaHiddenViolation.nodes = ariaHiddenViolation.nodes.filter(node => {
-                const selector = node.target && node.target[0];
-                if (typeof selector !== 'string') return true;
-                try {
-                  const el = document.querySelector(selector);
-                  if (!el) return true;
-                  const focusables = el.querySelectorAll(
-                    'a[href], area[href], button:not([disabled]), input:not([disabled]):not([type="hidden"]), select:not([disabled]), textarea:not([disabled]), [tabindex]',
-                  );
-                  if (focusables.length === 0) return false;
-                  return Array.from(focusables).some(child => {
-                    const tabindex = child.getAttribute('tabindex');
-                    if (tabindex === null) return true;
-                    const parsed = parseInt(tabindex, 10);
-                    return isNaN(parsed) || parsed >= 0;
-                  });
-                } catch {
-                  return true;
-                }
+            // Resolve a selector to an Element, suppressing invalid-selector
+            // exceptions (axe can emit selectors the browser refuses).
+            const resolveElement = (sel: string): Element | null => {
+              try {
+                return document.querySelector(sel);
+              } catch {
+                return null;
+              }
+            };
+
+            // ---- target-size --------------------------------------------
+            // SPA frameworks (notably Salesforce Lightning) can resize an
+            // interactive element after axe measured boundingClientRect.
+            // Drop the finding if the element now meets the rule's minSize.
+            // Scoped to the "element too small" cases (no messageKey, or
+            // contentOverflow — which only fires when the element itself
+            // is too small); partially-obscured findings depend on
+            // neighbor geometry and are left alone.
+            const DEFAULT_TARGET_MIN_SIZE = 24;
+            pruneViolation('target-size', node => {
+              const sel = getSelector(node);
+              if (!sel) return true;
+              const data = getCheckData<{ minSize?: number; messageKey?: string }>(
+                node,
+                'target-size',
+              );
+              if (!data) return true;
+              if (data.messageKey && data.messageKey !== 'contentOverflow') return true;
+              const minSize =
+                typeof data.minSize === 'number' ? data.minSize : DEFAULT_TARGET_MIN_SIZE;
+              const el = resolveElement(sel);
+              if (!el) return true;
+              const rect = el.getBoundingClientRect();
+              return !(rect.width >= minSize && rect.height >= minSize);
+            });
+
+            // ---- aria-hidden-focus --------------------------------------
+            // Handle race conditions with JS that sets tabindex="-1" after
+            // aria-hidden (common in carousel/slider libraries like slick).
+            const FOCUSABLE_SELECTOR =
+              'a[href], area[href], button:not([disabled]), ' +
+              'input:not([disabled]):not([type="hidden"]), ' +
+              'select:not([disabled]), textarea:not([disabled]), [tabindex]';
+            pruneViolation('aria-hidden-focus', node => {
+              const sel = getSelector(node);
+              if (!sel) return true;
+              const el = resolveElement(sel);
+              if (!el) return true;
+              const focusables = el.querySelectorAll(FOCUSABLE_SELECTOR);
+              if (focusables.length === 0) return false;
+              return Array.from(focusables).some(child => {
+                const tabindex = child.getAttribute('tabindex');
+                if (tabindex === null) return true;
+                const parsed = parseInt(tabindex, 10);
+                return Number.isNaN(parsed) || parsed >= 0;
               });
-              if (ariaHiddenViolation.nodes.length === 0) {
-                results.violations = results.violations.filter(
-                  v => v.id !== 'aria-hidden-focus',
-                );
+            });
+
+            // ---- color-contrast -----------------------------------------
+            // CSS-variable theme swaps and late-loading stylesheets can
+            // cause text to briefly render on the wrong background. Re-run
+            // axe scoped to just the flagged elements with only the
+            // color-contrast rule and drop findings that no longer fail.
+            // Uses axe's own logic to avoid reimplementing color
+            // composition (ancestor background walk, opacity, gradients).
+            const colorContrastViolation = results.violations.find(
+              v => v.id === 'color-contrast',
+            );
+            if (colorContrastViolation && colorContrastViolation.nodes.length > 0) {
+              try {
+                // Map each flagged node to its live element so we can match
+                // re-run results back to originals by identity — axe may
+                // regenerate slightly different selectors across runs on a
+                // hydrating page.
+                const nodeElements = new Map<NodeResult, Element>();
+                for (const node of colorContrastViolation.nodes) {
+                  const sel = getSelector(node);
+                  if (!sel) continue;
+                  const el = resolveElement(sel);
+                  if (el) nodeElements.set(node, el);
+                }
+                if (nodeElements.size > 0) {
+                  const uniqueElements = Array.from(new Set(nodeElements.values()));
+                  const reRun = await axe.run(uniqueElements, {
+                    runOnly: ['color-contrast'],
+                    resultTypes: ['violations'],
+                  });
+                  const stillFailing = new WeakSet<Element>();
+                  for (const v of reRun.violations || []) {
+                    for (const n of v.nodes) {
+                      const s = getSelector(n as NodeResult);
+                      if (!s) continue;
+                      const el = resolveElement(s);
+                      if (el) stillFailing.add(el);
+                    }
+                  }
+                  colorContrastViolation.nodes = colorContrastViolation.nodes.filter(
+                    n => {
+                      const el = nodeElements.get(n);
+                      // If we couldn't resolve the element, be conservative
+                      // and keep the finding.
+                      return el ? stillFailing.has(el) : true;
+                    },
+                  );
+                  if (colorContrastViolation.nodes.length === 0) {
+                    results.violations = results.violations.filter(
+                      v => v.id !== 'color-contrast',
+                    );
+                  }
+                }
+              } catch {
+                // Re-run failed; keep original findings to be safe.
               }
             }
 

--- a/src/crawlers/commonCrawlerFunc.ts
+++ b/src/crawlers/commonCrawlerFunc.ts
@@ -1132,6 +1132,51 @@ export const runAxeScript = async ({
             resultTypes: defaultResultTypes,
           })
           .then(async results => {
+            // Re-verify target-size violations against the live DOM. SPA
+            // frameworks (notably Salesforce Lightning, but also any site
+            // whose interactive elements get their final layout from async
+            // hydration or late CSS-driven reflow) can resize an anchor or
+            // button after axe measured boundingClientRect but before the
+            // finding is written. If the element's current rect meets the
+            // rule's minSize, treat axe's smaller measurement as stale and
+            // drop the finding. Scoped to the "element too small" cases
+            // (no messageKey, or contentOverflow — which only fires when
+            // the element itself is too small); partially-obscured findings
+            // depend on neighbor geometry and are left alone.
+            const targetSizeViolation = results.violations.find(
+              v => v.id === 'target-size',
+            );
+            if (targetSizeViolation) {
+              await new Promise(resolve => setTimeout(resolve, 0));
+              const DEFAULT_MIN_SIZE = 24;
+              targetSizeViolation.nodes = targetSizeViolation.nodes.filter(node => {
+                const selector = node.target && node.target[0];
+                if (typeof selector !== 'string') return true;
+                const axeCheck = (node.any || []).find(c => c.id === 'target-size') as
+                  | { data?: { minSize?: number; messageKey?: string } }
+                  | undefined;
+                const data = axeCheck && axeCheck.data;
+                if (!data) return true;
+                const mk = data.messageKey;
+                if (mk && mk !== 'contentOverflow') return true;
+                const minSize =
+                  typeof data.minSize === 'number' ? data.minSize : DEFAULT_MIN_SIZE;
+                try {
+                  const el = document.querySelector(selector);
+                  if (!el) return true;
+                  const rect = el.getBoundingClientRect();
+                  return !(rect.width >= minSize && rect.height >= minSize);
+                } catch {
+                  return true;
+                }
+              });
+              if (targetSizeViolation.nodes.length === 0) {
+                results.violations = results.violations.filter(
+                  v => v.id !== 'target-size',
+                );
+              }
+            }
+
             // Re-verify aria-hidden-focus violations against the live DOM to
             // handle race conditions with JS that sets tabindex="-1" after
             // aria-hidden (common in carousel/slider libraries like slick)


### PR DESCRIPTION
## Summary

Cuts intermittent axe findings that come from scanning a page mid-hydration rather than real accessibility defects. Two complementary changes:

1. **Phase 2.5 in `waitForPageLoaded`** — after DOM stability, wait for `document.fonts.ready` and all `document.images` to finish loading, capped by `OOBEE_ASSET_WAIT_MS` (default `5000ms`). Font swap and image/SVG paint change measured geometry without necessarily producing DOM mutations, so MutationObserver in Phase 2 doesn't catch them.
2. **Post-axe re-verification against the live DOM** for `target-size`, `color-contrast`, and `aria-hidden-focus`. After `axe.run()` returns, each flagged node is re-checked once its enclosing state has settled; findings whose failure condition no longer holds are dropped.

## Why

Some rules produce false positives when axe evaluates an element whose state hasn't finished settling — mid-hydration reflow, late aria-attribute injection, CSS-variable theme swap, late-loading stylesheets. The report is then written against an intermediate state the user never actually sees.

Motivating cases seen in the wild:
- **CPF logo (SVG-in-anchor)** intermittently flagged as `24×16` target-size because the anchor's box hadn't settled when axe measured.
- **Salesforce Lightning / LWC** pages resizing interactive elements after axe's `getBoundingClientRect`.
- **CSS-variable theme swaps** causing text to briefly render on the wrong background before the final theme is applied.
- **Carousel/slider libraries (e.g. slick)** setting `tabindex="-1"` on focusable descendants after `aria-hidden` is applied.

## What changed

### `src/constants/common.ts` — `waitForPageLoaded`
- New Phase 2.5 awaits `document.fonts.ready` and outstanding `<img>` loads in parallel, race-capped by `OOBEE_ASSET_WAIT_MS`.
- New tunable: `OOBEE_ASSET_WAIT_MS` (default `5000ms`). Bumped from an initial `2000ms` after Docker runs under CPU contention hit the deadline on pages with slow font servers or many lazy-loading images.
- Debug/warn log lines updated to include the assets phase timing and reason.

### `src/crawlers/commonCrawlerFunc.ts` — `runAxeScript`
- Introduced shared helpers (`getSelector`, `getCheckData`, `pruneViolation`, `resolveElement`) so each rule's re-check reads as its predicate plus a two-line `pruneViolation` call.
- **`target-size`**: re-measure each flagged element's `getBoundingClientRect` and drop the finding if it now meets the rule's `minSize`. Scoped to the "element too small" cases (no `messageKey`, or `contentOverflow`); partially-obscured / `tooManyRects` findings depend on neighbor geometry and are left alone.
- **`color-contrast`**: re-run axe scoped to just the flagged elements with `runOnly: ['color-contrast']` and drop findings that no longer fail. Uses axe's own logic to avoid reimplementing color composition (ancestor background walk, opacity, gradients). Matches re-run results back to originals by element identity — axe may regenerate slightly different selectors across runs on a hydrating page.
- **`aria-hidden-focus`**: migrated to the shared helpers; behavior unchanged.
- All re-checks yield one microtask before inspecting so any pending post-axe layout / hydration continuations flush first. Re-run failures fall through conservatively (keep the original finding).

## Notes on approach

An earlier iteration on this branch tried a Phase 3 layout-stability probe (`ResizeObserver` + N consecutive stable rAF frames). It worked on macOS (~1 warn in 11 pages) but never resolved on Docker's headless Chromium, deadlining on every page — 3s wasted per page with no guarantee the flake was actually prevented. That probe was reverted in favor of the post-axe re-verification approach, which is deterministic and cross-site.

## Tunables

| Env var | Default | Purpose |
| --- | --- | --- |
| `OOBEE_ASSET_WAIT_MS` | `5000` | Hard cap for Phase 2.5 (fonts + images). Prevents a slow font server from blocking crawl throughput. |

Existing tunables (`OOBEE_STABILITY_TIMEOUT_MS`, `OOBEE_QUIET_MS`, `OOBEE_MAX_MUTATIONS`) are unchanged.

## Test plan

- [ ] Run a full crawl on a Salesforce Lightning / LWC page previously producing intermittent `target-size` findings on the CPF logo — verify the finding no longer appears.
- [ ] Run against a page with CSS-variable theme swap on hydration — verify transient `color-contrast` findings are dropped when the settled state passes.
- [ ] Run against a slick / carousel page — verify existing `aria-hidden-focus` behavior is preserved after the helper refactor.
- [ ] Run on Docker headless Chromium under CPU contention — confirm Phase 2.5 does not routinely hit the `OOBEE_ASSET_WAIT_MS` deadline; if it does, tune upward.
- [ ] Inspect debug logs for the new `assets="..."` phase timing; confirm quiet pages resolve fast.
- [ ] Verify no regression on pages with real target-size / color-contrast / aria-hidden-focus violations — findings that truly fail after settling must still be reported.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
