### PR TITLE
improv/optimise report accuracy

### DIFF
--- a/src/constants/common.ts
+++ b/src/constants/common.ts
@@ -2326,7 +2326,7 @@ export const waitForPageLoaded = async (page: Page) => {
   // Docker containers under CPU contention; lower them locally via env vars
   // if crawl throughput matters more than tail-end hydration coverage.
   const loadTimeout      = Number(process.env.OOBEE_LOAD_TIMEOUT_MS)      || 30000;
-  const stabilityTimeout = Number(process.env.OOBEE_STABILITY_TIMEOUT_MS) || 15000;
+  const stabilityTimeout = Number(process.env.OOBEE_STABILITY_TIMEOUT_MS) || 30000;
   const quietMs          = Number(process.env.OOBEE_QUIET_MS)             || 1500;
   const maxMutations     = Number(process.env.OOBEE_MAX_MUTATIONS)        || 5000;
   const assetWaitMs      = Number(process.env.OOBEE_ASSET_WAIT_MS)        || 5000;

--- a/src/static/ejs/partials/scripts/ruleModal/itemCardRenderer.ejs
+++ b/src/static/ejs/partials/scripts/ruleModal/itemCardRenderer.ejs
@@ -240,7 +240,7 @@
           ${createElementSection(item)}
           ${
             (() => {
-              const showDetails = item.displayNeedsReview || ['color-contrast', 'color-contrast-enhanced', 'oobee-grading-text-contents', 'target-size', 'valid-lang', 'aria-valid-attr-value', 'aria-required-children', 'aria-prohibited-attr'].includes(aiConfig.ruleInCategory.rule);
+              const showDetails = item.displayNeedsReview || ['color-contrast', 'color-contrast-enhanced', 'oobee-grading-text-contents', 'target-size', 'valid-lang', 'aria-valid-attr-value', 'aria-required-children', 'aria-prohibited-attr', 'aria-allowed-attr'].includes(aiConfig.ruleInCategory.rule);
               return showDetails && item.message
                 ? `<div class="d-flex justify-content-between g-one">
             <div class="fw-semibold page-item-card-section-title">Details</div>

--- a/src/static/ejs/partials/scripts/ruleModal/pageAccordionBuilder.ejs
+++ b/src/static/ejs/partials/scripts/ruleModal/pageAccordionBuilder.ejs
@@ -394,7 +394,7 @@
 
           ${
             (() => {
-              const showDetails = item.displayNeedsReview || ['color-contrast', 'color-contrast-enhanced', 'oobee-grading-text-contents', 'target-size', 'valid-lang', 'aria-valid-attr-value', 'aria-required-children', 'aria-prohibited-attr'].includes(aiConfig.ruleInCategory.rule);
+              const showDetails = item.displayNeedsReview || ['color-contrast', 'color-contrast-enhanced', 'oobee-grading-text-contents', 'target-size', 'valid-lang', 'aria-valid-attr-value', 'aria-required-children', 'aria-prohibited-attr', 'aria-allowed-attr'].includes(aiConfig.ruleInCategory.rule);
               return showDetails && item.message
                 ? `<div class="d-flex justify-content-between g-one modal-view">
             <div class="fw-semibold page-item-card-section-title">Details</div>


### PR DESCRIPTION
## Summary

Two small changes that reduce false positives and add missing diagnostic detail in the report UI.

- **Raise `waitForPageLoaded` stability budget default from 15s to 30s.** Some SPAs fire the `load` event immediately but keep mutating the DOM well past 15s while hydrating. When the stability deadline expired mid-hydration, axe scanned an unsettled DOM, producing intermittent false positives (e.g. `landmark-one-main`, `bypass`, and target-size flakes tied to unloaded images/SVGs). Doubling the default gives slow-hydrating pages room to reach a quiet DOM before the scan. `OOBEE_STABILITY_TIMEOUT_MS` still overrides.
- **Show the Details section for `aria-allowed-attr` findings** in both the item card and page accordion report views, matching the treatment already given to other rules whose oobee message carries diagnostic value that isn't obvious from the rule name alone (`color-contrast`, `target-size`, `valid-lang`, `aria-required-children`, etc.).

## Motivation

Observed on a recent 1800-page scan: 46 pages emitted the `waitForPageLoaded: stability hard deadline hit` warning (all with the pattern `0-1ms load + 15001ms stability + 5000ms assets` — instant `load` event, DOM never quiet for the required 1.5s window inside 15s). Those pages were scanned mid-mutation and contributed a disproportionate share of hydration-timing findings. Raising the default budget catches the long tail without needing per-deployment env-var tuning.

Separately, `aria-allowed-attr` findings were being rendered without their oobee message body, which is the piece that tells the developer *which* attribute on *which* element is disallowed. Adding it to the shared allowlist brings this rule in line with the others.

## Changes

| File | Change |
|---|---|
| `src/constants/common.ts` | `OOBEE_STABILITY_TIMEOUT_MS` default `15000` → `30000` |
| `src/static/ejs/partials/scripts/ruleModal/itemCardRenderer.ejs` | add `aria-allowed-attr` to the details-display rule list |
| `src/static/ejs/partials/scripts/ruleModal/pageAccordionBuilder.ejs` | add `aria-allowed-attr` to the details-display rule list |

Net diff: 3 files, +3/−3 lines.

## Impact and trade-offs

- **Scan duration.** Worst case is +15s per page that hits the new deadline. On the observed 1800-page scan this is bounded at ~11 minutes total (46 pages × 15s), and typically much less because pages that resolve via the MutationObserver's quiet window don't consume the extra budget.
- **Backwards compatibility.** No API change. Existing `OOBEE_STABILITY_TIMEOUT_MS` overrides continue to work identically. Anyone tuning down for CI throughput can keep their setting.
- **Report UI.** The `aria-allowed-attr` change is purely additive — Details section now renders for that rule when a message is present; existing behaviour for all other rules is unchanged.

## Test plan

- [ ] Run a scan against a known slow-hydrating SPA page and confirm the stability warning no longer fires within 30s.
- [ ] Run a scan that intentionally uses `OOBEE_STABILITY_TIMEOUT_MS=15000` and confirm the override still takes effect (warning fires at 15s as before).
- [ ] Run a scan against a page with an `aria-allowed-attr` violation and open the report — confirm the Details section renders with the offending attribute in both the item card view and the page accordion view.
- [ ] Sanity check that pages that already resolved quickly still resolve quickly (no regression from raising the deadline).

## Related

- Extends the hydration-quality work from `fix(hydration): reduce mid-hydration false positives in axe findings` (commit `c4e336a1`).
- Extends the report-detail work from `fix: accessible-label false positives, Details section for two ARIA rules, correct report title` (#809).
