### PR TITLE
fix(runCustom): resolve on context close to prevent Node exit code 13

### DIFF
--- a/src/crawlers/runCustom.ts
+++ b/src/crawlers/runCustom.ts
@@ -190,7 +190,17 @@ const runCustom = async (
           return Promise.resolve(true);
         });
 
-    await allPagesClosedPromise(pageClosePromises);
+    // Race the page-close wait against context 'close'. When the caller sends
+    // SIGUSR1 (or otherwise triggers softCloseBrowserAndContext), context.close()
+    // tears the browser down; individual pages may not fire their own 'close'
+    // event before the context is gone. Without this race, pageClosePromises
+    // stays pending, this await never resolves, and Node exits the process with
+    // code 13 ("Unfinished Top-Level Await") from cli.ts's top-level await.
+    const contextClosedPromise = new Promise<true>(resolve => {
+      context.once('close', () => resolve(true));
+    });
+
+    await Promise.race([allPagesClosedPromise(pageClosePromises), contextClosedPromise]);
   } catch (error) {
     log(`PLAYWRIGHT EXECUTION ERROR ${error}`);
     cleanUpAndExit(1, randomToken, true);


### PR DESCRIPTION
When the caller sends SIGUSR1 (e.g. oobee-web-custom-flow tearing the scan down), softCloseBrowserAndContext calls context.close(). Individual pages don't always emit their own 'close' event before the context is gone, leaving entries in pageClosePromises pending. That made allPagesClosedPromise never resolve, so cli.ts's top-level await scanInit(...) never resolved and Node exited with code 13 ("Unfinished Top-Level Await") even though the scan itself had finished.

Race the page-close wait against a context 'close' promise so a context teardown always unblocks the await path.

This PR adds... <!-- A brief description of what your PR does -->

<!-- This checklist is just a guideline.-->
<!-- If any of the following does not apply to your PR, please leave them unchecked and explain in the PR -->

- [ ] I've kept this PR as small as possible (~500 lines) by splitting it into PRs with manageable chunks of code
- [ ] I've requested reviews from 1 reviewer
- [ ] I've tested existing features (website scan, sitemap, custom flow) in both node index and cli
- [ ] I've synced this fork with GovTechSG repo
- [ ] I've added/updated unit tests
- [ ] I've added/updated any necessary dependencies in `package[-lock].json` `npm audit`, portable installation on GitHub Actions
