### PR TITLE
fix(crawlee): upgrade to 3.18.0 with per-phase request queues (#819)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@govtechsg/oobee",
-  "version": "0.11.7",
+  "version": "0.11.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@govtechsg/oobee",
-      "version": "0.11.7",
+      "version": "0.11.8",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1049.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "axios": "^1.8.2",
         "base64-stream": "^1.0.0",
         "cheerio": "^1.0.0-rc.12",
-        "crawlee": "^3.17.0",
+        "crawlee": "^3.18.0",
         "ejs": "^3.1.9",
         "file-type": "^21.3.3",
         "fs-extra": "^11.2.0",
@@ -88,9 +88,9 @@
       }
     },
     "node_modules/@apify/consts": {
-      "version": "2.53.3",
-      "resolved": "https://registry.npmjs.org/@apify/consts/-/consts-2.53.3.tgz",
-      "integrity": "sha512-X26SC8d6kLMSWzBcYldKgzKFJXGnTAka/bRmvL+iYHJEabFzVYupj64kGhar6QTPeGKNt6WR/hNE+dToNqHZQA==",
+      "version": "2.57.0",
+      "resolved": "https://registry.npmjs.org/@apify/consts/-/consts-2.57.0.tgz",
+      "integrity": "sha512-kyD+pq72+RxpPUUikk5pWyGRcbehoQSkTIgd3kqE/MCy+MGPTYBbMb4lb2C92+Zh8K5eYyTrfobHKrpqyHAWMQ==",
       "license": "Apache-2.0"
     },
     "node_modules/@apify/datastructures": {
@@ -100,12 +100,12 @@
       "license": "Apache-2.0"
     },
     "node_modules/@apify/log": {
-      "version": "2.5.41",
-      "resolved": "https://registry.npmjs.org/@apify/log/-/log-2.5.41.tgz",
-      "integrity": "sha512-c826B4jhfF6CBOgyGyZyiT4GrhPaFWrZegFbY6bk/ffQc5BCPqAOT315qEEpFE4d6hP0d86tdcsiRknxkEFO0A==",
+      "version": "2.5.48",
+      "resolved": "https://registry.npmjs.org/@apify/log/-/log-2.5.48.tgz",
+      "integrity": "sha512-3aWhBik4P1Q6hubU38XgiB0PnGR5UkIC3gbxm0LQYQd1FwfOID5CrgRkbyab3BJaspN6LToIccgHbtDgSz2Pog==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@apify/consts": "^2.53.3",
+        "@apify/consts": "^2.57.0",
         "ansi-colors": "^4.1.1"
       }
     },
@@ -125,28 +125,28 @@
       }
     },
     "node_modules/@apify/pseudo_url": {
-      "version": "2.0.82",
-      "resolved": "https://registry.npmjs.org/@apify/pseudo_url/-/pseudo_url-2.0.82.tgz",
-      "integrity": "sha512-xvxh66eNGzwY3OrWGOJevUdiFsNOTzRzRC/jVbiFA5755aUZkS1U+j9c/a3TAVRZDG6/XGVtPOUMXylKICqweQ==",
+      "version": "2.0.89",
+      "resolved": "https://registry.npmjs.org/@apify/pseudo_url/-/pseudo_url-2.0.89.tgz",
+      "integrity": "sha512-bOuyQlSIKOXCh8XU1Enou8N6mAWA2v895x5e/HawVD8/hoq3TlQgYfqnbiLM9rVswAV5TcCDMBEIT6xqhfFtdw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@apify/log": "^2.5.41"
+        "@apify/log": "^2.5.48"
       }
     },
     "node_modules/@apify/timeout": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/@apify/timeout/-/timeout-0.3.5.tgz",
-      "integrity": "sha512-3nuQXwxh2sKxBo5tgDoZWuZHiSpqrKg1+sJHjFSk8blhyX6I2FZzpfW7UaCELeYLZiSjWUPh2rXNrc3zLmJGJg==",
+      "version": "0.4.8",
+      "resolved": "https://registry.npmjs.org/@apify/timeout/-/timeout-0.4.8.tgz",
+      "integrity": "sha512-SKBSXUYVYSaKCa5ogEEcAeKctbyRHq3v2yNLmzxZ/Rb+X4AuEFySd04nURGQPY2trtcKwKZP1sxrWvqwRH2WRA==",
       "license": "Apache-2.0"
     },
     "node_modules/@apify/utilities": {
-      "version": "2.34.1",
-      "resolved": "https://registry.npmjs.org/@apify/utilities/-/utilities-2.34.1.tgz",
-      "integrity": "sha512-9jHBMQEcJS/NTQg2joYOH8QdvEZLPNteKwV3dCpSQcQs0dsK8TgrAbc/ZzJWlK4/HSJK/RKQ1QbD1Ntoh9FwUg==",
+      "version": "2.35.5",
+      "resolved": "https://registry.npmjs.org/@apify/utilities/-/utilities-2.35.5.tgz",
+      "integrity": "sha512-A2HmUJCKx7Z3BGP2ELw0YNS2PPfl4WE3orcVaKaF1mwmKCfbW5E/kdWgmJ19zyUWI/Rm3Bn0x3NmJtk02SCShA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@apify/consts": "^2.53.3",
-        "@apify/log": "^2.5.41"
+        "@apify/consts": "^2.57.0",
+        "@apify/log": "^2.5.48"
       }
     },
     "node_modules/@asamuzakjp/css-color": {
@@ -1244,17 +1244,18 @@
       }
     },
     "node_modules/@crawlee/basic": {
-      "version": "3.17.0",
-      "resolved": "https://registry.npmjs.org/@crawlee/basic/-/basic-3.17.0.tgz",
-      "integrity": "sha512-0DVwt4BLBgiR8X5I2lopvUqxJjaHxCpnFawIKcHts0PxFp+ApTZ02LN+31wgnRSOa45JnjfMJLTvHLsWj4XhyQ==",
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@crawlee/basic/-/basic-3.18.0.tgz",
+      "integrity": "sha512-CkREQFeIcGSz06s13ySJSlDivIyur61RfiTsTZatCm0l2Ro2V0ghYduog2ckqhfcYne8D5QJWB2VBWF0LorV7w==",
       "license": "Apache-2.0",
       "dependencies": {
+        "@apify/datastructures": "^2.0.0",
         "@apify/log": "^2.4.0",
-        "@apify/timeout": "^0.3.0",
+        "@apify/timeout": "^0.4.0",
         "@apify/utilities": "^2.7.10",
-        "@crawlee/core": "3.17.0",
-        "@crawlee/types": "3.17.0",
-        "@crawlee/utils": "3.17.0",
+        "@crawlee/core": "3.18.0",
+        "@crawlee/types": "3.18.0",
+        "@crawlee/utils": "3.18.0",
         "csv-stringify": "^6.2.0",
         "fs-extra": "^11.0.0",
         "got-scraping": "^4.2.1",
@@ -1268,16 +1269,16 @@
       }
     },
     "node_modules/@crawlee/browser": {
-      "version": "3.17.0",
-      "resolved": "https://registry.npmjs.org/@crawlee/browser/-/browser-3.17.0.tgz",
-      "integrity": "sha512-FtmPvxD6TpVN3vOzW8+QMpqNXnTjjUD4eysFR2OmJYmLnhBf4kv8yhAzjIFHxFbWG3sP6G27ntIGUihcRRDPHw==",
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@crawlee/browser/-/browser-3.18.0.tgz",
+      "integrity": "sha512-sh4P5STb3L2KZvOqMXAfSN0QXyb2bpoGmcTP1ozUdpXb/MCazcantn5jZB7P4yewwGrk3fUDiHXwsvGzwK7bPA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@apify/timeout": "^0.3.0",
-        "@crawlee/basic": "3.17.0",
-        "@crawlee/browser-pool": "3.17.0",
-        "@crawlee/types": "3.17.0",
-        "@crawlee/utils": "3.17.0",
+        "@apify/timeout": "^0.4.0",
+        "@crawlee/basic": "3.18.0",
+        "@crawlee/browser-pool": "3.18.0",
+        "@crawlee/types": "3.18.0",
+        "@crawlee/utils": "3.18.0",
         "ow": "^0.28.1",
         "tslib": "^2.4.0",
         "type-fest": "^4.0.0"
@@ -1299,15 +1300,15 @@
       }
     },
     "node_modules/@crawlee/browser-pool": {
-      "version": "3.17.0",
-      "resolved": "https://registry.npmjs.org/@crawlee/browser-pool/-/browser-pool-3.17.0.tgz",
-      "integrity": "sha512-LG5TFkv+PdLSw0TcosqJ9KEKOvBWha+7JP4Tu+Hk1M/QBdRdF2AVlCDIOUV3rO0F0UYOBhLQDWfAZjBW9Bc21w==",
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@crawlee/browser-pool/-/browser-pool-3.18.0.tgz",
+      "integrity": "sha512-HiwF7aE2RVs6wi9Nowhe4/F39Z11lhxP+Pd21UWYXANb4m0TvnvDs2d+SlHmNStakQZWt06ZZQ7iXeK1lRC5uQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@apify/log": "^2.4.0",
-        "@apify/timeout": "^0.3.0",
-        "@crawlee/core": "3.17.0",
-        "@crawlee/types": "3.17.0",
+        "@apify/timeout": "^0.4.0",
+        "@crawlee/core": "3.18.0",
+        "@crawlee/types": "3.18.0",
         "fingerprint-generator": "^2.1.68",
         "fingerprint-injector": "^2.1.68",
         "lodash.merge": "^4.6.2",
@@ -1336,14 +1337,14 @@
       }
     },
     "node_modules/@crawlee/cheerio": {
-      "version": "3.17.0",
-      "resolved": "https://registry.npmjs.org/@crawlee/cheerio/-/cheerio-3.17.0.tgz",
-      "integrity": "sha512-7GdOv44B5MrDBGQoab2KaRlnoODvzQ656RkG6PDqK/X97t9fRVS3qS9uc+76jtctMFW5jPAsGsREfDcP8hXumw==",
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@crawlee/cheerio/-/cheerio-3.18.0.tgz",
+      "integrity": "sha512-GT8NSYgY6gYPKkCFagk8HdGmIZCWu19mpjtIGmUl8X8xzNe0PEPfncJR8h/ZERHuUTmv/RuN+kMTH87+T6nKJQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@crawlee/http": "3.17.0",
-        "@crawlee/types": "3.17.0",
-        "@crawlee/utils": "3.17.0",
+        "@crawlee/http": "3.18.0",
+        "@crawlee/types": "3.18.0",
+        "@crawlee/utils": "3.18.0",
         "cheerio": "1.0.0-rc.12",
         "htmlparser2": "^9.0.0",
         "tslib": "^2.4.0"
@@ -1412,12 +1413,12 @@
       }
     },
     "node_modules/@crawlee/cli": {
-      "version": "3.17.0",
-      "resolved": "https://registry.npmjs.org/@crawlee/cli/-/cli-3.17.0.tgz",
-      "integrity": "sha512-uOFYpFxLy0SyonNEPqVPU6FzJSl2s0FqoW+/3NsjliI/GpGpz61pfQbhBiM3E+oxXAo1S5Oamil2tmifXc7UiA==",
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@crawlee/cli/-/cli-3.18.0.tgz",
+      "integrity": "sha512-a/MW+YWMFl9WL6d2trVX+6ZfAe+wtPngf4Hyj/QzdH1dGCAjG5c+M7PyhOvjibSYdiTXRFGXNz8ikPEcpGfgRg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@crawlee/templates": "3.17.0",
+        "@crawlee/templates": "3.18.0",
         "ansi-colors": "^4.1.3",
         "fs-extra": "^11.0.0",
         "inquirer": "^8.2.4",
@@ -1483,21 +1484,22 @@
       }
     },
     "node_modules/@crawlee/core": {
-      "version": "3.17.0",
-      "resolved": "https://registry.npmjs.org/@crawlee/core/-/core-3.17.0.tgz",
-      "integrity": "sha512-LPsD5+zzLF+0QFGCcZcUKMULJAkjnL7YVWhCp58zYupbmLjVHW9YJoECEF9awf5lbvPwoxoChxzEIl/lRNU0TQ==",
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@crawlee/core/-/core-3.18.0.tgz",
+      "integrity": "sha512-PchBgodjH3tYS9zcWEsNjnabUbBTVt/P5BX/trEySHBqA8jsi3Pps5mxezVnQONfb/zUCxxgg8GArgIoLXKbSQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@apify/consts": "^2.20.0",
         "@apify/datastructures": "^2.0.0",
         "@apify/log": "^2.4.0",
         "@apify/pseudo_url": "^2.0.30",
-        "@apify/timeout": "^0.3.0",
+        "@apify/timeout": "^0.4.0",
         "@apify/utilities": "^2.7.10",
-        "@crawlee/memory-storage": "3.17.0",
-        "@crawlee/types": "3.17.0",
-        "@crawlee/utils": "3.17.0",
+        "@crawlee/memory-storage": "3.18.0",
+        "@crawlee/types": "3.18.0",
+        "@crawlee/utils": "3.18.0",
         "@sapphire/async-queue": "^1.5.1",
+        "@standard-schema/spec": "^1.0.0",
         "@vladfrangu/async_event_emitter": "^2.2.2",
         "csv-stringify": "^6.2.0",
         "fs-extra": "^11.0.0",
@@ -1516,16 +1518,17 @@
       }
     },
     "node_modules/@crawlee/http": {
-      "version": "3.17.0",
-      "resolved": "https://registry.npmjs.org/@crawlee/http/-/http-3.17.0.tgz",
-      "integrity": "sha512-DJARnv7pHUxkzKkQyM05UVaYa10IoVifWmPNp9X/WS4acCEEQ3aMq0cZeYEGH0XR0nVu7wZut5nBfRVfprVbYA==",
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@crawlee/http/-/http-3.18.0.tgz",
+      "integrity": "sha512-idnT78UYwLoJvTb0cs9L6kH0zlBi5JVCIx1yy56QR7JaJCP+EwRWyO8JQtJu2vnQXMD6E6ON8yLSHcIV2wZwgg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@apify/timeout": "^0.3.0",
+        "@apify/timeout": "^0.4.0",
         "@apify/utilities": "^2.7.10",
-        "@crawlee/basic": "3.17.0",
-        "@crawlee/types": "3.17.0",
-        "@crawlee/utils": "3.17.0",
+        "@crawlee/basic": "3.18.0",
+        "@crawlee/core": "3.18.0",
+        "@crawlee/types": "3.18.0",
+        "@crawlee/utils": "3.18.0",
         "@types/content-type": "^1.1.5",
         "cheerio": "1.0.0-rc.12",
         "content-type": "^1.0.4",
@@ -1581,16 +1584,16 @@
       }
     },
     "node_modules/@crawlee/jsdom": {
-      "version": "3.17.0",
-      "resolved": "https://registry.npmjs.org/@crawlee/jsdom/-/jsdom-3.17.0.tgz",
-      "integrity": "sha512-aRvJ/JScHZ/53tt+3BhHPZQkTdBvaNg8fPkQIPP7C9jkkxUedFD1o1hW/8a3Y6k1b+f9qaNYy1AYFVubAS7p+w==",
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@crawlee/jsdom/-/jsdom-3.18.0.tgz",
+      "integrity": "sha512-2GLgOjVMiaL5E5Ijs5ZTyC2p8DQIwEizIH3vdtm/4IRr41Yc054QdBdq2FGXeCNl52SHoR63VcjV+k9GIrXDhA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@apify/timeout": "^0.3.0",
+        "@apify/timeout": "^0.4.0",
         "@apify/utilities": "^2.7.10",
-        "@crawlee/http": "3.17.0",
-        "@crawlee/types": "3.17.0",
-        "@crawlee/utils": "3.17.0",
+        "@crawlee/http": "3.18.0",
+        "@crawlee/types": "3.18.0",
+        "@crawlee/utils": "3.18.0",
         "@types/jsdom": "^21.0.0",
         "cheerio": "1.0.0-rc.12",
         "jsdom": "^26.0.0",
@@ -1753,15 +1756,17 @@
       }
     },
     "node_modules/@crawlee/linkedom": {
-      "version": "3.17.0",
-      "resolved": "https://registry.npmjs.org/@crawlee/linkedom/-/linkedom-3.17.0.tgz",
-      "integrity": "sha512-1GYbWDTGU42I4IsfSToBXkBank2cWXJ8NG+G3xySIFlX4/l5ogWzsRYkNvSJb+vJDJ72cfuhSsWalWSrpHIvLg==",
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@crawlee/linkedom/-/linkedom-3.18.0.tgz",
+      "integrity": "sha512-SYeFjoASWldD/O1B83UH6LlOv1E+0T9Otedi/fRqEymRCyVS5NQYL1kS5VWHrtYMMw+RNxFQlkhula/BmFNc5g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@apify/timeout": "^0.3.0",
+        "@apify/timeout": "^0.4.0",
         "@apify/utilities": "^2.7.10",
-        "@crawlee/http": "3.17.0",
-        "@crawlee/types": "3.17.0",
+        "@crawlee/http": "3.18.0",
+        "@crawlee/types": "3.18.0",
+        "@crawlee/utils": "3.18.0",
+        "cheerio": "1.0.0-rc.12",
         "linkedom": "^0.18.0",
         "ow": "^0.28.2",
         "tslib": "^2.4.0"
@@ -1770,14 +1775,54 @@
         "node": ">=16.0.0"
       }
     },
+    "node_modules/@crawlee/linkedom/node_modules/cheerio": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.12.tgz",
+      "integrity": "sha512-VqR8m68vM46BNnuZ5NtnGBKIE/DfN0cRIzg9n40EIq9NOv90ayxLBXA8fXC5gquFRGJSTRqBq25Jt2ECLR431Q==",
+      "license": "MIT",
+      "dependencies": {
+        "cheerio-select": "^2.1.0",
+        "dom-serializer": "^2.0.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1",
+        "htmlparser2": "^8.0.1",
+        "parse5": "^7.0.0",
+        "parse5-htmlparser2-tree-adapter": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/cheerio?sponsor=1"
+      }
+    },
+    "node_modules/@crawlee/linkedom/node_modules/htmlparser2": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.2.tgz",
+      "integrity": "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1",
+        "entities": "^4.4.0"
+      }
+    },
     "node_modules/@crawlee/memory-storage": {
-      "version": "3.17.0",
-      "resolved": "https://registry.npmjs.org/@crawlee/memory-storage/-/memory-storage-3.17.0.tgz",
-      "integrity": "sha512-3dT2eY9oqfl7LTO+aqQYCKmLGRDK8j9J64h/eVQwXVSqRyGBhTraZxE4ABKF0kQrMJd1/N7u9dRcAacESIEqBg==",
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@crawlee/memory-storage/-/memory-storage-3.18.0.tgz",
+      "integrity": "sha512-V2H5iAqSTu9cj61YK7YFZC6DZu0QafgEVK7d6ijGkY7T5UoCBZTguR/oolgoiYLSbIGBAVhGx5Un1ixeWBsquQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@apify/log": "^2.4.0",
-        "@crawlee/types": "3.17.0",
+        "@crawlee/types": "3.18.0",
         "@sapphire/async-queue": "^1.5.0",
         "@sapphire/shapeshift": "^3.0.0",
         "content-type": "^1.0.4",
@@ -1793,19 +1838,19 @@
       }
     },
     "node_modules/@crawlee/playwright": {
-      "version": "3.17.0",
-      "resolved": "https://registry.npmjs.org/@crawlee/playwright/-/playwright-3.17.0.tgz",
-      "integrity": "sha512-uN+rmUDhanQJ/iP2bmy8BzPqO0reISMMv0P5WojM0YtSh3R0aVIKV/5qe+CkbqauZwQc9NOSzR50S20qsM+nuw==",
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@crawlee/playwright/-/playwright-3.18.0.tgz",
+      "integrity": "sha512-MkyNayLG0dtjIcRmosf42N23RcVCIqmh0XWx8JQG1Bw291Z6ukZYjdqkzClMM2SJSYl8IPRRVS+ttY1vAVByHQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@apify/datastructures": "^2.0.0",
         "@apify/log": "^2.4.0",
-        "@apify/timeout": "^0.3.1",
-        "@crawlee/browser": "3.17.0",
-        "@crawlee/browser-pool": "3.17.0",
-        "@crawlee/core": "3.17.0",
-        "@crawlee/types": "3.17.0",
-        "@crawlee/utils": "3.17.0",
+        "@apify/timeout": "^0.4.0",
+        "@crawlee/browser": "3.18.0",
+        "@crawlee/browser-pool": "3.18.0",
+        "@crawlee/core": "3.18.0",
+        "@crawlee/types": "3.18.0",
+        "@crawlee/utils": "3.18.0",
         "cheerio": "1.0.0-rc.12",
         "jquery": "^3.6.0",
         "lodash.isequal": "^4.5.0",
@@ -1813,7 +1858,8 @@
         "ml-matrix": "^6.11.0",
         "ow": "^0.28.1",
         "string-comparison": "^1.3.0",
-        "tslib": "^2.4.0"
+        "tslib": "^2.4.0",
+        "type-fest": "^4.0.0"
       },
       "engines": {
         "node": ">=16.0.0"
@@ -1872,17 +1918,17 @@
       }
     },
     "node_modules/@crawlee/puppeteer": {
-      "version": "3.17.0",
-      "resolved": "https://registry.npmjs.org/@crawlee/puppeteer/-/puppeteer-3.17.0.tgz",
-      "integrity": "sha512-FC+rzmyWICv2oF5d1NgLsu2m28+zLpz/AGcvV1pO9a6i1wFHDlDUOzcumM4niHWH+TeWhp12nwxDHtTHWjDrmA==",
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@crawlee/puppeteer/-/puppeteer-3.18.0.tgz",
+      "integrity": "sha512-qE6kkX1Cg0mUhwpp8prk3stusHD1UiQQFJ58U1jRxgOX5YVejzZr9GIgdmc/nYsBmWjkjKSii4PXJj84MPKUwg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@apify/datastructures": "^2.0.0",
         "@apify/log": "^2.4.0",
-        "@crawlee/browser": "3.17.0",
-        "@crawlee/browser-pool": "3.17.0",
-        "@crawlee/types": "3.17.0",
-        "@crawlee/utils": "3.17.0",
+        "@crawlee/browser": "3.18.0",
+        "@crawlee/browser-pool": "3.18.0",
+        "@crawlee/types": "3.18.0",
+        "@crawlee/utils": "3.18.0",
         "cheerio": "1.0.0-rc.12",
         "devtools-protocol": "*",
         "idcac-playwright": "^0.2.0",
@@ -1947,9 +1993,9 @@
       }
     },
     "node_modules/@crawlee/templates": {
-      "version": "3.17.0",
-      "resolved": "https://registry.npmjs.org/@crawlee/templates/-/templates-3.17.0.tgz",
-      "integrity": "sha512-QHeTwaIyebFjWF06QiUcMBK4i3siU4SHlv50uch+8t9lnGzNUY2+PDaIbWRLVh8VlYcuMKYb3XLJNezNvzcYhg==",
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@crawlee/templates/-/templates-3.18.0.tgz",
+      "integrity": "sha512-sOE4NWXFj+BFG1EMVdDOo0OuEUPyDBF3pgt2BYbhUqO0hL6ZoVIYFYjBbQ9catlrf6zat+el76in1QIdsWxziA==",
       "license": "Apache-2.0",
       "dependencies": {
         "ansi-colors": "^4.1.3",
@@ -1963,9 +2009,9 @@
       }
     },
     "node_modules/@crawlee/types": {
-      "version": "3.17.0",
-      "resolved": "https://registry.npmjs.org/@crawlee/types/-/types-3.17.0.tgz",
-      "integrity": "sha512-y67RHnM+b8eoaTRoouB0jbqpwpUE+4ZTxeEgvnLx+ABkdtkLNYlXQOx3FybEWzFVp6MnmBtmsez2tQjRCmIopQ==",
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@crawlee/types/-/types-3.18.0.tgz",
+      "integrity": "sha512-GPkKtm9IwnpB7RnKP14LOdNdZAoJQW6A4HfMwz+BefX1VlqaZ4ZoBJsPlO7OZpNSUW0rNwOpr9LnvZww3ZFjWw==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.4.0"
@@ -1975,14 +2021,14 @@
       }
     },
     "node_modules/@crawlee/utils": {
-      "version": "3.17.0",
-      "resolved": "https://registry.npmjs.org/@crawlee/utils/-/utils-3.17.0.tgz",
-      "integrity": "sha512-pKpBzI6knmkgbcHACpIGNDhsQvuFPavVJ+43ehEw3EqV13ThKR0sP/vBTjdDicTrAbRl3fhi6CaokOTymOZwGw==",
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@crawlee/utils/-/utils-3.18.0.tgz",
+      "integrity": "sha512-OU79yjzHyI2wt24FfmcRQWKf1dh9vqZUJj7HB0o01lY1OY/gQCyCFWQAIudrr0lId8o9zw6lIHV9REwUofEKYA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@apify/log": "^2.4.0",
         "@apify/ps-tree": "^1.2.0",
-        "@crawlee/types": "3.17.0",
+        "@crawlee/types": "3.18.0",
         "@types/sax": "^1.2.7",
         "cheerio": "1.0.0-rc.12",
         "file-type": "^21.3.1",
@@ -1990,6 +2036,7 @@
         "ow": "^0.28.1",
         "robots-parser": "^3.0.1",
         "sax": "^1.4.1",
+        "tldts": "^7.0.0",
         "tslib": "^2.4.0",
         "whatwg-mimetype": "^4.0.0"
       },
@@ -3821,6 +3868,12 @@
         "color": "^5.0.2",
         "text-hex": "1.0.x"
       }
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
     },
     "node_modules/@streamparser/json": {
       "version": "0.0.20",
@@ -5897,23 +5950,24 @@
       "license": "MIT"
     },
     "node_modules/crawlee": {
-      "version": "3.17.0",
-      "resolved": "https://registry.npmjs.org/crawlee/-/crawlee-3.17.0.tgz",
-      "integrity": "sha512-PRekRgz6WSgcxx8wcT1NAwV4fRfBXuPxDD0MZNCbcHNKORL7m7m6yvi1UNPblbIFkWP3NyngW4J96gKlkb97Wg==",
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/crawlee/-/crawlee-3.18.0.tgz",
+      "integrity": "sha512-TzbXJrCOv+RyfD/rRiRC3JDadDEgJKoK/WKqzd5KCtwAR088dcOj2fg4xLrA+VxbD0cqRAIyqi1Zt8bgF0JIbA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@crawlee/basic": "3.17.0",
-        "@crawlee/browser": "3.17.0",
-        "@crawlee/browser-pool": "3.17.0",
-        "@crawlee/cheerio": "3.17.0",
-        "@crawlee/cli": "3.17.0",
-        "@crawlee/core": "3.17.0",
-        "@crawlee/http": "3.17.0",
-        "@crawlee/jsdom": "3.17.0",
-        "@crawlee/linkedom": "3.17.0",
-        "@crawlee/playwright": "3.17.0",
-        "@crawlee/puppeteer": "3.17.0",
-        "@crawlee/utils": "3.17.0",
+        "@crawlee/basic": "3.18.0",
+        "@crawlee/browser": "3.18.0",
+        "@crawlee/browser-pool": "3.18.0",
+        "@crawlee/cheerio": "3.18.0",
+        "@crawlee/cli": "3.18.0",
+        "@crawlee/core": "3.18.0",
+        "@crawlee/http": "3.18.0",
+        "@crawlee/jsdom": "3.18.0",
+        "@crawlee/linkedom": "3.18.0",
+        "@crawlee/memory-storage": "3.18.0",
+        "@crawlee/playwright": "3.18.0",
+        "@crawlee/puppeteer": "3.18.0",
+        "@crawlee/utils": "3.18.0",
         "import-local": "^3.1.0",
         "tslib": "^2.4.0"
       },
@@ -6039,9 +6093,9 @@
       }
     },
     "node_modules/csv-stringify": {
-      "version": "6.8.1",
-      "resolved": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-6.8.1.tgz",
-      "integrity": "sha512-tZ6X6TKQyQgCo5OptXcyAbfN1pwmoxEqELPQ7KFazNErx7kiVsDK8o+VYRXhfMl4N9vvOOLXuioquR2MeP847A==",
+      "version": "6.8.3",
+      "resolved": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-6.8.3.tgz",
+      "integrity": "sha512-gIeSCvq5F4VtXV3naV3VAewLhBkiZBz+PPhTOA8H3Y8h/ELa+R1ml0GZck/4/Nzo9ep2lvOluilJ6MJlbZsKMA==",
       "license": "MIT"
     },
     "node_modules/data-urls": {
@@ -6275,9 +6329,9 @@
       }
     },
     "node_modules/devtools-protocol": {
-      "version": "0.0.1656784",
-      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1656784.tgz",
-      "integrity": "sha512-3jUemAFb1EvBZL2k5uiM7QWDbhReiLqwPn3zhVNVhR4mCyG1x6GrkmVJhh/0F/LSMhHfSI0Yi1HuKe/Kyu8dfQ==",
+      "version": "0.0.1674729",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1674729.tgz",
+      "integrity": "sha512-i4tJOKEw0gm4ccrH9donjjSAaR8wToyoqD9fYiIlHhlrS6xx0HSu5TSi2iFqBa6KoiAomDvCH1994zDzPY0ASA==",
       "license": "BSD-3-Clause"
     },
     "node_modules/doctrine": {
@@ -7188,9 +7242,9 @@
       "license": "MIT"
     },
     "node_modules/figlet": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/figlet/-/figlet-1.11.0.tgz",
-      "integrity": "sha512-EEx3OS/l2bFqcUNN2NM9FPJp8vAMrgbCxsbl2hbcJNNxOEwVe3mEzrhan7TbJQViZa8mMqhihlbCaqD+LyYKTQ==",
+      "version": "1.11.4",
+      "resolved": "https://registry.npmjs.org/figlet/-/figlet-1.11.4.tgz",
+      "integrity": "sha512-ZU41480OncL+NVLQrT0GVnbO0COL24sLSrzksioDgunmdJNYEUxhJJZ4Y3x1csN8XXqN5OcCZTLG8lKdquNyfQ==",
       "license": "MIT",
       "dependencies": {
         "commander": "^14.0.0"
@@ -7284,13 +7338,13 @@
       }
     },
     "node_modules/fingerprint-generator": {
-      "version": "2.1.82",
-      "resolved": "https://registry.npmjs.org/fingerprint-generator/-/fingerprint-generator-2.1.82.tgz",
-      "integrity": "sha512-5Z/yCKW324pMyMarpIKe/QPdkrFWKNJv3ktdU+fXHri80+HAwNE6QhMvEvsMkK9Q8DeCXZlpPHV77UBa1nFb4A==",
+      "version": "2.1.88",
+      "resolved": "https://registry.npmjs.org/fingerprint-generator/-/fingerprint-generator-2.1.88.tgz",
+      "integrity": "sha512-rwYKE/UZTAnfu3DoBgFH+otrRewvkscG8TkiDY8xw7QBga0evHoL7H70HrtP/CBqjspVrfqE7ZYt7qDM3dYk+g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "generative-bayesian-network": "^2.1.82",
-        "header-generator": "^2.1.82",
+        "generative-bayesian-network": "2.1.88",
+        "header-generator": "2.1.88",
         "tslib": "^2.4.0"
       },
       "engines": {
@@ -7298,12 +7352,12 @@
       }
     },
     "node_modules/fingerprint-injector": {
-      "version": "2.1.82",
-      "resolved": "https://registry.npmjs.org/fingerprint-injector/-/fingerprint-injector-2.1.82.tgz",
-      "integrity": "sha512-FN7W1wbhHk2PBCF6wpBEcFnmOdGUItZnbpVBtYVcQ1/iGM0skNUDqJyH1YOjmpQiqEl2Rhh7qWNXYsivjsT+tg==",
+      "version": "2.1.88",
+      "resolved": "https://registry.npmjs.org/fingerprint-injector/-/fingerprint-injector-2.1.88.tgz",
+      "integrity": "sha512-npQr/Nc00x3XfbT9TE6RqPLIaYbun63rCL8isGqZVp0mlWw2mAr0J81WsIW3ENZB2w/dkCA9QewA0ufoYMB0Qw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "fingerprint-generator": "^2.1.82",
+        "fingerprint-generator": "2.1.88",
         "tslib": "^2.4.0"
       },
       "engines": {
@@ -7520,12 +7574,12 @@
       }
     },
     "node_modules/generative-bayesian-network": {
-      "version": "2.1.83",
-      "resolved": "https://registry.npmjs.org/generative-bayesian-network/-/generative-bayesian-network-2.1.83.tgz",
-      "integrity": "sha512-LssI9es+oUoezoHloFGw0Hts0YEfujjBOE8KNl70oBt4HPjD/4rpUqcgZ/M7RCmgKvkmCyPB2KWowyJHuKyhfw==",
+      "version": "2.1.88",
+      "resolved": "https://registry.npmjs.org/generative-bayesian-network/-/generative-bayesian-network-2.1.88.tgz",
+      "integrity": "sha512-kxbW6CCsiEAVdBYPont/6ZVOa47Pyfv5ldYFIvj8wmOx9uQOZ4c8wdR0jEf2pE6DeVuIAfmolm+91bYne6/3uA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "adm-zip": "^0.5.9",
+        "adm-zip": "^0.6.0",
         "tslib": "^2.4.0"
       }
     },
@@ -7962,13 +8016,13 @@
       }
     },
     "node_modules/header-generator": {
-      "version": "2.1.82",
-      "resolved": "https://registry.npmjs.org/header-generator/-/header-generator-2.1.82.tgz",
-      "integrity": "sha512-4NjPB0+bAKjPoponSmTOkK58IEF2W22sOJA5O48k/MxbCZgOm+jrU4WVR53Z2I6xFgIPkVrQmKtt1LAbWtfqXw==",
+      "version": "2.1.88",
+      "resolved": "https://registry.npmjs.org/header-generator/-/header-generator-2.1.88.tgz",
+      "integrity": "sha512-12GkTL1CDaPTQ6gkd8TPwxNtn7t3wSExnWU9qgWfEDh8IqpD1NAVcvzfHphIzULez8WP2DK9YQsDegajjDdTKQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "browserslist": "^4.21.1",
-        "generative-bayesian-network": "^2.1.82",
+        "generative-bayesian-network": "2.1.88",
         "ow": "^0.28.1",
         "tslib": "^2.4.0"
       },
@@ -9846,15 +9900,15 @@
       "license": "MIT"
     },
     "node_modules/linkedom": {
-      "version": "0.18.12",
-      "resolved": "https://registry.npmjs.org/linkedom/-/linkedom-0.18.12.tgz",
-      "integrity": "sha512-jalJsOwIKuQJSeTvsgzPe9iJzyfVaEJiEXl+25EkKevsULHvMJzpNqwvj1jOESWdmgKDiXObyjOYwlUqG7wo1Q==",
+      "version": "0.18.13",
+      "resolved": "https://registry.npmjs.org/linkedom/-/linkedom-0.18.13.tgz",
+      "integrity": "sha512-ES/o9qotMpzpN2MHs+Iq/JcVoOj8Fa5wiQYrTdFpvAnwXL0g66XHHUc9WUMk6nAlBtGsFQ24ne+SYnvnaQ2FSw==",
       "license": "ISC",
       "dependencies": {
-        "css-select": "^5.1.0",
+        "css-select": "^7.0.0",
         "cssom": "^0.5.0",
         "html-escaper": "^3.0.3",
-        "htmlparser2": "^10.0.0",
+        "htmlparser2": "^10.1.0",
         "uhyphen": "^0.2.0"
       },
       "engines": {
@@ -9869,11 +9923,152 @@
         }
       }
     },
+    "node_modules/linkedom/node_modules/boolbase": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-2.0.0.tgz",
+      "integrity": "sha512-DkVaaQHymRhpYEYo9x1oo7Q7B0Y6KJUsjm3c9eTyFDby4MHLBTwZ6ZDWBel5zrYxj1WsZgC5oLpiz+93MluXeA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/linkedom/node_modules/css-select": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-7.0.0.tgz",
+      "integrity": "sha512-snmjEVXy+1LnwXdxhYvTMj1d9tOh4HxkA1YmoayVBeeyR2C14Pum7fcxJIm4SswYspVy866eYNwlH6xC3/VH5g==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^2.0.0",
+        "css-what": "^8.0.0",
+        "domhandler": "^6.0.1",
+        "domutils": "^4.0.2",
+        "nth-check": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/linkedom/node_modules/css-what": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-8.0.0.tgz",
+      "integrity": "sha512-DH0Bqq3DNp5tdOReuNyAA+Ev4Y2GS5FMbZpeTLP6C4CDi0h5nL0BmUPChXw3o/qbHLDWHl49sbNqQVY7bMSDdw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/linkedom/node_modules/dom-serializer": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-3.1.1.tgz",
+      "integrity": "sha512-4MEa38/QexBob6gFNwu+EGdWvhJ1OKuNwdYY3Y3NyeWDQfnGeDYQUDfIRzWu5B5gsv03so2Uxd28YC6zrsx3Lw==",
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^3.0.0",
+        "domhandler": "^6.0.0",
+        "entities": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/linkedom/node_modules/domelementtype": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-3.0.0.tgz",
+      "integrity": "sha512-umCQid3jKbDmVjx8jGaW7uUykm4DEUeyV21hPxNMo2nV955DhUThwqyOIDtreepP31hl84X7G5U9ZfsWvIB3Pg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/linkedom/node_modules/domhandler": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-6.0.1.tgz",
+      "integrity": "sha512-gYzvtM72ZtxQO0T048kd6HWSbbGCNOUwcnfQ01cqIJ4X2IYKFFHZ5mKvrQETcFXxsRObZulDaKmy//R7TPtsBg==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/linkedom/node_modules/domutils": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-4.0.2.tgz",
+      "integrity": "sha512-qI4JLRKnSzqFqr7hAlS5xQDusBCjKSEG4t4+7aNrIQMHBcsC2TGEhuyABJdYkgSewL57PNLYEiibY2iPKhKpaA==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^3.0.0",
+        "domelementtype": "^3.0.0",
+        "domhandler": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
+    "node_modules/linkedom/node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/linkedom/node_modules/html-escaper": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-3.0.3.tgz",
       "integrity": "sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ==",
       "license": "MIT"
+    },
+    "node_modules/linkedom/node_modules/nth-check": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-3.0.1.tgz",
+      "integrity": "sha512-GX0gsdbGVCgnRgbeGaubfjpBXyYRWOOCVeYh08bSQvDZqxz5ndXs1OTfAt/h36G1xvI94YIspsI0sVFqAV9+RQ==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
+      }
     },
     "node_modules/locate-path": {
       "version": "6.0.0",
@@ -10161,9 +10356,9 @@
       }
     },
     "node_modules/ml-matrix": {
-      "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/ml-matrix/-/ml-matrix-6.13.0.tgz",
-      "integrity": "sha512-QpV0UTUkglg6vPUgThKGBEtit2ac6habSoZ33bwI9rU0UHZLqw6G3ukTIE8zWiUF3sjK8YAlhx/o/b9layzH8A==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ml-matrix/-/ml-matrix-6.15.0.tgz",
+      "integrity": "sha512-wFa1v6KP8bKp+fj0nYmRs1Pb5K4zRkXGKsOvLinvILENFIADncm4XlOI+S1M7yuACMGfI6cfk0IifDgd4j5xmw==",
       "license": "MIT",
       "dependencies": {
         "is-any-array": "^3.0.0",
@@ -10199,9 +10394,9 @@
       "optional": true
     },
     "node_modules/nanoid": {
-      "version": "3.3.15",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
-      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "version": "3.3.17",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
+      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "axios": "^1.8.2",
     "base64-stream": "^1.0.0",
     "cheerio": "^1.0.0-rc.12",
-    "crawlee": "^3.17.0",
+    "crawlee": "^3.18.0",
     "ejs": "^3.1.9",
     "file-type": "^21.3.3",
     "fs-extra": "^11.2.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@govtechsg/oobee",
   "main": "dist/npmIndex.js",
-  "version": "0.11.7",
+  "version": "0.11.8",
   "type": "module",
   "author": "Government Technology Agency <info@tech.gov.sg>",
   "bin": {

--- a/src/combine.ts
+++ b/src/combine.ts
@@ -73,7 +73,10 @@ const combineRun = async (details: Data, deviceToScan: string) => {
   } = envDetails;
 
   process.env.CRAWLEE_LOG_LEVEL = 'ERROR';
-  process.env.CRAWLEE_STORAGE_DIR = randomToken;
+  // Absolute path — @crawlee/memory-storage@3.18 rejects absolute paths passed as
+  // storage names, so CRAWLEE_STORAGE_DIR must carry the full location and callers
+  // pass relative names ('crawlee', 'crawlee_rq') to Dataset/RequestQueue.open().
+  process.env.CRAWLEE_STORAGE_DIR = getStoragePath(randomToken);
   constants.sitemapFetchedLinks = null;
 
   if (isPageCaptureEnabled() && !process.env.OOBEE_SCAN_PRODUCT) {

--- a/src/crawlers/commonCrawlerFunc.ts
+++ b/src/crawlers/commonCrawlerFunc.ts
@@ -22,7 +22,6 @@ import { flagUnlabelledClickableElements } from './custom/flagUnlabelledClickabl
 import xPathToCss from './custom/xPathToCss.js';
 import type { Response as PlaywrightResponse } from 'playwright';
 import fs from 'fs';
-import { getStoragePath } from '../utils.js';
 import { ensureAndInjectSafeBrowsing } from '../safeBrowsingProfile.js';
 import path from 'path';
 
@@ -1388,13 +1387,18 @@ export const runAxeScript = async ({
   return filterAxeResults(results, pageTitle, customFlowDetails);
 };
 
+// @crawlee/memory-storage@3.18 rejects absolute paths as storage names, so callers
+// must pass relative names. The actual storage location is conveyed via the
+// CRAWLEE_STORAGE_DIR env var (set to getStoragePath(randomToken) at scan entry).
+// requestQueueName is parameterised so intelligent scans can isolate per-phase
+// request queues — sharing one queue directory across crawlSitemap → crawlDomain
+// transitions triggered a Windows EPERM race on the request-queue .json.lock files.
 export const createCrawleeSubFolders = async (
-  randomToken: string,
+  _randomToken: string,
+  requestQueueName: string = 'crawlee_rq',
 ): Promise<{ dataset: Dataset; requestQueue: RequestQueue }> => {
-
-  const baseDir = path.join(getStoragePath(randomToken), "crawlee");
-  const dataset = await Dataset.open(baseDir);
-  const requestQueue = await RequestQueue.open(`${baseDir}_rq`);
+  const dataset = await Dataset.open('crawlee');
+  const requestQueue = await RequestQueue.open(requestQueueName);
   return { dataset, requestQueue };
 };
 

--- a/src/crawlers/crawlDomain.ts
+++ b/src/crawlers/crawlDomain.ts
@@ -80,6 +80,7 @@ const crawlDomain = async ({
   datasetFromIntelligent = null,
   urlsCrawledFromIntelligent = null,
   ruleset = [],
+  requestQueueName,
 }: {
   url: string;
   randomToken: string;
@@ -101,19 +102,20 @@ const crawlDomain = async ({
   datasetFromIntelligent?: crawlee.Dataset;
   urlsCrawledFromIntelligent?: UrlsCrawled;
   ruleset?: RuleFlags[];
+  requestQueueName?: string;
 }) => {
   const crawlStartTime = Date.now();
   let dataset: crawlee.Dataset;
   let urlsCrawled: UrlsCrawled;
   const { requestQueue }: { requestQueue: crawlee.RequestQueue } =
-    await createCrawleeSubFolders(randomToken);
+    await createCrawleeSubFolders(randomToken, requestQueueName);
   let durationExceeded = false;
 
   if (fromCrawlIntelligentSitemap) {
     dataset = datasetFromIntelligent;
     urlsCrawled = urlsCrawledFromIntelligent;
   } else {
-    ({ dataset } = await createCrawleeSubFolders(randomToken));
+    ({ dataset } = await createCrawleeSubFolders(randomToken, requestQueueName));
     urlsCrawled = { ...constants.urlsCrawledObj };
   }
 

--- a/src/crawlers/crawlIntelligentSitemap.ts
+++ b/src/crawlers/crawlIntelligentSitemap.ts
@@ -156,11 +156,16 @@ const crawlIntelligentSitemap = async (
       extraHTTPHeaders,
       safeMode,
       scanDuration,
+      requestQueueName: 'crawlee_rq_domain',
     });
   }
 
-  // Process all discovered sitemaps sequentially, sharing dataset and urlsCrawled
-  for (const currentSitemapUrl of sitemapUrls) {
+  // Process all discovered sitemaps sequentially, sharing dataset and urlsCrawled.
+  // Each phase gets its own request queue name to avoid Windows EPERM races on
+  // .json.lock files when phase N+1 begins enqueuing before phase N's async
+  // lock-file cleanup has released the shared crawlee_rq/ directory.
+  for (let i = 0; i < sitemapUrls.length; i += 1) {
+    const currentSitemapUrl = sitemapUrls[i];
     if (urlsCrawled.scanned.length >= maxRequestsPerCrawl) break;
 
     const elapsed = Date.now() - startTime;
@@ -193,6 +198,7 @@ const crawlIntelligentSitemap = async (
       crawledFromLocalFile: false,
       scanDuration: scanDuration > 0 ? remainingDuration : 0,
       ruleset,
+      requestQueueName: `crawlee_rq_sitemap_${i + 1}`,
     });
   }
 
@@ -225,6 +231,7 @@ const crawlIntelligentSitemap = async (
       urlsCrawledFromIntelligent: urlsCrawled,
       scanDuration: remainingScanDuration,
       ruleset,
+      requestQueueName: 'crawlee_rq_domain',
     });
   } else if (!hasDurationRemaining) {
     consoleLogger.info(

--- a/src/crawlers/crawlSitemap.ts
+++ b/src/crawlers/crawlSitemap.ts
@@ -62,6 +62,7 @@ const crawlSitemap = async ({
   urlsCrawledFromIntelligent = null,
   crawledFromLocalFile = false,
   ruleset = [],
+  requestQueueName,
 }: {
   sitemapUrl: string;
   randomToken: string;
@@ -84,6 +85,7 @@ const crawlSitemap = async ({
   urlsCrawledFromIntelligent?: UrlsCrawled;
   crawledFromLocalFile?: boolean;
   ruleset?: RuleFlags[];
+  requestQueueName?: string;
 }) => {
   const crawlStartTime = Date.now();
   let dataset: crawlee.Dataset;
@@ -103,7 +105,7 @@ const crawlSitemap = async ({
     dataset = datasetFromIntelligent;
     urlsCrawled = urlsCrawledFromIntelligent;
   } else {
-    ({ dataset } = await createCrawleeSubFolders(randomToken));
+    ({ dataset } = await createCrawleeSubFolders(randomToken, requestQueueName));
     urlsCrawled = { ...constants.urlsCrawledObj };
   }
 
@@ -142,7 +144,7 @@ const crawlSitemap = async ({
   // has zero impact on crawl behavior (Crawlee processes RequestList first).
   // Having it available enables: download re-enqueue for PDF scanning,
   // 403 rate-limit retry, and enqueueLinks for intelligent sitemap discovery.
-  const { requestQueue } = await createCrawleeSubFolders(randomToken);
+  const { requestQueue } = await createCrawleeSubFolders(randomToken, requestQueueName);
 
   const crawler = register(
     new crawlee.PlaywrightCrawler({

--- a/src/crawlers/runCustom.ts
+++ b/src/crawlers/runCustom.ts
@@ -1,6 +1,6 @@
 /* eslint-env browser */
 import { createCrawleeSubFolders, splitAuthHeaders, addAuthRouteHandler } from './commonCrawlerFunc.js';
-import { cleanUpAndExit, register, registerSoftClose } from '../utils.js';
+import { cleanUpAndExit, getStoragePath, register, registerSoftClose } from '../utils.js';
 import constants, {
   getIntermediateScreenshotsPath,
   guiInfoStatusTypes,
@@ -64,7 +64,7 @@ const runCustom = async (
   extraHTTPHeaders?: Record<string, string>,
 ) => {
   // checks and delete datasets path if it already exists
-  process.env.CRAWLEE_STORAGE_DIR = randomToken;
+  process.env.CRAWLEE_STORAGE_DIR = getStoragePath(randomToken);
 
   const urlsCrawled: UrlsCrawled = { ...constants.urlsCrawledObj };
   const { dataset } = await createCrawleeSubFolders(randomToken);

--- a/src/mergeAxeResults.ts
+++ b/src/mergeAxeResults.ts
@@ -1101,29 +1101,24 @@ const generateArtifacts = async (
     await storageClient.teardown();
   }
 
-  // Gracefully drop Dataset and RequestQueue — releases locks and removes files
-  const crawleeDir = path.join(storagePath, 'crawlee');
+  // Gracefully drop the Dataset — releases handles cleanly. Per-phase request
+  // queues (crawlee_rq_sitemap_*, crawlee_rq_domain) can't be enumerated here
+  // by name; the rm below wipes their parent directory.
   try {
-    const dataset = await Dataset.open(crawleeDir);
+    const dataset = await Dataset.open('crawlee');
     await dataset.drop();
   } catch (error) {
     consoleLogger.info(`Dataset drop: ${error.message}`);
   }
 
-  try {
-    const requestQueue = await RequestQueue.open(`${crawleeDir}_rq`);
-    await requestQueue.drop();
-  } catch (error) {
-    consoleLogger.info(`RequestQueue drop: ${error.message}`);
-  }
-
-  // Fallback rm for any leftover files not managed by Crawlee's storage API
-  const crawleePath = path.join(storagePath, 'crawlee');
-  try {
-    await fs.promises.rm(crawleePath, { recursive: true, force: true });
-    await fs.promises.rm(`${crawleePath}_rq`, { recursive: true, force: true });
-  } catch {
-    // Best-effort; storage was already dropped via API
+  // Fallback rm — memory-storage@3.18 owns the layout:
+  //   <storagePath>/{datasets,request_queues,key_value_stores}/
+  for (const dir of ['datasets', 'request_queues', 'key_value_stores']) {
+    try {
+      await fs.promises.rm(path.join(storagePath, dir), { recursive: true, force: true });
+    } catch {
+      // Best-effort; already dropped via API or never created
+    }
   }
 
   try {

--- a/src/mergeAxeResults.ts
+++ b/src/mergeAxeResults.ts
@@ -812,7 +812,7 @@ const generateArtifacts = async (
   consoleLogger.info('Generating report artifacts');
 
   const storagePath = getStoragePath(randomToken);
-  const intermediateDatasetsPath = `${storagePath}/crawlee`;
+  const intermediateDatasetsPath = `${storagePath}/datasets/crawlee`;
   const oobeeAppVersion = getVersion();
   const isCustomFlow = scanType === ScannerTypes.CUSTOM;
 

--- a/src/npmIndex.ts
+++ b/src/npmIndex.ts
@@ -14,7 +14,7 @@ import {
   submitForm,
 } from './constants/common.js';
 import { createCrawleeSubFolders, enrichViolationMessages, filterAxeResults } from './crawlers/commonCrawlerFunc.js';
-import { createAndUpdateResultsFolders, getVersion } from './utils.js';
+import { createAndUpdateResultsFolders, getStoragePath, getVersion } from './utils.js';
 import generateArtifacts, { createBasicFormHTMLSnippet, sendWcagBreakdownToSentry } from './mergeAxeResults.js';
 import { enrichColorContrastDOMContext, takeScreenshotForHTMLElements } from './screenshotFunc/htmlScreenshotFunc.js';
 import { consoleLogger, silentLogger } from './logs.js';
@@ -363,7 +363,7 @@ export const init = async ({
   // max numbers of mustFix/goodToFix occurrences before test returns a fail
   const { mustFix: mustFixThreshold, goodToFix: goodToFixThreshold } = thresholds;
 
-  process.env.CRAWLEE_STORAGE_DIR = randomToken;
+  process.env.CRAWLEE_STORAGE_DIR = getStoragePath(randomToken);
   constants.sitemapFetchedLinks = null;
 
   const scanDetails = {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -7,7 +7,7 @@ import axe, { Rule } from 'axe-core';
 import { v4 as uuidv4 } from 'uuid';
 import { getDomain } from 'tldts';
 import { normalizeUrl } from '@apify/utilities';
-import { Dataset, RequestQueue, Configuration } from 'crawlee';
+import { Dataset, Configuration } from 'crawlee';
 import constants, {
   BrowserTypes,
   destinationPath,
@@ -463,23 +463,22 @@ export const cleanUp = async (randomToken?: string, isError: boolean = false): P
       if (storageClient.teardown) {
         await storageClient.teardown();
       }
-      const crawleeDir = path.join(storagePath, 'crawlee');
-      const dataset = await Dataset.open(crawleeDir);
+      // Drop the dataset via API so Crawlee releases its handles cleanly. The
+      // per-phase request queues (crawlee_rq_sitemap_*, crawlee_rq_domain) are
+      // wiped by the rm calls below — we can't enumerate every phase name here.
+      const dataset = await Dataset.open('crawlee');
       await dataset.drop();
-      const requestQueue = await RequestQueue.open(`${crawleeDir}_rq`);
-      await requestQueue.drop();
     } catch (error) {
       consoleLogger.info(`Crawlee storage drop in cleanUp: ${error.message}`);
     }
-    try {
-      fs.rmSync(path.join(storagePath, 'crawlee'), { recursive: true, force: true });
-    } catch (error) {
-      consoleLogger.warn(`Unable to force remove crawlee folder: ${error.message}`);
-    }
-    try {
-      fs.rmSync(path.join(storagePath, 'crawlee_rq'), { recursive: true, force: true });
-    } catch (error) {
-      consoleLogger.warn(`Unable to force remove crawlee_rq folder: ${error.message}`);
+    // Since 3.18, memory-storage owns the layout: <storagePath>/{datasets,
+    // request_queues,key_value_stores}/. Sweep them all.
+    for (const dir of ['datasets', 'request_queues', 'key_value_stores']) {
+      try {
+        fs.rmSync(path.join(storagePath, dir), { recursive: true, force: true });
+      } catch (error) {
+        consoleLogger.warn(`Unable to force remove ${dir} folder: ${error.message}`);
+      }
     }
 
     try {
@@ -1078,7 +1077,7 @@ export const zipResults = async (zipName: string, resultsPath: string): Promise<
   async function addFolderToZip(folderPath: string, zipFolder: JSZip, isRoot = false): Promise<void> {
     const items = await fs.readdir(folderPath);
     for (const item of items) {
-      if (isRoot && item.startsWith('crawlee')) continue;
+      if (isRoot && (item === 'datasets' || item === 'request_queues' || item === 'key_value_stores')) continue;
       const fullPath = path.join(folderPath, item);
       const stats = await fs.stat(fullPath);
       if (stats.isDirectory()) {


### PR DESCRIPTION
## Summary

Fixes #819 (Crawlee 3.18 breaks scans at startup) and addresses a related Windows intelligent-scan stall.

## Problem 1 — Crawlee 3.18 rejects our storage names (#819)

`@crawlee/memory-storage@3.18.0` added a `resolveWithinDirectory` validator that rejects absolute paths passed as storage names. oobee was calling `Dataset.open(path.join(getStoragePath(randomToken), 'crawlee'))` and the equivalent for `RequestQueue`. This worked silently on 3.17 and hard-crashes on 3.18 — every scan fails immediately.

## Problem 2 — Windows intelligent-scan stall at phase transitions

On Windows, intelligent scans of large sitemapped sites (e.g. cpf.gov.sg) stalled indefinitely at phase transitions, reproducibly at the `crawlSitemap → crawlDomain` boundary around 3728 pages.

Root cause: all phases shared the same `crawlee_rq/` directory. When phase N's async lock-file cleanup was still in flight and phase N+1 started enqueuing, `mkdir '<request-id>.json.lock'` returned `EPERM`. Windows returns `EPERM` (not `ELOCKED`) so `proper-lockfile` doesn't retry. The error then propagates through Crawlee's async-executor anti-pattern in `request_provider.ts` — the outer `new Promise(async () => …)` never resolves when the async executor throws, `inProgressRequestBatchCount` gets stuck > 0, and `RequestQueue.isFinished()` returns `false` forever.

## Fix

- Upgrade `crawlee` to `^3.18.0`.
- Set `CRAWLEE_STORAGE_DIR` to the absolute storage path in all entry points (`combine.ts`, `npmIndex.ts`, `runCustom.ts`). Pass relative names (`'crawlee'`, `'crawlee_rq'`, …) to `Dataset.open()` / `RequestQueue.open()`.
- Intelligent scan uses **per-phase request queue names**: `crawlee_rq_sitemap_N` for each discovered sitemap and `crawlee_rq_domain` for the fallback/tail domain crawl. Each phase gets its own directory, so cross-phase lock races cannot happen.
- Standalone sitemap and website scans keep the default `'crawlee_rq'` name — behavior unchanged.

## Storage layout change

`memory-storage` now owns the layout (was implicit before):

```
Before                    After
<storage>/crawlee/        <storage>/datasets/crawlee/
<storage>/crawlee_rq/     <storage>/request_queues/{crawlee_rq,crawlee_rq_sitemap_N,crawlee_rq_domain}/
                          <storage>/key_value_stores/default/
```

Updated for the new layout:
- `cleanUp()` in `src/utils.ts` — drops the dataset via API and rms the three new parent dirs
- `generateArtifacts()` in `src/mergeAxeResults.ts` — reads intermediate dataset JSONs from `<storage>/datasets/crawlee/` (without this, scans complete but the report shows 0 issues)
- Zip exclusion filter in `src/utils.ts`

## Test plan

- [x] `npm run build` passes
- [ ] Website scan (`-c website`)
- [ ] Sitemap scan (`-c sitemap`)
- [ ] Local file scan (`-c localfile`)
- [ ] Custom scan (`-c custom`)
- [ ] Intelligent scan (`-c intelligent`) on small site
- [ ] Intelligent scan on cpf.gov.sg (Windows) — proceeds past the ~3728-page phase transition
- [ ] Cancelled scan leaves no `datasets/`, `request_queues/`, or `key_value_stores/` in export dir
- [ ] Results zip contains no Crawlee-internal folders

## Non-goals

Not patching Crawlee's async-executor bug in `request_provider.ts` — upstream still ships it. Per-phase isolation removes the trigger we identified; if `EPERM` occurs from other sources (Windows Defender, antivirus), the existing `psTreeHandler` suppression in `combine.ts` still catches the crash and `proper-lockfile`'s intra-phase retries handle transient failures.

## Companion PR

Requires GovTechSG/oobee-desktop `fix/crawlee-3.18-storage-layout` — updates the desktop app's post-cancel cleanup to sweep the new layout dirs.
