### PR TITLE
fix(crawlee): dedup URLs across sitemap phases in intelligent scan (Crawlee 3.18.0)

### DIFF
--- a/src/crawlers/crawlSitemap.ts
+++ b/src/crawlers/crawlSitemap.ts
@@ -132,6 +132,14 @@ const crawlSitemap = async ({
   const uuidToPdfMapping: Record<string, string> = {};
   const isScanHtml = [FileTypes.All, FileTypes.HtmlOnly].includes(fileTypes as FileTypes);
   const isScanPdfs = [FileTypes.All, FileTypes.PdfOnly].includes(fileTypes as FileTypes);
+  // Intelligent scans run multiple phases with per-phase request queues, so the
+  // queue-level uniqueKey dedup no longer prevents a URL scanned in phase N from
+  // being re-scanned when phase N+1 (another sitemap, or enqueueLinks discovery)
+  // enqueues it again. Track scanned URLs by normalized form and short-circuit
+  // the request handler when the current URL is already in urlsCrawled.scanned.
+  const scannedUrlSet = fromCrawlIntelligentSitemap
+    ? new Set<string>(urlsCrawled.scanned.map(item => normUrl(item.url)))
+    : null;
   const { playwrightDeviceDetailsObject } = viewportSettings;
   const { maxConcurrency } = constants;
   const { nonAuthHeaders, httpCredentials } = splitAuthHeaders(extraHTTPHeaders);
@@ -280,6 +288,15 @@ const crawlSitemap = async ({
 
         try {
           await waitForPageLoaded(page);
+
+          // Cross-phase dedup for intelligent scans: skip URLs already scanned by a
+          // previous phase (shared urlsCrawled). Standalone sitemap scans have
+          // scannedUrlSet === null and fall through unchanged. Placed after
+          // waitForPageLoaded so every loaded page still stabilizes the browser
+          // context before we return.
+          if (scannedUrlSet?.has(normUrl(request.url))) {
+            return;
+          }
 
           const actualUrl = page.url() || request.loadedUrl || request.url;
 
@@ -460,6 +477,7 @@ const crawlSitemap = async ({
                 pageTitle: results.pageTitle,
                 actualUrl, // i.e. actualUrl
               });
+              scannedUrlSet?.add(normUrl(request.url));
               rateController.onSuccess(crawler.autoscaledPool);
               if (rateController.isLimitReached()) {
                 isAbortingScan = true;
@@ -490,6 +508,14 @@ const crawlSitemap = async ({
                         req.url = req.url.replace(/(?<=&|\?)utm_.*?(&|$)/gim, '');
                       } catch {}
                       if (isDisallowedInRobotsTxt(req.url)) return null;
+                      // Mirror crawlDomain's optimization: skip page.goto for URLs
+                      // already scanned in this or a previous phase. The handler's
+                      // early-return still catches them, but this saves the
+                      // navigation cost. scannedUrlSet is only non-null under
+                      // fromCrawlIntelligentSitemap.
+                      if (scannedUrlSet?.has(normUrl(req.url))) {
+                        req.skipNavigation = true;
+                      }
                       if (isUrlPdf(req.url)) {
                         req.skipNavigation = true;
                       }


### PR DESCRIPTION
Crawlee 3.18's per-phase request queues (crawlee_rq_sitemap_N, crawlee_rq_domain) removed the queue-level uniqueKey dedup that previously prevented cross-phase duplicate scans in the intelligent flow. Same-URL entries in multiple sitemap files (observed on cpf.gov.sg article pages) were being axe-scanned twice, double-counted in urlsCrawled.scanned, and duplicated in the intermediate dataset — inflating both the page count and the issue count in the final report.

crawlSitemap now consults the shared urlsCrawled.scanned via a scannedUrlSet (only when fromCrawlIntelligentSitemap), guards the request handler after waitForPageLoaded so page stabilization still runs on every load, and mirrors crawlDomain's transformRequestFunction optimization to set skipNavigation=true for already-scanned URLs discovered via enqueueLinks — saving the page.goto cost.

Standalone sitemap scans see scannedUrlSet === null and behave identically to before.

This PR adds... <!-- A brief description of what your PR does -->

<!-- This checklist is just a guideline.-->
<!-- If any of the following does not apply to your PR, please leave them unchecked and explain in the PR -->

- [ ] I've kept this PR as small as possible (~500 lines) by splitting it into PRs with manageable chunks of code
- [ ] I've requested reviews from 1 reviewer
- [ ] I've tested existing features (website scan, sitemap, custom flow) in both node index and cli
- [ ] I've synced this fork with GovTechSG repo
- [ ] I've added/updated unit tests
- [ ] I've added/updated any necessary dependencies in `package[-lock].json` `npm audit`, portable installation on GitHub Actions
