### PR TITLE
fix(crawlee): upgrade to 3.18.0 with storage-name fix and shared-queue dedup

### DIFF
--- a/src/crawlers/commonCrawlerFunc.ts
+++ b/src/crawlers/commonCrawlerFunc.ts
@@ -1390,9 +1390,6 @@ export const runAxeScript = async ({
 // @crawlee/memory-storage@3.18 rejects absolute paths as storage names, so callers
 // must pass relative names. The actual storage location is conveyed via the
 // CRAWLEE_STORAGE_DIR env var (set to getStoragePath(randomToken) at scan entry).
-// requestQueueName is parameterised so intelligent scans can isolate per-phase
-// request queues — sharing one queue directory across crawlSitemap → crawlDomain
-// transitions triggered a Windows EPERM race on the request-queue .json.lock files.
 export const createCrawleeSubFolders = async (
   _randomToken: string,
   requestQueueName: string = 'crawlee_rq',

--- a/src/crawlers/crawlIntelligentSitemap.ts
+++ b/src/crawlers/crawlIntelligentSitemap.ts
@@ -156,14 +156,13 @@ const crawlIntelligentSitemap = async (
       extraHTTPHeaders,
       safeMode,
       scanDuration,
-      requestQueueName: 'crawlee_rq_domain',
     });
   }
 
-  // Process all discovered sitemaps sequentially, sharing dataset and urlsCrawled.
-  // Each phase gets its own request queue name to avoid Windows EPERM races on
-  // .json.lock files when phase N+1 begins enqueuing before phase N's async
-  // lock-file cleanup has released the shared crawlee_rq/ directory.
+  // Process all discovered sitemaps sequentially, sharing dataset, urlsCrawled,
+  // and a single request queue. The shared queue gives us Crawlee's built-in
+  // uniqueKey dedup across phases for free — a URL enqueued in phase 1 won't be
+  // re-enqueued in phase 2.
   for (let i = 0; i < sitemapUrls.length; i += 1) {
     const currentSitemapUrl = sitemapUrls[i];
     if (urlsCrawled.scanned.length >= maxRequestsPerCrawl) break;
@@ -198,7 +197,6 @@ const crawlIntelligentSitemap = async (
       crawledFromLocalFile: false,
       scanDuration: scanDuration > 0 ? remainingDuration : 0,
       ruleset,
-      requestQueueName: `crawlee_rq_sitemap_${i + 1}`,
     });
   }
 
@@ -231,7 +229,6 @@ const crawlIntelligentSitemap = async (
       urlsCrawledFromIntelligent: urlsCrawled,
       scanDuration: remainingScanDuration,
       ruleset,
-      requestQueueName: 'crawlee_rq_domain',
     });
   } else if (!hasDurationRemaining) {
     consoleLogger.info(

--- a/src/crawlers/crawlSitemap.ts
+++ b/src/crawlers/crawlSitemap.ts
@@ -132,11 +132,11 @@ const crawlSitemap = async ({
   const uuidToPdfMapping: Record<string, string> = {};
   const isScanHtml = [FileTypes.All, FileTypes.HtmlOnly].includes(fileTypes as FileTypes);
   const isScanPdfs = [FileTypes.All, FileTypes.PdfOnly].includes(fileTypes as FileTypes);
-  // Intelligent scans run multiple phases with per-phase request queues, so the
-  // queue-level uniqueKey dedup no longer prevents a URL scanned in phase N from
-  // being re-scanned when phase N+1 (another sitemap, or enqueueLinks discovery)
-  // enqueues it again. Track scanned URLs by normalized form and short-circuit
-  // the request handler when the current URL is already in urlsCrawled.scanned.
+  // Intelligent scans process multiple sitemaps sequentially. The shared request
+  // queue deduplicates enqueueLinks discoveries, but each phase builds its own
+  // RequestList from the sitemap XML — RequestList entries bypass queue dedup.
+  // Track previously scanned URLs so we can filter the RequestList upfront and
+  // short-circuit the handler for any that slip through.
   const scannedUrlSet = fromCrawlIntelligentSitemap
     ? new Set<string>(urlsCrawled.scanned.map(item => normUrl(item.url)))
     : null;
@@ -144,8 +144,20 @@ const crawlSitemap = async ({
   const { maxConcurrency } = constants;
   const { nonAuthHeaders, httpCredentials } = splitAuthHeaders(extraHTTPHeaders);
 
+  // Filter out URLs already scanned in previous phases to avoid navigating to
+  // them at all (the handler-level check is a safety net, not the primary gate).
+  const filteredSources = scannedUrlSet
+    ? linksFromSitemap.filter(req => !scannedUrlSet.has(normUrl(req.url)))
+    : linksFromSitemap;
+
+  if (scannedUrlSet && filteredSources.length < linksFromSitemap.length) {
+    consoleLogger.info(
+      `Skipped ${linksFromSitemap.length - filteredSources.length} URLs already scanned in previous phases`,
+    );
+  }
+
   const requestList = await RequestList.open({
-    sources: linksFromSitemap,
+    sources: filteredSources,
   });
 
   // Always create a request queue alongside the request list. An empty queue
@@ -508,13 +520,10 @@ const crawlSitemap = async ({
                         req.url = req.url.replace(/(?<=&|\?)utm_.*?(&|$)/gim, '');
                       } catch {}
                       if (isDisallowedInRobotsTxt(req.url)) return null;
-                      // Mirror crawlDomain's optimization: skip page.goto for URLs
-                      // already scanned in this or a previous phase. The handler's
-                      // early-return still catches them, but this saves the
-                      // navigation cost. scannedUrlSet is only non-null under
-                      // fromCrawlIntelligentSitemap.
+                      // Drop URLs already scanned in this or a previous phase —
+                      // no point enqueuing them at all.
                       if (scannedUrlSet?.has(normUrl(req.url))) {
-                        req.skipNavigation = true;
+                        return null;
                       }
                       if (isUrlPdf(req.url)) {
                         req.skipNavigation = true;


### PR DESCRIPTION
## Summary

Upgrade to Crawlee 3.18.0 and fix the breaking change where `@crawlee/memory-storage` now rejects absolute paths passed to `Dataset.open()` / `RequestQueue.open()`.

Also simplifies the intelligent sitemap crawler by replacing per-phase request queues with a single shared queue, giving us built-in cross-phase URL deduplication.

## Problem

- **Storage name validation (issue #819):** Crawlee 3.18.0's memory-storage validates that storage names are not absolute paths. oobee passed `path.join(getStoragePath(randomToken), 'crawlee')` as the name, which is an absolute path — causing a runtime error.
- **Cross-phase duplication:** Intelligent sitemap scans run multiple phases (domain crawl → sitemap phases → enqueueLinks discovery). With per-phase request queues introduced in #820, a URL scanned in phase 1 could be re-enqueued and re-crawled in phase 2 since each queue tracked uniqueness independently.

## Solution

### Storage name fix
- Pass relative names (`'crawlee'`, `'crawlee_rq'`) to `Dataset.open()` / `RequestQueue.open()`
- Set `CRAWLEE_STORAGE_DIR` env var to `getStoragePath(randomToken)` at scan entry — this tells Crawlee where to write on disk
- Update all callers (`crawlDomain`, `crawlSitemap`, `crawlIntelligentSitemap`, `runCustom`, `combine`, `npmIndex`)
- Update cleanup paths in `utils.ts` and `mergeAxeResults.ts` to match 3.18's on-disk layout (`datasets/`, `request_queues/`, `key_value_stores/`)

### Shared queue dedup for intelligent sitemap
- Use a single shared request queue across all phases — Crawlee's built-in `uniqueKey` dedup prevents re-enqueuing across phases for free
- Pre-filter `RequestList` sources against already-scanned URLs (since `RequestList` entries bypass queue-level dedup)
- Drop already-scanned URLs from `enqueueLinks` via `return null` instead of `skipNavigation`, so they aren't navigated at all
- Add `scannedUrlSet` tracking that updates as each URL completes, providing a handler-level safety net

## Files changed

| File | Change |
|------|--------|
| `package.json` | Bump crawlee to 3.18.0 |
| `src/crawlers/commonCrawlerFunc.ts` | Use relative storage names, add `requestQueueName` param |
| `src/crawlers/crawlDomain.ts` | Accept `requestQueueName`, pass through to `createCrawleeSubFolders` |
| `src/crawlers/crawlSitemap.ts` | Pre-filter RequestList sources, handler-level dedup, enqueueLinks dedup |
| `src/crawlers/crawlIntelligentSitemap.ts` | Remove per-phase queue names, use shared queue |
| `src/crawlers/runCustom.ts` | Set `CRAWLEE_STORAGE_DIR` to full path |
| `src/combine.ts` | Set `CRAWLEE_STORAGE_DIR` to full path |
| `src/npmIndex.ts` | Set `CRAWLEE_STORAGE_DIR` to full path |
| `src/mergeAxeResults.ts` | Update dataset path, sweep 3.18 layout dirs on cleanup |
| `src/utils.ts` | Update cleanup to sweep `datasets/`, `request_queues/`, `key_value_stores/`; update zip exclusion |

## Test plan

- [ ] Run intelligent sitemap scan against a site with overlapping sitemap URLs — verify no duplicate pages in results
- [ ] Run standard sitemap scan — verify no regression
- [ ] Run domain crawl — verify no regression
- [ ] Confirm log message `Skipped N URLs already scanned in previous phases` appears when sitemap phases overlap
- [ ] Verify cleanup removes all crawlee artifacts after scan completion and on cancel
- [ ] Test on Windows — confirm no EPERM lock-file errors on scan transitions
