### PR TITLE
feat(crawl): abort and generate partial report when idle too long

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ verapdf --version
 | OOBEE_SCAN_METADATA | Overrides the `entryUrl` tag sent to telemetry. | |
 | OOBEE_SCAN_PRODUCT | Adds a `scanProduct` tag to telemetry events. | |
 | OOBEE_CONSECUTIVE_MAX_RETRIES | Max consecutive HTTP failures before the circuit breaker aborts the crawl. | `100` |
+| OOBEE_MAX_IDLE_MINUTES | Max minutes without a successful page scan before the crawl aborts and generates a partial report from pages already scanned. Helps avoid losing results when sites start blocking mid-crawl. | `5` |
 | OOBEE_SAVE_DOM | Set to `1` or `true` to save full-page DOM HTML for each scanned page in both desktop and mobile viewports to the results directory. Mobile viewport width is determined from iPhone 11 device profile. Works with all scan types (Website, Sitemap, Intelligent, LocalFile, Custom). | |
 | OOBEE_SAVE_PAGE_SCREENSHOT | Set to `1` or `true` to save full-page desktop and mobile viewport screenshots for each scanned page. Mobile viewport width is determined from iPhone 11 device profile. Works with all scan types (Website, Sitemap, Intelligent, LocalFile, Custom). | |
 | HTTP_PROXY | URL of the proxy server to be used for HTTP requests (e.g. `http://proxy.example.com:8080`). | |

--- a/src/crawlers/crawlDomain.ts
+++ b/src/crawlers/crawlDomain.ts
@@ -386,6 +386,8 @@ const crawlDomain = async ({
   };
 
   let isAbortingScanNow = false;
+  let lastSuccessTime = Date.now();
+  const maxIdleMs = (Number(process.env.OOBEE_MAX_IDLE_MINUTES) || 5) * 60 * 1000;
   const remainingBudget = fromCrawlIntelligentSitemap
     ? Math.max(0, maxRequestsPerCrawl - urlsCrawledFromIntelligent.scanned.length)
     : maxRequestsPerCrawl;
@@ -765,6 +767,7 @@ const crawlDomain = async ({
                   actualUrl, // i.e. actualUrl
                 });
                 rateController.onSuccess(crawler.autoscaledPool);
+                lastSuccessTime = Date.now();
                 if (rateController.isLimitReached()) {
                   isAbortingScanNow = true;
                   activeCrawler.autoscaledPool.abort();
@@ -792,6 +795,7 @@ const crawlDomain = async ({
                 pageTitle: results.pageTitle,
               });
               rateController.onSuccess(crawler.autoscaledPool);
+              lastSuccessTime = Date.now();
               if (rateController.isLimitReached()) {
                 isAbortingScanNow = true;
                 activeCrawler.autoscaledPool.abort();
@@ -918,6 +922,19 @@ const crawlDomain = async ({
         ) {
           consoleLogger.info(
             `Aborting crawl: consecutive HTTP failures threshold reached (site may be rate-limiting). Successfully scanned ${urlsCrawled.scanned.length} pages.`,
+          );
+          isAbortingScanNow = true;
+          crawler.autoscaledPool?.abort();
+          return;
+        }
+
+        const timeSinceLastSuccess = Date.now() - lastSuccessTime;
+        if (
+          urlsCrawled.scanned.length > 0 &&
+          timeSinceLastSuccess > maxIdleMs
+        ) {
+          consoleLogger.info(
+            `Aborting crawl: no successful scan in ${Math.round(timeSinceLastSuccess / 1000)}s. Generating partial report with ${urlsCrawled.scanned.length} pages.`,
           );
           isAbortingScanNow = true;
           crawler.autoscaledPool?.abort();

--- a/src/crawlers/crawlSitemap.ts
+++ b/src/crawlers/crawlSitemap.ts
@@ -92,6 +92,8 @@ const crawlSitemap = async ({
   let urlsCrawled: UrlsCrawled;
   let durationExceeded = false;
   let isAbortingScan = false;
+  let lastSuccessTime = Date.now();
+  const maxIdleMs = (Number(process.env.OOBEE_MAX_IDLE_MINUTES) || 5) * 60 * 1000;
   const remainingBudget = fromCrawlIntelligentSitemap
     ? Math.max(0, maxRequestsPerCrawl - urlsCrawledFromIntelligent.scanned.length)
     : maxRequestsPerCrawl;
@@ -491,6 +493,7 @@ const crawlSitemap = async ({
               });
               scannedUrlSet?.add(normUrl(request.url));
               rateController.onSuccess(crawler.autoscaledPool);
+              lastSuccessTime = Date.now();
               if (rateController.isLimitReached()) {
                 isAbortingScan = true;
                 crawler.autoscaledPool.abort();
@@ -645,6 +648,19 @@ const crawlSitemap = async ({
         ) {
           consoleLogger.info(
             `Aborting crawl: consecutive HTTP failures threshold reached (site may be rate-limiting). Successfully scanned ${urlsCrawled.scanned.length} pages.`,
+          );
+          isAbortingScan = true;
+          crawler.autoscaledPool?.abort();
+          return;
+        }
+
+        const timeSinceLastSuccess = Date.now() - lastSuccessTime;
+        if (
+          urlsCrawled.scanned.length > 0 &&
+          timeSinceLastSuccess > maxIdleMs
+        ) {
+          consoleLogger.info(
+            `Aborting crawl: no successful scan in ${Math.round(timeSinceLastSuccess / 1000)}s. Generating partial report with ${urlsCrawled.scanned.length} pages.`,
           );
           isAbortingScan = true;
           crawler.autoscaledPool?.abort();


### PR DESCRIPTION
## Summary

- Add idle-timeout abort: if no page is successfully scanned within 5 minutes (configurable via `OOBEE_MAX_IDLE_MINUTES`), the crawl stops gracefully and generates a partial report from pages already scanned
- Applies to both sitemap and domain crawlers
- Prevents losing all scan progress when sites start blocking mid-crawl (e.g. Incapsula/WAF rate-limiting) and the ECS task eventually times out

## Problem

Sites like onepa.gov.sg (behind Incapsula) allow initial pages to be scanned but progressively block requests after ~50-90 pages. The crawler would keep retrying for hours until the ECS task timeout killed the process — losing all successfully scanned results.

## Test plan

- [ ] `npx tsc --noEmit` passes
- [ ] Scan a site that blocks after some pages — verify partial report is generated after 5 min idle
- [ ] Scan a normal site — verify the idle timeout does not trigger (successes keep resetting the timer)
- [ ] Test with `OOBEE_MAX_IDLE_MINUTES=1` to verify env var override works

🤖 Generated with [Claude Code](https://claude.com/claude-code)
