### PR TITLE
fix(crawl): add periodic idle check so abort fires promptly

### DIFF
--- a/src/crawlers/crawlDomain.ts
+++ b/src/crawlers/crawlDomain.ts
@@ -992,7 +992,19 @@ const crawlDomain = async ({
     }),
   );
 
+  const idleCheckInterval = setInterval(() => {
+    const timeSinceLastSuccess = Date.now() - lastSuccessTime;
+    if (urlsCrawled.scanned.length > 0 && timeSinceLastSuccess > maxIdleMs) {
+      consoleLogger.info(
+        `Aborting crawl: no successful scan in ${Math.round(timeSinceLastSuccess / 1000)}s. Generating partial report with ${urlsCrawled.scanned.length} pages.`,
+      );
+      isAbortingScanNow = true;
+      crawler.autoscaledPool?.abort();
+    }
+  }, 30_000);
+
   await crawler.run();
+  clearInterval(idleCheckInterval);
 
   // Additional passes: keep re-visiting scanned seed-hostname pages for
   // click-discovery until no new pages are found or limits are reached.
@@ -1045,7 +1057,19 @@ const crawlDomain = async ({
 
       if (enqueued === 0) break;
 
+      lastSuccessTime = Date.now();
+      const clickPassIdleCheck = setInterval(() => {
+        const timeSinceLastSuccess = Date.now() - lastSuccessTime;
+        if (urlsCrawled.scanned.length > 0 && timeSinceLastSuccess > maxIdleMs) {
+          consoleLogger.info(
+            `Aborting crawl: no successful scan in ${Math.round(timeSinceLastSuccess / 1000)}s. Generating partial report with ${urlsCrawled.scanned.length} pages.`,
+          );
+          isAbortingScanNow = true;
+          crawler.autoscaledPool?.abort();
+        }
+      }, 30_000);
       await crawler.run();
+      clearInterval(clickPassIdleCheck);
 
       // Stop looping if no new pages were discovered in this pass
     } while (urlsCrawled.scanned.length > prevScannedCount);

--- a/src/crawlers/crawlSitemap.ts
+++ b/src/crawlers/crawlSitemap.ts
@@ -730,7 +730,19 @@ const crawlSitemap = async ({
     }),
   );
 
+  const idleCheckInterval = setInterval(() => {
+    const timeSinceLastSuccess = Date.now() - lastSuccessTime;
+    if (urlsCrawled.scanned.length > 0 && timeSinceLastSuccess > maxIdleMs) {
+      consoleLogger.info(
+        `Aborting crawl: no successful scan in ${Math.round(timeSinceLastSuccess / 1000)}s. Generating partial report with ${urlsCrawled.scanned.length} pages.`,
+      );
+      isAbortingScan = true;
+      crawler.autoscaledPool?.abort();
+    }
+  }, 30_000);
+
   await crawler.run();
+  clearInterval(idleCheckInterval);
 
   await requestList.isFinished();
 


### PR DESCRIPTION
## Summary

- The idle timeout from #827 was only evaluated inside `failedRequestHandler`, meaning it couldn't fire until a hanging request timed out (up to 90s per attempt). If the site silently drops connections, the abort was delayed unnecessarily.
- Adds a 30s `setInterval` timer that checks idle time independently of request failures, so the crawl aborts promptly once `OOBEE_MAX_IDLE_MINUTES` elapses without a successful scan.
- Applied to both `crawlSitemap` and `crawlDomain` (including the click-discovery passes). `crawlIntelligentSitemap` delegates to these, so it's covered transitively.

## Test plan

- [ ] Run a sitemap crawl against a site that blocks after a few pages — confirm abort fires within ~30s of the idle threshold rather than waiting for request timeouts
- [ ] Verify `OOBEE_MAX_IDLE_MINUTES` env var is still respected
- [ ] Confirm normal crawls (no stalling) are unaffected

Ref: #827

🤖 Generated with [Claude Code](https://claude.com/claude-code)