### PR TITLE
feat(npm): expose htmlMaxBytes option in init()

### DIFF
--- a/src/npmIndex.ts
+++ b/src/npmIndex.ts
@@ -331,6 +331,7 @@ export const init = async ({
   ruleset = [RuleFlags.DEFAULT],
   specifiedMaxConcurrency = 25,
   followRobots = false,
+  htmlMaxBytes,
 }: {
   entryUrl: string;
   testLabel: string;
@@ -349,6 +350,7 @@ export const init = async ({
   ruleset?: RuleFlags[];
   specifiedMaxConcurrency?: number;
   followRobots?: boolean;
+  htmlMaxBytes?: number;
 }) => {
   consoleLogger.info('Starting Oobee');
 
@@ -364,6 +366,9 @@ export const init = async ({
   const { mustFix: mustFixThreshold, goodToFix: goodToFixThreshold } = thresholds;
 
   process.env.CRAWLEE_STORAGE_DIR = getStoragePath(randomToken);
+  if (htmlMaxBytes !== undefined) {
+    process.env.OOBEE_HTML_MAX_BYTES = String(htmlMaxBytes);
+  }
   constants.sitemapFetchedLinks = null;
 
   const scanDetails = {


### PR DESCRIPTION
Allow callers to configure HTML truncation limit via the npm API. Pass 0 to disable truncation entirely. If not set, the existing default (1024 bytes) applies.

Ref: #826

This PR adds... <!-- A brief description of what your PR does -->

<!-- This checklist is just a guideline.-->
<!-- If any of the following does not apply to your PR, please leave them unchecked and explain in the PR -->

- [ ] I've kept this PR as small as possible (~500 lines) by splitting it into PRs with manageable chunks of code
- [ ] I've requested reviews from 1 reviewer
- [ ] I've tested existing features (website scan, sitemap, custom flow) in both node index and cli
- [ ] I've synced this fork with GovTechSG repo
- [ ] I've added/updated unit tests
- [ ] I've added/updated any necessary dependencies in `package[-lock].json` `npm audit`, portable installation on GitHub Actions
