### PR TITLE
feat(scan): attach parentHtml ancestor outerHTML to scan items for LLM context

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,9 +3,14 @@ on:
   workflow_dispatch:
     inputs:
       release_tag:
-        description: 'Git tag or ref to publish (e.g. 0.11.4). The commit at this ref will be built and published; its package.json version is what lands on npm.'
+        description: 'Git ref to publish — a tag (e.g. 0.11.4), branch (e.g. feat/foo), or commit SHA. The commit at this ref will be built and published; its package.json version is what lands on npm.'
         required: true
         type: string
+      skip_git_tag:
+        description: 'Skip creating and force-pushing the {version} and "latest" git tags after publish. Use when publishing from a branch or pre-release where moving tags is not desired.'
+        required: false
+        type: boolean
+        default: false
 permissions:
   contents: write
 jobs:
@@ -31,6 +36,7 @@ jobs:
         run: node dist/generateOobeeClientScanner.js
 
       - name: Create and push git tags
+        if: ${{ !inputs.skip_git_tag }}
         run: |
           VERSION=$(node -p "require('./package.json').version")
           git config user.name "github-actions[bot]"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch:
     inputs:
       release_tag:
-        description: 'Git ref to publish — a tag (e.g. 0.11.4), branch (e.g. feat/foo), or commit SHA. The commit at this ref will be built and published; its package.json version is what lands on npm.'
+        description: 'Git ref to check out and publish — an existing tag (e.g. 0.11.4), branch (e.g. feat/foo), or commit SHA. This is NOT the npm version; the version published to npm is whatever is in that commit''s package.json.'
         required: true
         type: string
       skip_git_tag:
@@ -17,11 +17,11 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.release_tag }}
       # Setup .npmrc file to publish to npm
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: '22.x'
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch:
     inputs:
       release_tag:
-        description: 'Git ref to check out and publish — an existing tag (e.g. 0.11.4), branch (e.g. feat/foo), or commit SHA. This is NOT the npm version; the version published to npm is whatever is in that commit''s package.json.'
+        description: 'Git ref to publish — a tag (e.g. 0.11.4), branch (e.g. feat/foo), or commit SHA. The commit at this ref will be built and published; its package.json version is what lands on npm.'
         required: true
         type: string
       skip_git_tag:
@@ -17,11 +17,11 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v3
         with:
           ref: ${{ inputs.release_tag }}
       # Setup .npmrc file to publish to npm
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v3
         with:
           node-version: '22.x'
           registry-url: 'https://registry.npmjs.org'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@govtechsg/oobee",
-  "version": "0.11.10",
+  "version": "0.11.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@govtechsg/oobee",
-      "version": "0.11.10",
+      "version": "0.11.11",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1049.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@govtechsg/oobee",
-  "version": "0.11.9",
+  "version": "0.11.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@govtechsg/oobee",
-      "version": "0.11.9",
+      "version": "0.11.10",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1049.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9482,9 +9482,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@govtechsg/oobee",
   "main": "dist/npmIndex.js",
-  "version": "0.11.10",
+  "version": "0.11.11",
   "type": "module",
   "author": "Government Technology Agency <info@tech.gov.sg>",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
       "eslint": "^9.26.0"
     },
     "fast-xml-parser": ">=5.3.8",
-    "js-yaml": "^4.1.1",
+    "js-yaml": "^4.3.1",
     "minimatch": "^10.2.4",
     "brace-expansion": "^5.0.9",
     "glob": "^13.0.6",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@govtechsg/oobee",
   "main": "dist/npmIndex.js",
-  "version": "0.11.9",
+  "version": "0.11.10",
   "type": "module",
   "author": "Government Technology Agency <info@tech.gov.sg>",
   "bin": {

--- a/src/crawlers/commonCrawlerFunc.ts
+++ b/src/crawlers/commonCrawlerFunc.ts
@@ -60,6 +60,7 @@ export type ContrastDOMContext = {
 export interface NodeResultWithScreenshot extends NodeResult {
   screenshotPath?: string;
   contrastDOMContext?: ContrastDOMContext;
+  parentHtml?: string;
 }
 
 type RuleDetails = {
@@ -129,6 +130,16 @@ const isTransientPageTeardown = (e: unknown): boolean => {
 const htmlMaxBytes = (() => {
   const v = parseInt(process.env.OOBEE_HTML_MAX_BYTES, 10);
   return Number.isFinite(v) ? v : 1024;
+})();
+
+const parentHtmlDepth = (() => {
+  const v = parseInt(process.env.OOBEE_PARENT_HTML_DEPTH, 10);
+  return Number.isFinite(v) && v > 0 ? v : 0;
+})();
+
+const parentHtmlMaxBytes = (() => {
+  const v = parseInt(process.env.OOBEE_PARENT_HTML_MAX_BYTES, 10);
+  return Number.isFinite(v) ? v : htmlMaxBytes;
 })();
 
 const truncateHtml = (html: string, maxBytes = htmlMaxBytes, suffix = '…'): string => {
@@ -786,7 +797,7 @@ export const filterAxeResults = (
     }
 
     const addTo = (category: ResultCategory, node: NodeResultWithScreenshot) => {
-      const { html, failureSummary, screenshotPath, target, impact: axeImpact } = node;
+      const { html, failureSummary, screenshotPath, target, impact: axeImpact, parentHtml } = node;
       if (!(rule in category.rules)) {
         category.rules[rule] = {
           description,
@@ -811,6 +822,14 @@ export const filterAxeResults = (
       }
       finalHtml = truncateHtml(finalHtml);
 
+      let finalParentHtml: string | undefined;
+      if (typeof parentHtml === 'string' && parentHtml.length > 0) {
+        const sanitised = parentHtml.includes('</script>')
+          ? parentHtml.replaceAll('</script>', '&lt;/script>')
+          : parentHtml;
+        finalParentHtml = truncateHtml(sanitised, parentHtmlMaxBytes);
+      }
+
       const xpath = target.length === 1 && typeof target[0] === 'string' ? target[0] : null;
 
       // add in screenshot path
@@ -820,6 +839,7 @@ export const filterAxeResults = (
         screenshotPath,
         xpath: xpath || undefined,
         displayNeedsReview: displayNeedsReview || undefined,
+        ...(finalParentHtml ? { parentHtml: finalParentHtml } : {}),
       });
       category.rules[rule].totalItems += 1;
       category.totalItems += 1;
@@ -1079,6 +1099,7 @@ export const runAxeScript = async ({
       disableOobee,
       enableWcagAaa,
       gradingReadabilityFlag,
+      parentHtmlDepth,
       evaluateAltTextFunctionString,
       escapeCssSelectorFunctionString,
       framesCheckFunctionString,
@@ -1098,6 +1119,24 @@ export const runAxeScript = async ({
         eval(getAxeConfigurationFunctionString);
         // remove so that axe does not scan
         document.querySelector(saflyIconSelector)?.remove();
+
+        // Walk up N ancestors from `selector`'s element and return that
+        // ancestor's outerHTML for LLM sibling-context. Returns undefined when
+        // the feature is disabled (depth <= 0), when the selector doesn't
+        // resolve, or when the walk lands on <html> / past root.
+        const computeParentHtml = (selector: string, depth: number): string | undefined => {
+          if (!selector || !Number.isFinite(depth) || depth <= 0) return undefined;
+          let el: Element | null;
+          try { el = document.querySelector(selector); } catch { return undefined; }
+          if (!el) return undefined;
+          let ancestor: Element = el;
+          for (let i = 0; i < depth; i++) {
+            const p = ancestor.parentElement;
+            if (!p || p.tagName === 'HTML') return undefined;
+            ancestor = p;
+          }
+          return ancestor.outerHTML;
+        };
 
         const oobeeAccessibleLabelFlaggedXpaths = disableOobee
           ? []
@@ -1298,6 +1337,24 @@ export const runAxeScript = async ({
               }
             }
 
+            // Attach parentHtml to axe's violations + incomplete nodes when
+            // parentHtmlDepth > 0 (opt-in via env / init param). Skipped
+            // entirely when disabled — no DOM queries in the default path.
+            if (parentHtmlDepth > 0) {
+              const attachParentHtml = (rules: any[]) => {
+                for (const rule of rules || []) {
+                  for (const node of rule.nodes || []) {
+                    const sel = node.target && node.target[0];
+                    if (typeof sel !== 'string') continue;
+                    const ph = computeParentHtml(sel, parentHtmlDepth);
+                    if (ph) (node as any).parentHtml = ph;
+                  }
+                }
+              };
+              attachParentHtml(results.violations);
+              attachParentHtml(results.incomplete);
+            }
+
             if (disableOobee) {
               return results;
             }
@@ -1314,24 +1371,31 @@ export const runAxeScript = async ({
               help: 'Clickable elements (i.e. elements with mouse-click interaction) must have accessible labels.',
               helpUrl: 'https://www.deque.com/blog/accessible-aria-buttons',
               nodes: escapedCssSelectors
-                .map((cssSelector: string): NodeResult => ({
-                  html: findElementByCssSelector(cssSelector),
-                  target: [cssSelector],
-                  impact: 'serious' as ImpactValue,
-                  failureSummary:
-                    'Fix any of the following:\n  The clickable element does not have an accessible label.',
-                  any: [
-                    {
-                      id: 'oobee-accessible-label',
-                      data: null,
-                      relatedNodes: [],
-                      impact: 'serious',
-                      message: 'The clickable element does not have an accessible label.',
-                    },
-                  ],
-                  all: [],
-                  none: [],
-                }))
+                .map((cssSelector: string): NodeResult => {
+                  const node: NodeResult = {
+                    html: findElementByCssSelector(cssSelector),
+                    target: [cssSelector],
+                    impact: 'serious' as ImpactValue,
+                    failureSummary:
+                      'Fix any of the following:\n  The clickable element does not have an accessible label.',
+                    any: [
+                      {
+                        id: 'oobee-accessible-label',
+                        data: null,
+                        relatedNodes: [],
+                        impact: 'serious',
+                        message: 'The clickable element does not have an accessible label.',
+                      },
+                    ],
+                    all: [],
+                    none: [],
+                  };
+                  if (parentHtmlDepth > 0) {
+                    const ph = computeParentHtml(cssSelector, parentHtmlDepth);
+                    if (ph) (node as any).parentHtml = ph;
+                  }
+                  return node;
+                })
                 .filter(item => item.html),
             };
 
@@ -1353,6 +1417,7 @@ export const runAxeScript = async ({
       disableOobee,
       enableWcagAaa,
       gradingReadabilityFlag,
+      parentHtmlDepth: parentHtmlDepth,
       evaluateAltTextFunctionString: evaluateAltText.toString(),
       escapeCssSelectorFunctionString: escapeCssSelector.toString(),
       framesCheckFunctionString: framesCheck.toString(),

--- a/src/mergeAxeResults/types.ts
+++ b/src/mergeAxeResults/types.ts
@@ -4,6 +4,7 @@ export type ItemsInfo = {
   screenshotPath: string;
   xpath: string;
   displayNeedsReview?: boolean;
+  parentHtml?: string;
 };
 
 export type PageInfo = {
@@ -25,6 +26,7 @@ export type HtmlGroupItem = {
   screenshotPath: string;
   displayNeedsReview?: boolean;
   pageUrls: string[];
+  parentHtml?: string;
 };
 
 export type HtmlGroups = {

--- a/src/npmIndex.ts
+++ b/src/npmIndex.ts
@@ -62,7 +62,14 @@ const getAxeScriptContent = () => {
   return axe.source;
 };
 
-const getOobeeFunctionsScript = (disableOobee: boolean, enableWcagAaa: boolean) => {
+const getOobeeFunctionsScript = (
+  disableOobee: boolean,
+  enableWcagAaa: boolean,
+  parentHtmlDepth: number = 0,
+) => {
+  const safeParentHtmlDepth = Number.isFinite(parentHtmlDepth) && parentHtmlDepth > 0
+    ? Math.floor(parentHtmlDepth)
+    : 0;
   return `
       // Fix for missing __name function used by bundler
       if (typeof __name === 'undefined') {
@@ -214,6 +221,24 @@ const getOobeeFunctionsScript = (disableOobee: boolean, enableWcagAaa: boolean) 
 
       async function runA11yScan(elementsToScan = [], gradingReadabilityFlag = '') {
 
+        // Walk up N ancestors from a CSS selector's element and return that
+        // ancestor's outerHTML for LLM sibling-context. Returns undefined when
+        // the feature is disabled (depth <= 0), when the selector doesn't
+        // resolve, or when the walk lands on <html> / past root.
+        function computeParentHtml(selector, depth) {
+          if (!selector || !Number.isFinite(depth) || depth <= 0) return undefined;
+          var el;
+          try { el = document.querySelector(selector); } catch (_) { return undefined; }
+          if (!el) return undefined;
+          var ancestor = el;
+          for (var i = 0; i < depth; i++) {
+            var p = ancestor.parentElement;
+            if (!p || p.tagName === 'HTML') return undefined;
+            ancestor = p;
+          }
+          return ancestor.outerHTML;
+        }
+
         const oobeeAccessibleLabelFlaggedXpaths = (window).disableOobee
           ? []
           : (await (window).flagUnlabelledClickableElements()).map(item => item.xpath);
@@ -265,12 +290,30 @@ const getOobeeFunctionsScript = (disableOobee: boolean, enableWcagAaa: boolean) 
             }
           });
         }
-  
+
+        // Attach parentHtml to violations + incomplete nodes when the feature
+        // is enabled via window.parentHtmlDepth (from init()/env var). Skipped
+        // entirely when disabled — no DOM queries in the default path.
+        var parentHtmlDepthValue = (window).parentHtmlDepth;
+        if (Number.isFinite(parentHtmlDepthValue) && parentHtmlDepthValue > 0 && axeScanResults) {
+          ['violations', 'incomplete'].forEach(function(type) {
+            if (!axeScanResults[type]) return;
+            axeScanResults[type].forEach(function(rule) {
+              (rule.nodes || []).forEach(function(node) {
+                var sel = node.target && node.target[0];
+                if (typeof sel !== 'string') return;
+                var ph = computeParentHtml(sel, parentHtmlDepthValue);
+                if (ph) node.parentHtml = ph;
+              });
+            });
+          });
+        }
+
         // add custom Oobee violations
         if (!(window).disableOobee) {
           // handle css id selectors that start with a digit
           const escapedCssSelectors = oobeeAccessibleLabelFlaggedCssSelectors.map((window).escapeCssSelector);
-  
+
           // Add oobee violations to Axe's report
           const oobeeAccessibleLabelViolations = {
             id: 'oobee-accessible-label',
@@ -280,27 +323,34 @@ const getOobeeFunctionsScript = (disableOobee: boolean, enableWcagAaa: boolean) 
             help: 'Clickable elements (i.e. elements with mouse-click interaction) must have accessible labels.',
             helpUrl: 'https://www.deque.com/blog/accessible-aria-buttons',
             nodes: escapedCssSelectors
-              .map(cssSelector => ({
-                html: (window).findElementByCssSelector(cssSelector),
-                target: [cssSelector],
-                impact: 'serious',
-                failureSummary:
-                  'Fix any of the following:\\n  The clickable element does not have an accessible label.',
-                any: [
-                  {
-                    id: 'oobee-accessible-label',
-                    data: null,
-                    relatedNodes: [],
-                    impact: 'serious',
-                    message: 'The clickable element does not have an accessible label.',
-                  },
-                ],
-                all: [],
-                none: [],
-              }))
+              .map(cssSelector => {
+                var node = {
+                  html: (window).findElementByCssSelector(cssSelector),
+                  target: [cssSelector],
+                  impact: 'serious',
+                  failureSummary:
+                    'Fix any of the following:\\n  The clickable element does not have an accessible label.',
+                  any: [
+                    {
+                      id: 'oobee-accessible-label',
+                      data: null,
+                      relatedNodes: [],
+                      impact: 'serious',
+                      message: 'The clickable element does not have an accessible label.',
+                    },
+                  ],
+                  all: [],
+                  none: [],
+                };
+                if (Number.isFinite(parentHtmlDepthValue) && parentHtmlDepthValue > 0) {
+                  var ph = computeParentHtml(cssSelector, parentHtmlDepthValue);
+                  if (ph) node.parentHtml = ph;
+                }
+                return node;
+              })
               .filter(item => item.html),
           };
-  
+
           axeScanResults.violations = [...axeScanResults.violations, oobeeAccessibleLabelViolations];
         }
   
@@ -312,6 +362,7 @@ const getOobeeFunctionsScript = (disableOobee: boolean, enableWcagAaa: boolean) 
       }
       window.disableOobee=${disableOobee};
       window.enableWcagAaa=${enableWcagAaa};
+      window.parentHtmlDepth=${safeParentHtmlDepth};
       window.runA11yScan = runA11yScan;
     `;
 };
@@ -332,6 +383,8 @@ export const init = async ({
   specifiedMaxConcurrency = 25,
   followRobots = false,
   htmlMaxBytes,
+  parentHtmlDepth,
+  parentHtmlMaxBytes,
 }: {
   entryUrl: string;
   testLabel: string;
@@ -351,6 +404,8 @@ export const init = async ({
   specifiedMaxConcurrency?: number;
   followRobots?: boolean;
   htmlMaxBytes?: number;
+  parentHtmlDepth?: number;
+  parentHtmlMaxBytes?: number;
 }) => {
   consoleLogger.info('Starting Oobee');
 
@@ -368,6 +423,12 @@ export const init = async ({
   process.env.CRAWLEE_STORAGE_DIR = getStoragePath(randomToken);
   if (htmlMaxBytes !== undefined) {
     process.env.OOBEE_HTML_MAX_BYTES = String(htmlMaxBytes);
+  }
+  if (parentHtmlDepth !== undefined) {
+    process.env.OOBEE_PARENT_HTML_DEPTH = String(parentHtmlDepth);
+  }
+  if (parentHtmlMaxBytes !== undefined) {
+    process.env.OOBEE_PARENT_HTML_MAX_BYTES = String(parentHtmlMaxBytes);
   }
   constants.sitemapFetchedLinks = null;
 
@@ -408,7 +469,9 @@ export const init = async ({
 
   const getOobeeFunctions = () => {
     throwErrorIfTerminated();
-    return getOobeeFunctionsScript(disableOobee, enableWcagAaa);
+    const depthFromEnv = parseInt(process.env.OOBEE_PARENT_HTML_DEPTH, 10);
+    const depth = Number.isFinite(depthFromEnv) && depthFromEnv > 0 ? depthFromEnv : 0;
+    return getOobeeFunctionsScript(disableOobee, enableWcagAaa, depth);
   };
 
   // Helper script for manually copy-paste testing in Chrome browser


### PR DESCRIPTION
## Summary

Adds an optional `parentHtml` field to each violation/incomplete item in `scanItems.json`, containing the outerHTML of the Nth ancestor of the affected element. Off by default; opt in via env var (`OOBEE_PARENT_HTML_DEPTH`) or `init()` param (`parentHtmlDepth`).

**Why:** Downstream LLM fix pipelines only receive the affected element's own `outerHTML` today. That's often too narrow to *fix* the issue — e.g. an unlabelled `<input type=checkbox>` needs to be considered together with a nearby `<label>` sibling that may be wrapped in one or more `<div>`s. `parentHtml` gives the LLM a broader-context snippet in a single string.

## Design

- **Shape**: single string, the outerHTML of the Nth ancestor. Since outerHTML already includes children, one string is enough to convey e.g. `<div><label>…</label><input …></div>`.
- **Default**: `depth = 0` (feature off). Scan output is byte-identical to today unless explicitly enabled.
- **Env vars**: `OOBEE_PARENT_HTML_DEPTH`, `OOBEE_PARENT_HTML_MAX_BYTES` (falls back to `htmlMaxBytes` / 1024).
- **`init()` params**: `parentHtmlDepth?: number`, `parentHtmlMaxBytes?: number` (mirrors the existing `htmlMaxBytes?: number` optional pattern). When either is provided, the corresponding env var is set for the scan.
- **Bailout**: walk stops and omits `parentHtml` if any step lands on `<html>` or `null`. Matches "if it's already reporting the top parent, just return today's behaviour."
- **Truncation**: reuses the existing `truncateHtml` helper with a dedicated `parentHtmlMaxBytes` budget.
- **Attached only on violations + incomplete**, not `passes` (would inflate JSON with data no consumer reads).

## Files changed

- `src/mergeAxeResults/types.ts` — added optional `parentHtml?: string` to `ItemsInfo` and `HtmlGroupItem`.
- `src/npmIndex.ts` — `getOobeeFunctionsScript(_, _, parentHtmlDepth)`, `runA11yScan` walks parents for violations + incomplete + the custom `oobee-accessible-label` builder, `init()` accepts `parentHtmlDepth` / `parentHtmlMaxBytes` and wires them to env vars.
- `src/crawlers/commonCrawlerFunc.ts` — mirrors the same walk inside the crawler's own `page.evaluate`; `filterAxeResults` → `addTo` sanitises + truncates `parentHtml` before emitting.

Both injection sites share the same ~10-line `computeParentHtml` helper, inlined in both places (one is a template-string function body, the other a `page.evaluate` closure — inlining beats an awkward abstraction).

## Follow-ups (deliberately out of scope)

1. **Orchestrator API** — will add `parent_html: z.string().optional()` to `InputIssue` and forward it in `simplifyFixRequest`. Until then the field is stripped silently by zod (same fate as `dom_element` today).
2. **AI pipeline** — will accept `parent_html` in `WCAGFixInput` and inject it as sibling-context in the LLM prompt.

## Test plan

- [x] `tsc --noEmit` — passes (no new type errors).
- [x] Throwaway Playwright verification script (deleted) — 20/20 assertions across:
  - Fixture A (`<div class=field><label>Accept</label><input type=checkbox></div>`) at depths 0/1/2: parentHtml present with correct content at depths 1 & 2; absent at depth 0.
  - Fixture B (`<input type=checkbox>` directly in `<body>`) at depths 1 & 2: no crash; depth=2 correctly bails when walk hits `<html>`.
  - Fixture C (depth=99, walk past root): no crash, no parentHtml emitted.
  - Static check on generated script at depth=0: bakes `window.parentHtmlDepth=0` and guards the walk with `> 0` so `document.querySelector` is never invoked in the default path.
- [ ] Manual: run `OOBEE_PARENT_HTML_DEPTH=2 npm start -- -u file:///path/to/checkbox-fixture.html`, inspect `results/<token>/reports/scanItems.json`, confirm items carry `parentHtml`.
- [ ] Manual: same scan with no env var set — diff `scanItems.json` against pre-change output. Expect byte-identical result.
- [ ] Manual: `OOBEE_PARENT_HTML_DEPTH=3 OOBEE_PARENT_HTML_MAX_BYTES=100` — confirm truncation `…` suffix appears.

## Companion PR

Paired with the devsuite VS Code extension change that threads `parent_html` into the orchestrator request payload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)