### PR TITLE
fix: isolate custom flow crawlee storage

### DIFF
--- a/src/crawlers/runCustom.ts
+++ b/src/crawlers/runCustom.ts
@@ -1,4 +1,5 @@
 /* eslint-env browser */
+import { Configuration } from 'crawlee';
 import { createCrawleeSubFolders, splitAuthHeaders, addAuthRouteHandler } from './commonCrawlerFunc.js';
 import { cleanUpAndExit, getStoragePath, register, registerSoftClose } from '../utils.js';
 import constants, {
@@ -76,8 +77,14 @@ const runCustom = async (
   hooks?: RunCustomHooks,
   maxPagesToScan?: number,
 ) => {
-  // checks and delete datasets path if it already exists
-  process.env.CRAWLEE_STORAGE_DIR = getStoragePath(randomToken);
+  // Crawlee keeps the storage client/manager on a process-global Configuration.
+  // Programmatic callers such as the VS Code extension run multiple scans in the
+  // same Node process, so force each scan to open its own result directory.
+  const storagePath = getStoragePath(randomToken);
+  const crawleeConfig = Configuration.getGlobalConfig();
+  process.env.CRAWLEE_STORAGE_DIR = storagePath;
+  crawleeConfig.set('storageClientOptions', { localDataDirectory: storagePath });
+  crawleeConfig.storageManagers.clear();
 
   const urlsCrawled = new UrlsCrawled();
   const { dataset } = await createCrawleeSubFolders(randomToken);


### PR DESCRIPTION
This fixes repeated scanCustomFlow runs when Oobee is used inside a long-lived process, such as the VS Code extension.

Previously, each scan only updated:
```
process.env.CRAWLEE_STORAGE_DIR = getStoragePath(randomToken);
```

This works for CLI usage because the Node process exits after one scan. In the VS Code extension, the same process stays alive across multiple scans, so Crawlee can keep its storage state cached from the previous scan.

This caused the second headed scan to reuse scan 1’s storage, which could result in empty/stale scan artifacts and show “No Accessibility issues found”.

The fix adds:
```
crawleeConfig.set("storageClientOptions", { localDataDirectory: storagePath });
crawleeConfig.storageManagers.clear();
```

storageClientOptions
= tells Crawlee the new scan folder to use

storageManagers.clear()
= makes Dataset.open / RequestQueue.open create fresh managers instead of reusing scan 1