### PR TITLE
Update UI for dev suite headed scan and parsed kwargs for scan custom flow

### DIFF
--- a/src/crawlers/custom/utils.ts
+++ b/src/crawlers/custom/utils.ts
@@ -8,6 +8,7 @@ import { capturePageData } from '../pageCapture.js';
 import { consoleLogger, guiInfoLog, silentLogger } from '../../logs.js';
 import { guiInfoStatusTypes, STATUS_CODE_METADATA } from '../../constants/constants.js';
 import { isSkippedUrl, validateCustomFlowLabel } from '../../constants/common.js';
+import type { CustomFlowOverlayScope } from '../../types/scanCustomFlow.js';
 
 declare global {
   interface Window {
@@ -22,8 +23,6 @@ declare global {
     updateMenuPos?: (pos: 'LEFT' | 'RIGHT') => void;
   }
 }
-
-type OverlayScope = 'all' | 'same-domain' | 'same-origin';
 
 const sameRegistrableDomain = (hostA: string, hostB: string) => {
   const domainA = getDomain(hostA);
@@ -42,19 +41,29 @@ const parseBoolEnv = (val: string | undefined, defaultVal: boolean) => {
   return defaultVal;
 };
 
-const parseOverlayScopeEnv = (val: string | undefined): OverlayScope | undefined => {
+const parseOverlayScope = (val: unknown): CustomFlowOverlayScope | undefined => {
   const v = String(val || '').trim().toLowerCase();
   return v === 'all' || v === 'same-domain' || v === 'same-origin' ? v : undefined;
 };
 
-const RESTRICT_OVERLAY_TO_ENTRY_DOMAIN = parseBoolEnv(
-  process.env.RESTRICT_OVERLAY_TO_ENTRY_DOMAIN,
-  false,
-);
-const OOBEE_OVERLAY_SCOPE: OverlayScope = parseOverlayScopeEnv(process.env.OOBEE_OVERLAY_SCOPE)
-  ?? (RESTRICT_OVERLAY_TO_ENTRY_DOMAIN ? 'same-domain' : 'all');
-const USE_EXTENSION_OVERLAY_UI = parseBoolEnv(process.env.DEV_SUITE_EXTENSION_OVERLAY_UI, false);
-const EXTENSION_SESSION_ORIGIN = process.env.OOBEE_EXTENSION_SESSION_ORIGIN || 'VS Code - Oobee Dev Suite extension';
+const getOverlayScope = (scope?: CustomFlowOverlayScope): CustomFlowOverlayScope => {
+  const restrictOverlayToEntryDomain = parseBoolEnv(
+    process.env.RESTRICT_OVERLAY_TO_ENTRY_DOMAIN,
+    false,
+  );
+
+  return parseOverlayScope(scope)
+    ?? parseOverlayScope(process.env.OOBEE_OVERLAY_SCOPE)
+    ?? (restrictOverlayToEntryDomain ? 'same-domain' : 'all');
+};
+
+const getUseExtensionOverlayUi = (useExtensionOverlayUi?: boolean): boolean =>
+  typeof useExtensionOverlayUi === 'boolean'
+    ? useExtensionOverlayUi
+    : parseBoolEnv(process.env.DEV_SUITE_EXTENSION_OVERLAY_UI, false);
+
+const getExtensionSessionOrigin = (extensionSessionOrigin?: string): string =>
+  extensionSessionOrigin || process.env.OOBEE_EXTENSION_SESSION_ORIGIN || 'VS Code - Oobee Dev Suite extension';
 const EXTENSION_WIDGET_FONT_FAMILY =
   '"Atkinson Hyperlegible Next", "Atkinson Hyperlegible", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Arial, sans-serif';
 const EXTENSION_VSCODE_ICON_SVG = String.raw`<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -85,7 +94,11 @@ const raceWithTimeout = async <T>(promise: Promise<T>, ms: number, label: string
   }
 };
 
-const isOverlayAllowed = (currentUrl: string, entryUrl: string) => {
+const isOverlayAllowed = (
+  currentUrl: string,
+  entryUrl: string,
+  overlayScope: CustomFlowOverlayScope,
+) => {
   try {
     const cur = new URL(currentUrl);
 
@@ -93,8 +106,8 @@ const isOverlayAllowed = (currentUrl: string, entryUrl: string) => {
 
     const base = new URL(entryUrl);
 
-    if (OOBEE_OVERLAY_SCOPE === 'all') return true;
-    if (OOBEE_OVERLAY_SCOPE === 'same-origin') return cur.origin === base.origin;
+    if (overlayScope === 'all') return true;
+    if (overlayScope === 'same-origin') return cur.origin === base.origin;
 
     return sameRegistrableDomain(cur.hostname, base.hostname);
   } catch {
@@ -1833,8 +1846,8 @@ export const addOverlayMenu = async (
         urlsCrawled,
         opts: {
           ...opts,
-          extensionOverlayUi: USE_EXTENSION_OVERLAY_UI,
-          sessionOrigin: EXTENSION_SESSION_ORIGIN,
+          extensionOverlayUi: getUseExtensionOverlayUi(opts.extensionOverlayUi),
+          sessionOrigin: getExtensionSessionOrigin(opts.sessionOrigin),
           fontFamily: EXTENSION_WIDGET_FONT_FAMILY,
           vscodeIconSvg: EXTENSION_VSCODE_ICON_SVG,
         },
@@ -1948,13 +1961,14 @@ export const initNewPage = async (page, pageClosePromises, processPageParams, pa
         // Re-check staleness after waiting because a newer navigation may have happened meanwhile.
         if (refreshSeq !== overlayRefreshSeq || page.isClosed()) return;
 
-        const allowed = isOverlayAllowed(page.url(), processPageParams.entryUrl);
+        const overlayScope = getOverlayScope(processPageParams.overlayScope);
+        const allowed = isOverlayAllowed(page.url(), processPageParams.entryUrl, overlayScope);
 
         if (!allowed) {
           // Restrictive overlay scopes intentionally hide the overlay once users
           // leave the configured URL boundary, while the default CLI keeps the
           // historical desktop fallback below.
-          if (OOBEE_OVERLAY_SCOPE !== 'all') {
+          if (overlayScope !== 'all') {
             await raceWithTimeout(
               removeOverlayMenu(page),
               OVERLAY_OPERATION_TIMEOUT_MS,
@@ -2000,6 +2014,8 @@ export const initNewPage = async (page, pageClosePromises, processPageParams, pa
               hideStopInput: !!processPageParams.customFlowLabel,
               entryUrl: processPageParams.entryUrl,
               maxPagesToScan: processPageParams.maxPagesToScan,
+              extensionOverlayUi: processPageParams.useExtensionOverlayUi,
+              sessionOrigin: processPageParams.extensionSessionOrigin,
             }),
             OVERLAY_OPERATION_TIMEOUT_MS,
             'addOverlayMenu',
@@ -2064,7 +2080,7 @@ export const initNewPage = async (page, pageClosePromises, processPageParams, pa
   };
 
   const showFinalisingBeforeClose = async () => {
-    if (!USE_EXTENSION_OVERLAY_UI) return;
+    if (!getUseExtensionOverlayUi(processPageParams.useExtensionOverlayUi)) return;
     await page.evaluate(() => {
       const win = window as Window;
       win.oobeeShowFinalising?.();

--- a/src/crawlers/custom/utils.ts
+++ b/src/crawlers/custom/utils.ts
@@ -674,7 +674,7 @@ export const addOverlayMenu = async (
           const topbarScanBtn = makeTopbarButton(
             'oobeeTopbarBtnScan',
             topbarScanIconSvg,
-            'Scan Page',
+            'Scan Page (Ctrl/Cmd+Shift+X)',
             () => { void customWindow.handleOnScanClick?.(); },
             btn => {
               btn.disabled = inProgress || isScanLimitReached;

--- a/src/crawlers/runCustom.ts
+++ b/src/crawlers/runCustom.ts
@@ -18,6 +18,7 @@ import {
   launchPersistentSafeContext,
 } from '../constants/common.js';
 import { BrowserTypes } from '../constants/constants.js';
+import type { CustomFlowOverlayScope } from '../types/scanCustomFlow.js';
 
 // Export of classes
 
@@ -34,6 +35,9 @@ export class ProcessPageParams {
   entryUrl!: string;
   strategy: string;
   maxPagesToScan?: number;
+  overlayScope?: CustomFlowOverlayScope;
+  useExtensionOverlayUi?: boolean;
+  extensionSessionOrigin?: string;
 
   constructor(
     scannedIdx: number,
@@ -76,6 +80,11 @@ const runCustom = async (
   extraHTTPHeaders?: Record<string, string>,
   hooks?: RunCustomHooks,
   maxPagesToScan?: number,
+  overlayOptions?: {
+    overlayScope?: CustomFlowOverlayScope;
+    useExtensionOverlayUi?: boolean;
+    extensionSessionOrigin?: string;
+  },
 ) => {
   // Crawlee keeps the storage client/manager on a process-global Configuration.
   // Programmatic callers such as the VS Code extension run multiple scans in the
@@ -101,6 +110,9 @@ const runCustom = async (
 
   processPageParams.entryUrl = url;
   processPageParams.maxPagesToScan = maxPagesToScan;
+  processPageParams.overlayScope = overlayOptions?.overlayScope;
+  processPageParams.useExtensionOverlayUi = overlayOptions?.useExtensionOverlayUi;
+  processPageParams.extensionSessionOrigin = overlayOptions?.extensionSessionOrigin;
 
   if (initialCustomFlowLabel && initialCustomFlowLabel.trim()) {
     processPageParams.customFlowLabel = initialCustomFlowLabel.trim();

--- a/src/crawlers/scanCustomFlow.ts
+++ b/src/crawlers/scanCustomFlow.ts
@@ -119,6 +119,9 @@ export const scanCustomFlow = (config: ScanCustomFlowConfig): ScanCustomFlowSess
     cleanupArtifacts = true,
     waitForResultSubmission = true,
     maxPagesToScan,
+    overlayScope,
+    useExtensionOverlayUi,
+    extensionSessionOrigin,
   } = config;
 
   const [date, time] = new Date().toLocaleString('sv').replace(/[-:]/g, '').split(' ');
@@ -194,6 +197,11 @@ export const scanCustomFlow = (config: ScanCustomFlowConfig): ScanCustomFlowSess
           },
         },
         maxPagesToScan,
+        {
+          overlayScope,
+          useExtensionOverlayUi,
+          extensionSessionOrigin,
+        },
       );
 
       scanDetails.endTime = new Date();

--- a/src/crawlers/scanCustomFlow.ts
+++ b/src/crawlers/scanCustomFlow.ts
@@ -119,6 +119,7 @@ export const scanCustomFlow = (config: ScanCustomFlowConfig): ScanCustomFlowSess
     cleanupArtifacts = true,
     waitForResultSubmission = true,
     maxPagesToScan,
+    scanSource,
     overlayScope,
     useExtensionOverlayUi,
     extensionSessionOrigin,
@@ -148,6 +149,7 @@ export const scanCustomFlow = (config: ScanCustomFlowConfig): ScanCustomFlowSess
     isSlowScanMode: 1, // Note: Considering refactor this because for applicable for normal scan with concurrent scan only.
     isAdhereRobots: followRobots,
     nameEmail: { name, email },
+    scanSource,
   };
   const viewportSettings: ViewportSettingsClass = {
     deviceChosen,

--- a/src/mergeAxeResults.ts
+++ b/src/mergeAxeResults.ts
@@ -804,6 +804,7 @@ const generateArtifacts = async (
     isSlowScanMode: number;
     isAdhereRobots: boolean;
     nameEmail?: { name: string; email: string };
+    scanSource?: string;
   },
   zip: string = undefined, // optional
   generateJsonFiles = false,
@@ -1144,6 +1145,7 @@ const generateArtifacts = async (
         browser: scanDetails.deviceChosen,
         email: scanDetails.nameEmail?.email,
         name: scanDetails.nameEmail?.name,
+        scanSource: scanDetails.scanSource,
       },
       allIssues,
       pagesScanned.length,

--- a/src/mergeAxeResults/sentryTelemetry.ts
+++ b/src/mergeAxeResults/sentryTelemetry.ts
@@ -26,6 +26,7 @@ const sendWcagBreakdownToSentry = async (
     browser: string;
     email?: string;
     name?: string;
+    scanSource?: string;
   },
   allIssues?: AllIssues,
   pagesScannedCount: number = 0,
@@ -45,6 +46,7 @@ const sendWcagBreakdownToSentry = async (
 
     // Tag app version
     tags.version = appVersion;
+    const scanProduct = scanInfo.scanSource?.trim() || process.env.OOBEE_SCAN_PRODUCT;
 
     // Get dynamic WCAG criteria map once
     const wcagCriteriaMap = await getWcagCriteriaMap();
@@ -141,8 +143,8 @@ const sendWcagBreakdownToSentry = async (
         scanType: scanInfo.scanType,
         browser: scanInfo.browser,
         entryUrl: process.env.OOBEE_SCAN_METADATA ?? scanInfo.entryUrl,
-        ...(process.env.OOBEE_SCAN_PRODUCT && {
-          scanProduct: process.env.OOBEE_SCAN_PRODUCT,
+        ...(scanProduct && {
+          scanProduct,
         }),
         ...(process.env.OOBEE_TAGGED_WEBSITE && {
           websiteTag: process.env.OOBEE_TAGGED_WEBSITE,

--- a/src/npmIndex.ts
+++ b/src/npmIndex.ts
@@ -674,6 +674,7 @@ const processAndSubmitResults = async (
   name: string,
   email: string,
   metadata: string,
+  scanSource?: string,
 ) => {
   const items = Array.isArray(scanData) ? scanData : [scanData];
   const numberOfPagesScanned = items.length;
@@ -798,6 +799,7 @@ const processAndSubmitResults = async (
       browser: 'chromium', // Defaulting since we might scan HTML without browser or implicit browser
       email: email,
       name: name,
+      scanSource,
     },
     undefined,
     numberOfPagesScanned,
@@ -853,6 +855,7 @@ export const scanHTML = async (
     pageTitle?: string; // If array, we will append index
     metadata?: string;
     ruleset?: RuleFlags[];
+    scanSource?: string;
   },
 ) => {
   const {
@@ -862,6 +865,7 @@ export const scanHTML = async (
     pageTitle = 'HTML Content',
     metadata = '',
     ruleset = [RuleFlags.DEFAULT],
+    scanSource,
   } = config;
 
   const enableWcagAaa = ruleset.includes(RuleFlags.ENABLE_WCAG_AAA);
@@ -898,7 +902,7 @@ export const scanHTML = async (
     });
   }
 
-  return processAndSubmitResults(scanData, name, email, metadata);
+  return processAndSubmitResults(scanData, name, email, metadata, scanSource);
 };
 
 export const scanPage = async (
@@ -909,6 +913,7 @@ export const scanPage = async (
     pageTitle?: string;
     metadata?: string;
     ruleset?: RuleFlags[];
+    scanSource?: string;
   },
 ) => {
   const {
@@ -917,6 +922,7 @@ export const scanPage = async (
     pageTitle,
     metadata = '',
     ruleset = [RuleFlags.DEFAULT],
+    scanSource,
   } = config;
 
   const disableOobee = ruleset.includes(RuleFlags.DISABLE_OOBEE);
@@ -967,6 +973,7 @@ export const scanPage = async (
     name,
     email,
     metadata,
+    scanSource,
   );
 };
 

--- a/src/types/scanCustomFlow.ts
+++ b/src/types/scanCustomFlow.ts
@@ -3,6 +3,8 @@ import type { BrowserTypes, RuleFlags } from '../constants/constants.js';
 
 export type UnknownRecord = Record<string, unknown>;
 
+export type CustomFlowOverlayScope = 'all' | 'same-domain' | 'same-origin';
+
 export type ScanItemsPage = UnknownRecord & {
   items?: UnknownRecord[];
   url?: string;
@@ -56,6 +58,9 @@ export type ScanCustomFlowConfig = {
   cleanupArtifacts?: boolean;
   waitForResultSubmission?: boolean;
   maxPagesToScan?: number;
+  overlayScope?: CustomFlowOverlayScope;
+  useExtensionOverlayUi?: boolean;
+  extensionSessionOrigin?: string;
   onReady?: () => void | Promise<void>;
 };
 

--- a/src/types/scanCustomFlow.ts
+++ b/src/types/scanCustomFlow.ts
@@ -58,6 +58,7 @@ export type ScanCustomFlowConfig = {
   cleanupArtifacts?: boolean;
   waitForResultSubmission?: boolean;
   maxPagesToScan?: number;
+  scanSource?: string;
   overlayScope?: CustomFlowOverlayScope;
   useExtensionOverlayUi?: boolean;
   extensionSessionOrigin?: string;


### PR DESCRIPTION
1 Added the text for the Scan Page button for (Ctrl/Cmd+Shift+X) was removed by claude.

2 Did a refactoring by parsed args to scanCustomFlow function which address PR comment in https://github.com/GovTechSG/oobee-dev-suite-vscode-extension/pull/49/changes/BASE..e565176e524e10b33dcf954682fd551ee4a89d75#diff-d0dd1437ccb35e816107e198ad39fcececd207c87ef5c3b5f3646f9e15c3eaad.
- Using `process.env` for this is less ideal because env vars are process-global and can affect other Oobee callers running in the same Node process.
- Passing config directly through `scanCustomFlow` makes the behavior clearer, typed, and easier to review.