### PR TITLE
fix: strip file:// before path.resolve in prepareData

### DIFF
--- a/src/constants/common.ts
+++ b/src/constants/common.ts
@@ -730,6 +730,11 @@ export const prepareData = async (argv: Answers): Promise<Data> => {
     // Set is as local file scan if not already so
     isLocalFileScan = true;
 
+    // path.resolve treats "file:///abs/path" as relative (no leading "/") and joins
+    // it with cwd, producing "<cwd>/file:/abs/path". Strip the file:// wrapper
+    // first so we resolve a real path.
+    url = convertLocalFileToPath(url);
+
     // Convert to absolute path
     url = path.resolve(url);
 


### PR DESCRIPTION
## Summary
- `path.resolve('file:///abs/path')` treats the URL as a *relative* path (no leading `/`) and joins it with cwd, producing `<cwd>/file:/abs/path`. `checkUrlConnectivityWithBrowser` then wraps that mangled path back into a `file://` URL, and the eventual `fs.statSync(fileURLToPath(...))` fails with `ENOENT` on the broken path.
- Strip the `file://` wrapper via `convertLocalFileToPath` before `path.resolve`, mirroring what call sites at [common.ts:931](https://github.com/GovTechSG/oobee/blob/master/src/constants/common.ts#L931) and [common.ts:1028](https://github.com/GovTechSG/oobee/blob/master/src/constants/common.ts#L1028) already do.

## Repro
Passing a `file:///` URL via `-c localfile -u file:///Users/.../report.html` fails with:
```
Local file check failed: ENOENT: no such file or directory, stat '<cwd>/file:/Users/.../report.html'
```

## Safety
Only affects the `file://` URL branch. `convertLocalFileToPath` is a no-op for plain relative (`./sitemap.xml`) and absolute (`/Users/...`) paths, so their behavior is unchanged — `path.resolve` still handles them exactly as before.

## Test plan
- [ ] `-c localfile -u file:///abs/path/to/file.html` — passes URL check, scan proceeds
- [ ] `-c localfile -u ./sitemap.xml` — unchanged, resolves to `<cwd>/sitemap.xml`
- [ ] `-c localfile -u /abs/path/to/file.html` — unchanged, resolves as absolute
- [ ] `-c sitemap -u ./sitemap.xml` — unchanged
- [ ] `-c website -u https://example.com` — unchanged (else-branch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)