### PR TITLE
ci: migrate npm publish to OIDC trusted publishing, add unpublish action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,7 +31,7 @@ jobs:
           npm install -g npm@latest
           npm --version
 
-      - run: npm ci
+      - run: npm ci --allow-git=root
         continue-on-error: false
 
       - run: npm run build

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,6 +26,11 @@ jobs:
           node-version: '22.x'
           registry-url: 'https://registry.npmjs.org'
 
+      - name: Upgrade npm (trusted publishing needs >= 11.5.1)
+        run: |
+          npm install -g npm@latest
+          npm --version
+
       - run: npm ci
         continue-on-error: false
 
@@ -46,4 +51,4 @@ jobs:
           git tag -af "latest" -m "Latest release ${VERSION}"
           git push origin "latest" --force
 
-      - run: npm publish --access public --provenance
+      - run: npm publish --access public --provenance --loglevel=verbose

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,10 +18,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: ${{ inputs.release_tag }}
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: '22.x'
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,13 +1,30 @@
-name: Publish Package to npmjs
+name: npm publish / unpublish / deprecate
 on:
   workflow_dispatch:
     inputs:
-      release_tag:
-        description: 'Git ref to publish — a tag (e.g. 0.11.4), branch (e.g. feat/foo), or commit SHA. The commit at this ref will be built and published; its package.json version is what lands on npm.'
+      action:
+        description: 'Which npm operation to run.'
         required: true
+        type: choice
+        options:
+          - publish
+          - unpublish
+          - deprecate
+        default: publish
+      release_tag:
+        description: '[publish] Git ref to publish — tag (e.g. 0.11.4), branch, or commit SHA. The commit at this ref is built and published; its package.json version lands on npm.'
+        required: false
+        type: string
+      version:
+        description: '[unpublish/deprecate] npm version to target (e.g. 0.11.13).'
+        required: false
+        type: string
+      deprecation_message:
+        description: '[deprecate] Message shown to installers of this version. Leave blank to un-deprecate a previously deprecated version.'
+        required: false
         type: string
       skip_git_tag:
-        description: 'Skip creating and force-pushing the {version} and "latest" git tags after publish. Use when publishing from a branch or pre-release where moving tags is not desired.'
+        description: '[publish] Skip creating and force-pushing the {version} and "latest" git tags after publish.'
         required: false
         type: boolean
         default: false
@@ -15,7 +32,8 @@ permissions:
   contents: write
   id-token: write
 jobs:
-  build:
+  publish:
+    if: ${{ inputs.action == 'publish' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -52,3 +70,56 @@ jobs:
           git push origin "latest" --force
 
       - run: npm publish --access public --provenance
+
+  unpublish:
+    if: ${{ inputs.action == 'unpublish' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate inputs
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          if [ -z "${VERSION}" ]; then
+            echo "::error::'version' input is required for the unpublish action"
+            exit 1
+          fi
+
+      - uses: actions/setup-node@v5
+        with:
+          node-version: '22.x'
+          registry-url: 'https://registry.npmjs.org'
+
+      - run: npm install -g npm@latest
+
+      - name: Unpublish @govtechsg/oobee@${{ inputs.version }}
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          VERSION: ${{ inputs.version }}
+        run: npm unpublish "@govtechsg/oobee@${VERSION}"
+
+  deprecate:
+    if: ${{ inputs.action == 'deprecate' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate inputs
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          if [ -z "${VERSION}" ]; then
+            echo "::error::'version' input is required for the deprecate action"
+            exit 1
+          fi
+
+      - uses: actions/setup-node@v5
+        with:
+          node-version: '22.x'
+          registry-url: 'https://registry.npmjs.org'
+
+      - run: npm install -g npm@latest
+
+      - name: Deprecate @govtechsg/oobee@${{ inputs.version }}
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          VERSION: ${{ inputs.version }}
+          MESSAGE: ${{ inputs.deprecation_message }}
+        run: npm deprecate "@govtechsg/oobee@${VERSION}" "${MESSAGE}"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,15 +13,15 @@ on:
         default: false
 permissions:
   contents: write
+  id-token: write
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.release_tag }}
-      # Setup .npmrc file to publish to npm
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: '22.x'
           registry-url: 'https://registry.npmjs.org'
@@ -46,14 +46,4 @@ jobs:
           git tag -af "latest" -m "Latest release ${VERSION}"
           git push origin "latest" --force
 
-      - name: Diagnose npm auth
-        run: |
-          npm whoami || true
-          npm access list packages @govtechsg || true
-          npm view @govtechsg/oobee versions --json || true
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
-      - run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - run: npm publish --access public --provenance

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -51,4 +51,4 @@ jobs:
           git tag -af "latest" -m "Latest release ${VERSION}"
           git push origin "latest" --force
 
-      - run: npm publish --access public --provenance --loglevel=verbose
+      - run: npm publish --access public --provenance

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -46,6 +46,14 @@ jobs:
           git tag -af "latest" -m "Latest release ${VERSION}"
           git push origin "latest" --force
 
+      - name: Diagnose npm auth
+        run: |
+          npm whoami || true
+          npm access list packages @govtechsg || true
+          npm view @govtechsg/oobee versions --json || true
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
       - run: npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,4 @@
-name: npm publish / unpublish / deprecate
+name: npm publish / unpublish
 on:
   workflow_dispatch:
     inputs:
@@ -9,18 +9,13 @@ on:
         options:
           - publish
           - unpublish
-          - deprecate
         default: publish
       release_tag:
         description: '[publish] Git ref to publish — tag (e.g. 0.11.4), branch, or commit SHA. The commit at this ref is built and published; its package.json version lands on npm.'
         required: false
         type: string
       version:
-        description: '[unpublish/deprecate] npm version to target (e.g. 0.11.13).'
-        required: false
-        type: string
-      deprecation_message:
-        description: '[deprecate] Message shown to installers of this version. Leave blank to un-deprecate a previously deprecated version.'
+        description: '[unpublish] npm version to target (e.g. 0.11.13).'
         required: false
         type: string
       skip_git_tag:
@@ -96,30 +91,3 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           VERSION: ${{ inputs.version }}
         run: npm unpublish "@govtechsg/oobee@${VERSION}"
-
-  deprecate:
-    if: ${{ inputs.action == 'deprecate' }}
-    runs-on: ubuntu-latest
-    steps:
-      - name: Validate inputs
-        env:
-          VERSION: ${{ inputs.version }}
-        run: |
-          if [ -z "${VERSION}" ]; then
-            echo "::error::'version' input is required for the deprecate action"
-            exit 1
-          fi
-
-      - uses: actions/setup-node@v5
-        with:
-          node-version: '22.x'
-          registry-url: 'https://registry.npmjs.org'
-
-      - run: npm install -g npm@latest
-
-      - name: Deprecate @govtechsg/oobee@${{ inputs.version }}
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-          VERSION: ${{ inputs.version }}
-          MESSAGE: ${{ inputs.deprecation_message }}
-        run: npm deprecate "@govtechsg/oobee@${VERSION}" "${MESSAGE}"


### PR DESCRIPTION
## Summary

Publishing `@govtechsg/oobee` to npm from GitHub Actions started failing with 404s because npm is winding down GAT bypass-2FA tokens (see [changelog 2026-07-08](https://github.blog/changelog/2026-07-08-npm-install-time-security-and-gat-bypass2fa-deprecation/)) — sensitive actions were blocked in August 2026 and direct publish is scheduled to be removed by January 2027. This PR migrates publish to OIDC trusted publishing, picks up the other npm v12 / Node-runner changes needed to keep publish green, and extends the same workflow with a `workflow_dispatch` `unpublish` action.

### Publish (OIDC trusted publishing)
- Switch `npm publish` to OIDC trusted publishing (`id-token: write`, no `NODE_AUTH_TOKEN`, `--provenance` for supply-chain attestation).
- Upgrade npm to `latest` on the runner — trusted publishing needs npm ≥ 11.5.1 and Node 22 still ships npm 10.x.
- Pass `--allow-git=root` to `npm ci` — npm v12 defaults `allow-git` to `none`, and `pdfjs-dist` is pinned to a veraPDF git ref in `package.json`.
- Bump `actions/checkout` and `actions/setup-node` to `@v5` to clear the Node 20 runner deprecation banner.

### Unpublish (NPM_TOKEN)
- New `action` choice input on `workflow_dispatch`: `publish` (default) or `unpublish`.
- `version` input names the npm version to unpublish (e.g. `0.11.13`).
- OIDC trusted publishing only mints publish-scoped tokens, so the `unpublish` job still uses the `NPM_TOKEN` repository secret.
- Constraints: `npm unpublish` only works within 72 h of publish and only if nothing depends on the version.

### Deprecate — intentionally not automated
Deprecate was prototyped and works via `npm deprecate`, but the current `NPM_TOKEN` (bypass-2FA GAT) 404s because npm now blocks manifest-mutating PUTs from bypass-2FA tokens. Rather than keep a Classic Automation token around just for this rare operation, we run deprecate manually from a maintainer's laptop with an interactive login when needed.

## One-time setup already done on npmjs.com

Trusted Publisher configured on `@govtechsg/oobee`:
- Publisher: GitHub Actions
- Org / repo: `GovTechSG` / `oobee`
- Workflow filename: `publish.yml`
- Environment: *(blank)*

## Test plan
- [x] Dispatched `publish` from this branch and successfully published `@govtechsg/oobee@0.11.13` to npm with a signed provenance statement (log index [2525631138](https://search.sigstore.dev/?logIndex=2525631138))
- [x] Dispatched `unpublish` from this branch and successfully unpublished a targeted version
- [ ] After merge, dispatch `publish` once from `master` to confirm the same works from the default branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)