### PR TITLE
fix(crawler): prevent hostile-site hangs and corrupted results.zip

### DIFF
--- a/src/combine.ts
+++ b/src/combine.ts
@@ -174,12 +174,20 @@ const combineRun = async (details: Data, deviceToScan: string) => {
 
   // Hard cap via OOBEE_MAX_SCAN_MINUTES (env). If set, clamp scanDuration so
   // hostile sites cannot keep the crawler alive past this wall-clock ceiling.
-  // Uses seconds internally to match the existing scanDuration contract.
+  // Uses seconds internally to match the existing scanDuration contract
+  // (scanDuration === 0 means "no limit", any positive value is seconds).
   const envMaxScanMinutes = Number(process.env.OOBEE_MAX_SCAN_MINUTES);
+  // Convert env var to seconds, but only if it parses to a positive finite
+  // number. Anything else (NaN, 0, negative, "off") means "no env cap" and we
+  // fall back to whatever the caller passed in.
   const envMaxScanSeconds =
     Number.isFinite(envMaxScanMinutes) && envMaxScanMinutes > 0 ? envMaxScanMinutes * 60 : 0;
+  // Start with the caller's scanDuration (or 0 if unset). Everything below
+  // only tightens this — the env cap can shorten a run but never lengthen it.
   let effectiveScanDuration = scanDuration || 0;
   if (envMaxScanSeconds > 0) {
+    // Two cases: caller provided a duration (take the tighter of the two) or
+    // caller passed 0/unset (env cap becomes the ceiling).
     effectiveScanDuration =
       effectiveScanDuration > 0
         ? Math.min(effectiveScanDuration, envMaxScanSeconds)

--- a/src/combine.ts
+++ b/src/combine.ts
@@ -19,6 +19,7 @@ import {
   uploadFolderToS3,
 } from './services/s3Uploader.js';
 import { writeManifest, resetCaptureEntries, isPageCaptureEnabled } from './crawlers/pageCapture.js';
+import { initShutdownHandler } from './shutdownController.js';
 
 // Class exports
 export class ViewportSettingsClass {
@@ -115,6 +116,11 @@ const combineRun = async (details: Data, deviceToScan: string) => {
   };
   process.on('uncaughtException', psTreeHandler);
 
+  // Install SIGTERM/SIGINT handler so container timeouts (GitHub Actions job
+  // timeout, `docker stop`) abort the crawler cleanly and let finalization
+  // (writeManifest → generateArtifacts → S3 upload) run before SIGKILL.
+  initShutdownHandler();
+
   const host = type === ScannerTypes.SITEMAP || type === ScannerTypes.LOCALFILE ? '' : getHost(url);
 
   let blacklistedPatterns: string[] | null = null;
@@ -166,6 +172,23 @@ const combineRun = async (details: Data, deviceToScan: string) => {
   let uiCustomFlowLabel: string | undefined;
   let durationExceeded = false;
 
+  // Hard cap via OOBEE_MAX_SCAN_MINUTES (env). If set, clamp scanDuration so
+  // hostile sites cannot keep the crawler alive past this wall-clock ceiling.
+  // Uses seconds internally to match the existing scanDuration contract.
+  const envMaxScanMinutes = Number(process.env.OOBEE_MAX_SCAN_MINUTES);
+  const envMaxScanSeconds =
+    Number.isFinite(envMaxScanMinutes) && envMaxScanMinutes > 0 ? envMaxScanMinutes * 60 : 0;
+  let effectiveScanDuration = scanDuration || 0;
+  if (envMaxScanSeconds > 0) {
+    effectiveScanDuration =
+      effectiveScanDuration > 0
+        ? Math.min(effectiveScanDuration, envMaxScanSeconds)
+        : envMaxScanSeconds;
+    consoleLogger.info(
+      `OOBEE_MAX_SCAN_MINUTES=${envMaxScanMinutes} → effective scan duration ${effectiveScanDuration}s (user-provided: ${scanDuration || 0}s).`,
+    );
+  }
+
   switch (type) {
     case ScannerTypes.CUSTOM:
       const res = await runCustom(
@@ -200,7 +223,7 @@ const combineRun = async (details: Data, deviceToScan: string) => {
         extraHTTPHeaders,
         strategy,
         userUrl: url,
-        scanDuration,
+        scanDuration: effectiveScanDuration,
         ruleset,
       });
       urlsCrawledObj = sitemapResult.urlsCrawled;
@@ -221,7 +244,7 @@ const combineRun = async (details: Data, deviceToScan: string) => {
         blacklistedPatterns,
         includeScreenshots,
         extraHTTPHeaders,
-        scanDuration,
+        scanDuration: effectiveScanDuration,
         ruleset,
       });
       if (localFileResult) {
@@ -251,7 +274,7 @@ const combineRun = async (details: Data, deviceToScan: string) => {
         followRobots,
         extraHTTPHeaders,
         safeMode,
-        scanDuration,
+        effectiveScanDuration,
         ruleset,
       );
       urlsCrawledObj = intelligentResult.urlsCrawled;
@@ -274,7 +297,7 @@ const combineRun = async (details: Data, deviceToScan: string) => {
         includeScreenshots,
         followRobots,
         extraHTTPHeaders,
-        scanDuration,
+        scanDuration: effectiveScanDuration,
         safeMode,
         ruleset,
       });

--- a/src/crawlers/crawlDomain.ts
+++ b/src/crawlers/crawlDomain.ts
@@ -42,6 +42,7 @@ import {
 import { consoleLogger, guiInfoLog } from '../logs.js';
 import { ViewportSettingsClass } from '../combine.js';
 import { capturePageData } from './pageCapture.js';
+import { registerCrawler, unregisterCrawler, isShutdownRequested } from '../shutdownController.js';
 
 const isBlacklisted = (url: string, blacklistedPatterns: string[]) => {
   if (!blacklistedPatterns) {
@@ -929,10 +930,7 @@ const crawlDomain = async ({
         }
 
         const timeSinceLastSuccess = Date.now() - lastSuccessTime;
-        if (
-          urlsCrawled.scanned.length > 0 &&
-          timeSinceLastSuccess > maxIdleMs
-        ) {
+        if (timeSinceLastSuccess > maxIdleMs) {
           consoleLogger.info(
             `Aborting crawl: no successful scan in ${Math.round(timeSinceLastSuccess / 1000)}s. Generating partial report with ${urlsCrawled.scanned.length} pages.`,
           );
@@ -992,9 +990,13 @@ const crawlDomain = async ({
     }),
   );
 
+  // Reset the idle timer right before crawler.run() so that pre-crawl setup
+  // (browser pool warmup, robots.txt fetch, etc.) doesn't count against the
+  // idle window.
+  lastSuccessTime = Date.now();
   const idleCheckInterval = setInterval(() => {
     const timeSinceLastSuccess = Date.now() - lastSuccessTime;
-    if (urlsCrawled.scanned.length > 0 && timeSinceLastSuccess > maxIdleMs) {
+    if (timeSinceLastSuccess > maxIdleMs) {
       consoleLogger.info(
         `Aborting crawl: no successful scan in ${Math.round(timeSinceLastSuccess / 1000)}s. Generating partial report with ${urlsCrawled.scanned.length} pages.`,
       );
@@ -1003,8 +1005,16 @@ const crawlDomain = async ({
     }
   }, 30_000);
 
-  await crawler.run();
-  clearInterval(idleCheckInterval);
+  registerCrawler(crawler);
+  try {
+    await crawler.run();
+  } finally {
+    unregisterCrawler(crawler);
+    clearInterval(idleCheckInterval);
+  }
+  if (isShutdownRequested()) {
+    isAbortingScanNow = true;
+  }
 
   // Additional passes: keep re-visiting scanned seed-hostname pages for
   // click-discovery until no new pages are found or limits are reached.
@@ -1060,7 +1070,7 @@ const crawlDomain = async ({
       lastSuccessTime = Date.now();
       const clickPassIdleCheck = setInterval(() => {
         const timeSinceLastSuccess = Date.now() - lastSuccessTime;
-        if (urlsCrawled.scanned.length > 0 && timeSinceLastSuccess > maxIdleMs) {
+        if (timeSinceLastSuccess > maxIdleMs) {
           consoleLogger.info(
             `Aborting crawl: no successful scan in ${Math.round(timeSinceLastSuccess / 1000)}s. Generating partial report with ${urlsCrawled.scanned.length} pages.`,
           );
@@ -1068,8 +1078,17 @@ const crawlDomain = async ({
           crawler.autoscaledPool?.abort();
         }
       }, 30_000);
-      await crawler.run();
-      clearInterval(clickPassIdleCheck);
+      registerCrawler(crawler);
+      try {
+        await crawler.run();
+      } finally {
+        unregisterCrawler(crawler);
+        clearInterval(clickPassIdleCheck);
+      }
+      if (isShutdownRequested()) {
+        isAbortingScanNow = true;
+        break;
+      }
 
       // Stop looping if no new pages were discovered in this pass
     } while (urlsCrawled.scanned.length > prevScannedCount);

--- a/src/crawlers/crawlDomain.ts
+++ b/src/crawlers/crawlDomain.ts
@@ -1005,13 +1005,23 @@ const crawlDomain = async ({
     }
   }, 30_000);
 
+  // Publish the crawler to the shutdown controller so a SIGTERM/SIGINT that
+  // arrives during crawler.run() can abort the autoscaledPool. Without this,
+  // the container's SIGKILL lands mid-write and produces a corrupted results.zip.
   registerCrawler(crawler);
   try {
     await crawler.run();
   } finally {
+    // Always unregister and clear the idle watchdog, even if crawler.run()
+    // threw — otherwise the click-pass loop below could inherit a stale
+    // reference or the interval could keep firing after the crawler exited.
     unregisterCrawler(crawler);
     clearInterval(idleCheckInterval);
   }
+  // If we got here because of SIGTERM/SIGINT (not a natural finish), route
+  // into the same partial-report finalization path that idle-abort and
+  // duration-cap use. The `!isAbortingScanNow` guard on the click-pass loop
+  // below then skips the extra passes.
   if (isShutdownRequested()) {
     isAbortingScanNow = true;
   }
@@ -1078,6 +1088,9 @@ const crawlDomain = async ({
           crawler.autoscaledPool?.abort();
         }
       }, 30_000);
+      // Same register/unregister pattern as the initial run — each click-pass
+      // iteration reuses the crawler instance and re-publishes it so a signal
+      // during this pass can still abort the pool cleanly.
       registerCrawler(crawler);
       try {
         await crawler.run();
@@ -1085,6 +1098,10 @@ const crawlDomain = async ({
         unregisterCrawler(crawler);
         clearInterval(clickPassIdleCheck);
       }
+      // Break out of the do/while explicitly on shutdown. Without the break,
+      // the loop condition (`urlsCrawled.scanned.length > prevScannedCount`)
+      // might still be true after a signal-triggered abort, and we'd start
+      // another pass instead of proceeding to finalization.
       if (isShutdownRequested()) {
         isAbortingScanNow = true;
         break;

--- a/src/crawlers/crawlRateController.ts
+++ b/src/crawlers/crawlRateController.ts
@@ -5,7 +5,14 @@ export class CrawlRateController {
   private readonly maxPages: number;
   private consecutiveFailures = 0;
   private successesSinceReduction = 0;
+  // Counts how many times concurrency has been halved without ever recovering
+  // back to the original ceiling in between. Resets only when concurrency
+  // returns to originalMaxConcurrency. Bounds the ratchet-recovery-ratchet
+  // cycle that would otherwise let a permanently hostile site keep the scan
+  // alive indefinitely at low concurrency.
+  private ratchetCycles = 0;
   private readonly maxConsecutiveFailures: number;
+  private readonly maxRatchetCycles: number;
   private readonly originalMaxConcurrency: number;
   private static readonly RECOVERY_INTERVAL = 10;
   private static readonly RECOVERY_STEP = 2;
@@ -13,6 +20,7 @@ export class CrawlRateController {
   constructor(maxRequestsPerCrawl: number, maxConcurrency: number) {
     this.maxPages = maxRequestsPerCrawl;
     this.maxConsecutiveFailures = Number(process.env.OOBEE_CONSECUTIVE_MAX_RETRIES) || 100;
+    this.maxRatchetCycles = Number(process.env.OOBEE_MAX_RATCHET_CYCLES) || 5;
     this.originalMaxConcurrency = maxConcurrency;
   }
 
@@ -28,6 +36,8 @@ export class CrawlRateController {
     this.consecutiveFailures = 0;
 
     if (!pool || pool.maxConcurrency >= this.originalMaxConcurrency) {
+      // Full recovery — clear the ratchet counter so the site gets a clean slate.
+      this.ratchetCycles = 0;
       return;
     }
 
@@ -39,6 +49,10 @@ export class CrawlRateController {
       );
       this.successesSinceReduction = 0;
       consoleLogger.info(`Recovering concurrency to ${pool.maxConcurrency}`);
+
+      if (pool.maxConcurrency >= this.originalMaxConcurrency) {
+        this.ratchetCycles = 0;
+      }
     }
   }
 
@@ -58,12 +72,20 @@ export class CrawlRateController {
     ) {
       pool.maxConcurrency = Math.max(1, Math.floor(pool.maxConcurrency / 2));
       this.successesSinceReduction = 0;
+      this.ratchetCycles++;
       consoleLogger.info(
-        `Rate limited (HTTP ${httpStatus}) — reducing concurrency to ${pool.maxConcurrency}`,
+        `Rate limited (HTTP ${httpStatus}) — reducing concurrency to ${pool.maxConcurrency} (ratchet cycle ${this.ratchetCycles}/${this.maxRatchetCycles})`,
       );
     }
 
     if (this.consecutiveFailures >= this.maxConsecutiveFailures) {
+      return true;
+    }
+
+    if (this.ratchetCycles >= this.maxRatchetCycles) {
+      consoleLogger.info(
+        `Concurrency has been reduced ${this.ratchetCycles} times without recovering to ${this.originalMaxConcurrency} — treating site as permanently hostile.`,
+      );
       return true;
     }
 

--- a/src/crawlers/crawlRateController.ts
+++ b/src/crawlers/crawlRateController.ts
@@ -33,14 +33,22 @@ export class CrawlRateController {
   }
 
   onSuccess(pool?: { maxConcurrency: number }): void {
+    // Any success breaks a streak of failures, regardless of whether we're
+    // running at reduced concurrency or not.
     this.consecutiveFailures = 0;
 
+    // Two "already recovered" cases: caller didn't pass a pool (nothing to
+    // recover), or the pool is already at (or above) the original ceiling.
+    // In both, we're not in a reduced state, so clear the ratchet counter
+    // to give the site a clean slate for the next hostile burst.
     if (!pool || pool.maxConcurrency >= this.originalMaxConcurrency) {
-      // Full recovery — clear the ratchet counter so the site gets a clean slate.
       this.ratchetCycles = 0;
       return;
     }
 
+    // Concurrency is currently below original — we're partially recovering.
+    // Count successes; every RECOVERY_INTERVAL of them earns +RECOVERY_STEP
+    // back on the pool's maxConcurrency, capped at the original ceiling.
     this.successesSinceReduction++;
     if (this.successesSinceReduction >= CrawlRateController.RECOVERY_INTERVAL) {
       pool.maxConcurrency = Math.min(
@@ -50,6 +58,12 @@ export class CrawlRateController {
       this.successesSinceReduction = 0;
       consoleLogger.info(`Recovering concurrency to ${pool.maxConcurrency}`);
 
+      // Only a *full* recovery back to the original ceiling clears the ratchet.
+      // Partial recovery (e.g. 2→4 when original was 10) keeps the counter so
+      // a site that halves-recovers-halves indefinitely still hits the abort
+      // threshold. This is the whole point of ratchetCycles — without it, the
+      // recovery mechanism would let a permanently hostile site keep the
+      // crawler alive at reduced concurrency forever.
       if (pool.maxConcurrency >= this.originalMaxConcurrency) {
         this.ratchetCycles = 0;
       }
@@ -61,8 +75,14 @@ export class CrawlRateController {
     pool?: { maxConcurrency: number },
     options?: { skipConcurrencyReduction?: boolean },
   ): boolean {
+    // Every failure adds to the consecutive streak; a single success resets it
+    // (see onSuccess). This is the coarser of two abort triggers — it catches
+    // outright dead sites where nothing ever works.
     this.consecutiveFailures++;
 
+    // Halve concurrency on 4xx/5xx, but only when the caller hasn't opted out
+    // and we're not already at the floor. Halving at 1 would be a no-op and
+    // would burn a ratchet cycle for nothing.
     if (
       !options?.skipConcurrencyReduction &&
       typeof httpStatus === 'number' &&
@@ -71,17 +91,26 @@ export class CrawlRateController {
       pool.maxConcurrency > 1
     ) {
       pool.maxConcurrency = Math.max(1, Math.floor(pool.maxConcurrency / 2));
+      // Reset the recovery counter — the halving invalidates any partial
+      // progress the site had made toward earning concurrency back.
       this.successesSinceReduction = 0;
+      // Increment the ratchet. Only cleared by a *full* recovery in onSuccess.
       this.ratchetCycles++;
       consoleLogger.info(
         `Rate limited (HTTP ${httpStatus}) — reducing concurrency to ${pool.maxConcurrency} (ratchet cycle ${this.ratchetCycles}/${this.maxRatchetCycles})`,
       );
     }
 
+    // First abort trigger: too many failures in a row with no successes in
+    // between. Catches sites that never respond OK.
     if (this.consecutiveFailures >= this.maxConsecutiveFailures) {
       return true;
     }
 
+    // Second abort trigger: the halve-recover-halve cycle happened too many
+    // times without a full recovery. Catches sites that let just enough
+    // requests through to keep the crawler alive but never enough to reach
+    // original concurrency. This is the case that was hanging 12h scans.
     if (this.ratchetCycles >= this.maxRatchetCycles) {
       consoleLogger.info(
         `Concurrency has been reduced ${this.ratchetCycles} times without recovering to ${this.originalMaxConcurrency} — treating site as permanently hostile.`,

--- a/src/crawlers/crawlSitemap.ts
+++ b/src/crawlers/crawlSitemap.ts
@@ -39,6 +39,7 @@ import {
 import { consoleLogger, guiInfoLog } from '../logs.js';
 import { ViewportSettingsClass } from '../combine.js';
 import { capturePageData } from './pageCapture.js';
+import { registerCrawler, unregisterCrawler, isShutdownRequested } from '../shutdownController.js';
 
 const crawlSitemap = async ({
   sitemapUrl,
@@ -655,10 +656,7 @@ const crawlSitemap = async ({
         }
 
         const timeSinceLastSuccess = Date.now() - lastSuccessTime;
-        if (
-          urlsCrawled.scanned.length > 0 &&
-          timeSinceLastSuccess > maxIdleMs
-        ) {
+        if (timeSinceLastSuccess > maxIdleMs) {
           consoleLogger.info(
             `Aborting crawl: no successful scan in ${Math.round(timeSinceLastSuccess / 1000)}s. Generating partial report with ${urlsCrawled.scanned.length} pages.`,
           );
@@ -730,9 +728,13 @@ const crawlSitemap = async ({
     }),
   );
 
+  // Reset the idle timer right before crawler.run() so that sitemap-discovery
+  // time (URL sitemaps can take minutes to walk a big sitemap index) doesn't
+  // count against the idle window.
+  lastSuccessTime = Date.now();
   const idleCheckInterval = setInterval(() => {
     const timeSinceLastSuccess = Date.now() - lastSuccessTime;
-    if (urlsCrawled.scanned.length > 0 && timeSinceLastSuccess > maxIdleMs) {
+    if (timeSinceLastSuccess > maxIdleMs) {
       consoleLogger.info(
         `Aborting crawl: no successful scan in ${Math.round(timeSinceLastSuccess / 1000)}s. Generating partial report with ${urlsCrawled.scanned.length} pages.`,
       );
@@ -741,8 +743,16 @@ const crawlSitemap = async ({
     }
   }, 30_000);
 
-  await crawler.run();
-  clearInterval(idleCheckInterval);
+  registerCrawler(crawler);
+  try {
+    await crawler.run();
+  } finally {
+    unregisterCrawler(crawler);
+    clearInterval(idleCheckInterval);
+  }
+  if (isShutdownRequested()) {
+    isAbortingScan = true;
+  }
 
   await requestList.isFinished();
 

--- a/src/crawlers/crawlSitemap.ts
+++ b/src/crawlers/crawlSitemap.ts
@@ -743,13 +743,22 @@ const crawlSitemap = async ({
     }
   }, 30_000);
 
+  // Publish the crawler to the shutdown controller so a SIGTERM/SIGINT that
+  // arrives during crawler.run() can abort the autoscaledPool. Without this,
+  // the container's SIGKILL lands mid-write and produces a corrupted results.zip.
   registerCrawler(crawler);
   try {
     await crawler.run();
   } finally {
+    // Always unregister and clear the idle watchdog, even if crawler.run()
+    // threw — otherwise a later phase could inherit a stale reference or the
+    // interval could keep firing after the crawler has exited.
     unregisterCrawler(crawler);
     clearInterval(idleCheckInterval);
   }
+  // If we got here because of SIGTERM/SIGINT (not a natural finish), route
+  // into the same partial-report finalization path that idle-abort and
+  // duration-cap use. Downstream code branches on isAbortingScan.
   if (isShutdownRequested()) {
     isAbortingScan = true;
   }

--- a/src/shutdownController.ts
+++ b/src/shutdownController.ts
@@ -1,0 +1,67 @@
+import { consoleLogger } from './logs.js';
+
+// A shared shutdown controller so combine.ts can install a single SIGTERM/SIGINT
+// handler and the currently running crawler can be aborted from that handler.
+// Without this, a container/runner sending SIGTERM (e.g. GitHub Actions job
+// timeout, `docker stop`) leaves Crawlee running until SIGKILL lands mid-write,
+// which is the "corrupted results.zip" symptom observed in production.
+//
+// The handler triggers the same autoscaledPool.abort() path used by the idle
+// watchdog, so finalization (writeManifest → generateArtifacts → submitForm →
+// S3 upload) runs the same way it does for an idle abort.
+
+interface AbortableCrawler {
+  autoscaledPool?: { abort: () => Promise<void> };
+}
+
+let currentCrawler: AbortableCrawler | null = null;
+let handlerInstalled = false;
+let shutdownRequested = false;
+let receivedSignal: NodeJS.Signals | null = null;
+
+export function registerCrawler(crawler: AbortableCrawler): void {
+  currentCrawler = crawler;
+}
+
+export function unregisterCrawler(crawler: AbortableCrawler): void {
+  if (currentCrawler === crawler) {
+    currentCrawler = null;
+  }
+}
+
+export function isShutdownRequested(): boolean {
+  return shutdownRequested;
+}
+
+export function getShutdownSignal(): NodeJS.Signals | null {
+  return receivedSignal;
+}
+
+export function initShutdownHandler(): void {
+  if (handlerInstalled) return;
+  handlerInstalled = true;
+
+  const handleShutdown = (signal: NodeJS.Signals) => {
+    if (shutdownRequested) {
+      // A second signal while we're already shutting down — the user (or the
+      // container) really wants us out. Exit immediately.
+      consoleLogger.warn(`Received second ${signal} — exiting immediately.`);
+      process.exit(143);
+    }
+    shutdownRequested = true;
+    receivedSignal = signal;
+    consoleLogger.warn(
+      `Received ${signal} — aborting current crawler and finalizing partial report.`,
+    );
+    if (currentCrawler?.autoscaledPool) {
+      Promise.resolve(currentCrawler.autoscaledPool.abort()).catch(err => {
+        consoleLogger.error(`Error aborting crawler pool on ${signal}: ${err}`);
+      });
+    } else {
+      consoleLogger.info(`No active crawler to abort on ${signal}.`);
+    }
+  };
+
+  process.on('SIGTERM', handleShutdown);
+  process.on('SIGINT', handleShutdown);
+}

--- a/src/shutdownController.ts
+++ b/src/shutdownController.ts
@@ -10,25 +10,49 @@ import { consoleLogger } from './logs.js';
 // watchdog, so finalization (writeManifest → generateArtifacts → submitForm →
 // S3 upload) runs the same way it does for an idle abort.
 
+// Minimal shape we need from a Crawlee crawler — only the pool's abort() is
+// actually called. Kept narrow so we don't couple the shutdown module to
+// Crawlee's full crawler surface.
 interface AbortableCrawler {
   autoscaledPool?: { abort: () => Promise<void> };
 }
 
+// The single active crawler for this process. Only one crawl phase runs at a
+// time (sitemap OR domain OR click-pass iteration), so a scalar is enough —
+// the current phase registers itself in registerCrawler and the previous
+// phase has already unregistered by then.
 let currentCrawler: AbortableCrawler | null = null;
+// Guards against installing the SIGTERM/SIGINT handlers twice if
+// initShutdownHandler() is called more than once (e.g. combineRun invoked
+// multiple times in a long-lived process).
 let handlerInstalled = false;
+// Latched true the first time a shutdown signal arrives. Never cleared —
+// once we decide to shut down, downstream code (crawler post-run checks)
+// should stay on the abort path even if the pool.abort() promise resolves.
 let shutdownRequested = false;
+// The signal that triggered shutdown, exposed for callers that want to log
+// or branch on SIGTERM vs SIGINT.
 let receivedSignal: NodeJS.Signals | null = null;
 
+// Called by each crawler right before crawler.run() so that if a signal
+// arrives mid-run, the handler knows which pool to abort.
 export function registerCrawler(crawler: AbortableCrawler): void {
   currentCrawler = crawler;
 }
 
+// Called after crawler.run() returns. The identity check prevents a stale
+// unregister call from clobbering a newer registration — belt-and-braces for
+// the sequential-phases pattern in crawlDomain's click-pass loop.
 export function unregisterCrawler(crawler: AbortableCrawler): void {
   if (currentCrawler === crawler) {
     currentCrawler = null;
   }
 }
 
+// Post-run branches in crawlSitemap/crawlDomain call this to decide whether
+// to treat the completed run as a normal finish or a signal-triggered abort
+// (in which case they set their local isAbortingScan flag so downstream
+// finalization writes a partial report).
 export function isShutdownRequested(): boolean {
   return shutdownRequested;
 }
@@ -38,26 +62,38 @@ export function getShutdownSignal(): NodeJS.Signals | null {
 }
 
 export function initShutdownHandler(): void {
+  // Idempotent — safe to call more than once.
   if (handlerInstalled) return;
   handlerInstalled = true;
 
   const handleShutdown = (signal: NodeJS.Signals) => {
     if (shutdownRequested) {
-      // A second signal while we're already shutting down — the user (or the
-      // container) really wants us out. Exit immediately.
+      // A second signal while we're already shutting down means the caller
+      // (usually the container escalating toward SIGKILL) has given up on
+      // graceful exit. Exit immediately with 128 + SIGTERM(15) = 143, the
+      // conventional exit code for termination-by-SIGTERM.
       consoleLogger.warn(`Received second ${signal} — exiting immediately.`);
       process.exit(143);
     }
+    // Latch the shutdown state before doing any async work. Any signal that
+    // arrives during pool.abort() will now take the "second signal" branch.
     shutdownRequested = true;
     receivedSignal = signal;
     consoleLogger.warn(
       `Received ${signal} — aborting current crawler and finalizing partial report.`,
     );
     if (currentCrawler?.autoscaledPool) {
+      // abort() returns a Promise. We can't await here (signal handlers are
+      // sync), so fire-and-forget with a catch to log rejections. Crawler
+      // exit + finalization happens via the awaited crawler.run() in the
+      // caller — this pool.abort() just unblocks that await.
       Promise.resolve(currentCrawler.autoscaledPool.abort()).catch(err => {
         consoleLogger.error(`Error aborting crawler pool on ${signal}: ${err}`);
       });
     } else {
+      // Signal arrived between crawl phases (or before the first phase
+      // started). Nothing to abort — the shutdownRequested flag will still
+      // cause the next phase's post-run check to bail.
       consoleLogger.info(`No active crawler to abort on ${signal}.`);
     }
   };


### PR DESCRIPTION
## Summary

Four related fixes for scans that ran for 12+ hours against hostile sites returning 403s, ending in SIGKILL and corrupted `results.zip` artifacts.

- Drop the `scanned.length > 0` gate on idle watchdogs so scans with zero successes can abort.
- Track ratchet cycles in `CrawlRateController` and abort when a site is permanently hostile.
- Add `OOBEE_MAX_SCAN_MINUTES` hard wall-clock cap in `combine.ts`.
- Install SIGTERM/SIGINT handler via new `shutdownController.ts` so container timeouts finalize partial reports instead of dying mid-write.

## Root Cause

Production run against a rate-limiting site: crawler hit 403s → `CrawlRateController.onFailure()` halved concurrency → recovered → got halved again → repeated indefinitely. No successful pages ever got scanned, so:

1. **Idle watchdogs never armed.** The watchdogs in `crawlSitemap.ts` and `crawlDomain.ts` gated their abort logic on `urlsCrawled.scanned.length > 0`. A run that fails every request never crosses the gate, so the watchdog effectively does nothing.
2. **Rate controller can recover forever.** `onFailure()` halved concurrency but had no memory of how many times it had already done so. A site that halves-recovers-halves in a loop keeps the crawler alive without progress.
3. **No wall-clock ceiling.** `scanDuration` is a per-crawler input; there was no top-level cap. If discovery/setup runs long and the caller passes `0`, the crawl runs until something else stops it.
4. **No SIGTERM handler.** When the GitHub Actions job timeout fired or `docker stop` sent SIGTERM, Crawlee's built-in handlers slowed shutdown but our post-crawl finalization (`writeManifest → generateArtifacts → submitForm → S3 upload`) had no chance to run before SIGKILL landed. The visible symptom was a truncated `results.zip`.

## Fixes

### 1. Ungate idle watchdogs — `crawlSitemap.ts`, `crawlDomain.ts`
Removed `urlsCrawled.scanned.length > 0 &&` from the watchdog condition. `lastSuccessTime` is now reset right before `crawler.run()` so sitemap-discovery time doesn't count against the idle window, but the watchdog itself always checks. Tunable via `OOBEE_MAX_IDLE_MINUTES`.

### 2. Ratchet-cycle abort — `crawlRateController.ts`
Added `ratchetCycles` counter incremented on each halving. Only cleared when concurrency recovers all the way to `originalMaxConcurrency` (`onSuccess`). When `ratchetCycles >= maxRatchetCycles`, `onFailure` returns `true` and logs *"treating site as permanently hostile"*. Tunable via `OOBEE_MAX_RATCHET_CYCLES` (default 5).

### 3. Wall-clock hard cap — `combine.ts`
New env `OOBEE_MAX_SCAN_MINUTES` clamps the effective `scanDuration` at the entry point. All four crawler paths (SITEMAP, LOCALFILE, INTELLIGENT, WEBSITE) now receive `effectiveScanDuration`. The existing `remainingDuration` mechanism in `crawlIntelligentSitemap` continues to work correctly across sequential sitemaps.

### 4. Graceful SIGTERM/SIGINT — new `src/shutdownController.ts`
Module-level `registerCrawler` / `unregisterCrawler` / `initShutdownHandler` / `isShutdownRequested`. `combine.ts` installs the handler once at scan start. Each `crawler.run()` in `crawlSitemap.ts` and `crawlDomain.ts` (initial run + click-pass loop) registers the active crawler in a `try/finally`. On signal receipt the handler calls `crawler.autoscaledPool.abort()` — the same abort path used by the idle watchdog and duration cap — so the existing finalization code runs identically to a normal abort. A second signal exits immediately (code 143). The `isShutdownRequested()` post-run check ensures downstream branches treat the scan as aborted.

## Environment Variables

| Variable | Default | Purpose |
|---|---|---|
| `OOBEE_MAX_IDLE_MINUTES` | (existing) | Abort if no page succeeds within this window |
| `OOBEE_CONSECUTIVE_MAX_RETRIES` | 100 | Abort after this many consecutive failures |
| `OOBEE_MAX_RATCHET_CYCLES` | 5 | Abort after this many concurrency halvings without recovery |
| `OOBEE_MAX_SCAN_MINUTES` | (unset — no cap) | Wall-clock ceiling on total scan time |

## Test plan

- [ ] Trigger a run against a site that returns 403 for all requests — should abort within `OOBEE_MAX_IDLE_MINUTES` instead of hanging
- [ ] Trigger a run with `OOBEE_MAX_RATCHET_CYCLES=2` against a rate-limiting site — should abort with *"treating site as permanently hostile"* log line
- [ ] Trigger a run with `OOBEE_MAX_SCAN_MINUTES=5` on a long-running site — should abort after 5 minutes and write partial report
- [ ] `kill -TERM <pid>` a running scan — should log SIGTERM, abort pool, write manifest + partial report, upload to S3
- [ ] Confirm a healthy full-length scan (e.g. wogaamomprod-style LocalFile) completes with `Exiting with code: 0` and successful S3 upload

🤖 Generated with [Claude Code](https://claude.com/claude-code)