### PR TITLE
fix(crawler): retry transient 5xx (500/502/503/504) once

### DIFF
--- a/src/crawlers/crawlDomain.ts
+++ b/src/crawlers/crawlDomain.ts
@@ -686,6 +686,29 @@ const crawlDomain = async ({
               });
               return;
             }
+            // Transient 5xx from load balancers / origin overload often resolves
+            // on a second attempt. Re-enqueue once (mirrors the 403 pattern) so
+            // a single flaky response doesn't drop the URL entirely. We do NOT
+            // call rateController.onFailure here — 5xx isn't a rate-limit signal,
+            // and halving concurrency for a transient upstream error would hurt
+            // throughput on the rest of the crawl.
+            const isTransient5xx =
+              responseStatus === 500 ||
+              responseStatus === 502 ||
+              responseStatus === 503 ||
+              responseStatus === 504;
+            if (isTransient5xx && !request.userData?.serverErrorRetried) {
+              try {
+                await requestQueue.addRequest({
+                  url: request.url,
+                  label: request.url,
+                  uniqueKey: `5xx_${request.url}`,
+                  userData: { serverErrorRetried: true },
+                });
+              } catch {}
+              return;
+            }
+
             if (responseStatus && responseStatus >= 300) {
               guiInfoLog(guiInfoStatusTypes.SKIPPED, {
                 numScanned: urlsCrawled.scanned.length,

--- a/src/crawlers/crawlSitemap.ts
+++ b/src/crawlers/crawlSitemap.ts
@@ -390,6 +390,26 @@ const crawlSitemap = async ({
             return;
           }
 
+          // Transient 5xx from load balancers / origin overload often resolves
+          // on a second attempt. Re-enqueue once (mirrors the 403 pattern) so
+          // a single flaky response doesn't drop the URL as "invalid". We do
+          // NOT call rateController.onFailure here — 5xx isn't a rate-limit
+          // signal, and halving concurrency for a transient upstream error
+          // would hurt throughput on the rest of the crawl.
+          const isTransient5xx =
+            status === 500 || status === 502 || status === 503 || status === 504;
+          if (isTransient5xx && !request.userData?.serverErrorRetried) {
+            try {
+              await requestQueue.addRequest({
+                url: request.url,
+                label: request.url,
+                uniqueKey: `5xx_${request.url}`,
+                userData: { serverErrorRetried: true },
+              });
+            } catch {}
+            return;
+          }
+
           if (isScanHtml && status < 300 && isWhitelistedContentType(contentType)) {
             const isRedirected = !areLinksEqual(page.url(), request.url);
             const isLoadedUrlInCrawledUrls = urlsCrawled.scanned.some(


### PR DESCRIPTION
## Summary

Transient upstream errors (502 Bad Gateway, 503 Service Unavailable, 504 Gateway Timeout, 500 Internal Server Error) frequently resolve on a second attempt. Before this change, a single 5xx response dropped the URL entirely — no retry.

- **Sitemap crawl**: URL was pushed to `urlsCrawled.invalid`.
- **Domain crawl**: URL was pushed to `urlsCrawled.userExcluded`.

Now both `requestHandler`s re-enqueue the URL once with a `userData.serverErrorRetried` flag so a single flaky response no longer drops the page.

## Why not use Crawlee's built-in retry?

Crawlee's `maxRequestRetries: 3` only fires on **thrown exceptions or network failures**, not on a successful HTTP response with a 5xx status. Playwright's `page.goto()` returns a normal `Response` object for 5xx — the `requestHandler` runs to completion and Crawlee treats the request as handled. `failedRequestHandler` never fires. So without an explicit re-enqueue, 5xx is a terminal state.

## Design choices

**Re-enqueue once (mirrors existing 403 pattern), not throw-to-retry.** The 403 branch in `failedRequestHandler` already uses this pattern with a `rateLimitRetried` flag. Reusing the same shape keeps the two retry paths consistent and reviewable.

**Only 500/502/503/504.** These are the widely recognised transient set. 501 (Not Implemented), 505 (HTTP Version Not Supported), and other 5xx values represent server-side permanent conditions and correctly fall through to the existing "record and move on" path.

**No `rateController.onFailure()` call for 5xx.** 5xx is an upstream/origin signal, not a rate-limit signal. Halving concurrency for a transient 502 would hurt throughput on the rest of the crawl for no gain — the retry itself is the correction. The 403 branch DOES call `onFailure` because 403 IS the rate-limit signal.

## Files

- [src/crawlers/crawlDomain.ts](src/crawlers/crawlDomain.ts) — new 5xx branch between the 403 branch and the generic `>= 300` branch in `requestHandler`.
- [src/crawlers/crawlSitemap.ts](src/crawlers/crawlSitemap.ts) — same, between the 403 branch and the `status < 300` success gate.

## Test plan

- [ ] Scan a URL that returns 502 on first request, 200 on second — should scan successfully (not appear in invalid/userExcluded).
- [ ] Scan a URL that returns 502 on both attempts — should appear in `urlsCrawled.invalid` (sitemap) / `urlsCrawled.userExcluded` (domain) exactly once, with `httpStatusCode: 502`.
- [ ] Scan a URL that returns 501 — should not retry, should appear in invalid/userExcluded on first attempt.
- [ ] Confirm concurrency is NOT halved when only 5xx responses arrive (verify against a mock 502 endpoint — `maxConcurrency` should stay at original).

🤖 Generated with [Claude Code](https://claude.com/claude-code)