### PR TITLE
Add custom flow finalizing callback

### DIFF
--- a/src/crawlers/scanCustomFlow.ts
+++ b/src/crawlers/scanCustomFlow.ts
@@ -206,6 +206,12 @@ export const scanCustomFlow = (config: ScanCustomFlowConfig): ScanCustomFlowSess
         },
       );
 
+      try {
+        await config.onFinalizing?.();
+      } catch (error) {
+        consoleLogger.warn('[scanCustomFlow] Failed to run onFinalizing callback.', error);
+      }
+
       scanDetails.endTime = new Date();
       scanDetails.urlsCrawled = customResult.urlsCrawled;
 

--- a/src/types/scanCustomFlow.ts
+++ b/src/types/scanCustomFlow.ts
@@ -63,6 +63,7 @@ export type ScanCustomFlowConfig = {
   useExtensionOverlayUi?: boolean;
   extensionSessionOrigin?: string;
   onReady?: () => void | Promise<void>;
+  onFinalizing?: () => void | Promise<void>;
 };
 
 export type ScanCustomFlowResult = {


### PR DESCRIPTION
Adds a finalizing callback to the custom headed scan flow so Dev Suite can update the UI immediately after the external browser is closed.

Previously, the scan remained in the “Headed Scan in progress” state while Oobee continued generating reports via mergeAxeResults, which made the Join/End controls briefly appear stale. With this callback, Dev Suite can switch to an “awaiting AI fixes” or finalizing state as soon as browser interaction ends, giving users clearer scan progress feedback.