### PR TITLE
Disable abort thresholds by default (avoid killing long scans on transient 403s)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -145,7 +145,9 @@ The `constants` default export object holds runtime state:
 | `OOBEE_SCAN_METADATA` | Overrides `entryUrl` tag in Sentry events |
 | `OOBEE_SCAN_PRODUCT` | Adds `scanProduct` tag to Sentry events |
 | `OOBEE_INSPECT_PRESET_SCAN` | `1`/`true`/`yes`/`on` = render the WOGAA Inspect preset rescan report design, including the combined Oobee/Inspect logo, rescan subtitle, viewport summary, and inspect-data text in the WCAG score card. |
-| `OOBEE_CONSECUTIVE_MAX_RETRIES` | Max consecutive HTTP failures before circuit breaker aborts crawl (default 100) |
+| `OOBEE_CONSECUTIVE_MAX_RETRIES` | Max consecutive HTTP failures before circuit breaker aborts crawl. `0` disables this check (default `0`) |
+| `OOBEE_MAX_RATCHET_CYCLES` | Max number of concurrency halvings without a full recovery before the crawl aborts. `0` disables this check (default `0`) |
+| `OOBEE_MAX_IDLE_MINUTES` | Max minutes without a successful page scan before the crawl aborts and generates a partial report. `0` disables this check (default `0`) |
 | `OOBEE_VALIDATE_URL` | If set, exit after URL validation without scanning |
 | `OOBEE_AXE_RECHECK_HYDRATION_MS` | Shared post-axe wait before rechecking selected hydration-sensitive violations (`aria-valid-attr-value`, `target-size`, `aria-hidden-focus`, `color-contrast`, `color-contrast-enhanced`). Default 5000ms; `0` reruns immediately. The wait only runs when one of those violations appears. |
 | `OOBEE_SAVE_DOM` | `1` or `true` = save full-page DOM HTML for desktop and mobile viewports to `pageDOMs/desktopPageDOMs/` and `pageDOMs/mobilePageDOMs/` in results directory. Mobile viewport uses iPhone 11 width programmatically. Supported scan types: Website, Sitemap, Intelligent, LocalFile, Custom |
@@ -382,7 +384,7 @@ When `CF_WORKER_PROXY` is set, `proxyService.getProxyInfo()` starts a local SOCK
 - Sites with WAFs (Cloudflare, Akamai, etc.) will start returning 403/503 after a certain number of concurrent requests — typically 200-300 pages in rapid succession.
 - Both crawlers use a shared `CrawlRateController` class (`src/crawlers/crawlRateController.ts`) that provides:
   1. **Strict maxPages**: `claimSlot()` is called at the moment of success (synchronously right before `urlsCrawled.scanned.push()`), not at the top of the request handler. `abort()` is called only after claiming the last slot (`isLimitReached()` becomes true post-claim). Never abort from the top of the handler — doing so kills in-flight pages that other handlers are scanning, causing undershoot.
-  2. **Circuit breaker**: After 100 consecutive HTTP 4xx/5xx failures (configurable via `OOBEE_CONSECUTIVE_MAX_RETRIES`), the crawl aborts gracefully.
+  2. **Circuit breaker**: After 100 consecutive HTTP 4xx/5xx failures (configurable via `OOBEE_CONSECUTIVE_MAX_RETRIES`, default `0` = disabled), the crawl aborts gracefully.
   3. **Adaptive concurrency**: On each 4xx/5xx failure, concurrency is halved (floor 1). Recovery is tracked by `successesSinceReduction` — after 10 successes since the last reduction, concurrency increases by +2 toward the original value. Non-4xx failures (timeouts, network errors) do NOT reset this counter, so recovery remains reachable on mixed-content sites where PDF/download errors are common. This automatically finds the site's rate limit threshold without manual tuning.
 - **Critical placement of `claimSlot()` and `abort()`**: `claimSlot()` must be synchronously right before `push()` — never at the top of the handler. `abort()` must be called only after the last slot is claimed — never from an early-exit check. Pages can be discarded mid-handler (redirect, dedup, robots.txt block), and aborting prematurely kills in-flight handlers that would have succeeded.
 - Only HTTP 4xx/5xx responses trigger rate adaptation and count toward the circuit breaker — timeouts and network errors do not.

--- a/CRAWL.md
+++ b/CRAWL.md
@@ -193,7 +193,8 @@ The `CrawlRateController` manages concurrency dynamically:
 
 - **On HTTP 4xx/5xx**: Concurrency halved (floor 1). Consecutive failure counter incremented.
 - **On success**: After 10 successes since the last concurrency reduction, concurrency increases by 2 (up to original max). Only 4xx/5xx failures reset this counter — non-HTTP failures (timeouts, download errors) do not erase recovery progress.
-- **Circuit breaker**: After 100 consecutive failures (`OOBEE_CONSECUTIVE_MAX_RETRIES`), the crawl aborts gracefully.
+- **Circuit breaker**: After `OOBEE_CONSECUTIVE_MAX_RETRIES` consecutive failures, the crawl aborts gracefully. Default `0` = disabled, so long-running scans no longer abort from a temporary burst of 403s/5xxs.
+- **Ratchet-cycle breaker**: After `OOBEE_MAX_RATCHET_CYCLES` concurrency halvings without a full recovery to original concurrency, the crawl aborts gracefully. Default `0` = disabled.
 - **403 retry**: First 403 halves concurrency once and re-enqueues with `rateLimitRetried` flag. Second 403 falls through to the circuit-breaker path with `skipConcurrencyReduction: true` — it counts toward consecutive failures but does not halve concurrency again for the same URL.
 
 Crawlee's `retryOnBlocked: true` detects blocked responses (403, 429) and rotates sessions automatically before the request reaches the handler.

--- a/README.md
+++ b/README.md
@@ -99,8 +99,9 @@ verapdf --version
 | OOBEE_TAGGED_WEBSITE | Tag to identify the website in telemetry. Can also be set via `-z, --websiteTag` CLI flag (CLI flag takes precedence). | |
 | OOBEE_SCAN_METADATA | Overrides the `entryUrl` tag sent to telemetry. | |
 | OOBEE_SCAN_PRODUCT | Adds a `scanProduct` tag to telemetry events. | |
-| OOBEE_CONSECUTIVE_MAX_RETRIES | Max consecutive HTTP failures before the circuit breaker aborts the crawl. | `100` |
-| OOBEE_MAX_IDLE_MINUTES | Max minutes without a successful page scan before the crawl aborts and generates a partial report from pages already scanned. Helps avoid losing results when sites start blocking mid-crawl. | `5` |
+| OOBEE_CONSECUTIVE_MAX_RETRIES | Max consecutive HTTP failures before the circuit breaker aborts the crawl. `0` disables this check. | `0` (disabled) |
+| OOBEE_MAX_RATCHET_CYCLES | Max number of concurrency halvings without a full recovery before the crawl aborts. `0` disables this check. | `0` (disabled) |
+| OOBEE_MAX_IDLE_MINUTES | Max minutes without a successful page scan before the crawl aborts and generates a partial report from pages already scanned. `0` disables this check. | `0` (disabled) |
 | OOBEE_SAVE_DOM | Set to `1` or `true` to save full-page DOM HTML for each scanned page in both desktop and mobile viewports to the results directory. Mobile viewport width is determined from iPhone 11 device profile. Works with all scan types (Website, Sitemap, Intelligent, LocalFile, Custom). | |
 | OOBEE_SAVE_PAGE_SCREENSHOT | Set to `1` or `true` to save full-page desktop and mobile viewport screenshots for each scanned page. Mobile viewport width is determined from iPhone 11 device profile. Works with all scan types (Website, Sitemap, Intelligent, LocalFile, Custom). | |
 | HTTP_PROXY | URL of the proxy server to be used for HTTP requests (e.g. `http://proxy.example.com:8080`). | |

--- a/src/crawlers/crawlDomain.ts
+++ b/src/crawlers/crawlDomain.ts
@@ -388,7 +388,10 @@ const crawlDomain = async ({
 
   let isAbortingScanNow = false;
   let lastSuccessTime = Date.now();
-  const maxIdleMs = (Number(process.env.OOBEE_MAX_IDLE_MINUTES) || 5) * 60 * 1000;
+  // Default 0 = disabled (no idle-timeout abort). Any positive value enables
+  // aborting after that many minutes without a successful scan.
+  const maxIdleMinutes = Number(process.env.OOBEE_MAX_IDLE_MINUTES) || 0;
+  const maxIdleMs = maxIdleMinutes > 0 ? maxIdleMinutes * 60 * 1000 : 0;
   const remainingBudget = fromCrawlIntelligentSitemap
     ? Math.max(0, maxRequestsPerCrawl - urlsCrawledFromIntelligent.scanned.length)
     : maxRequestsPerCrawl;
@@ -953,7 +956,7 @@ const crawlDomain = async ({
         }
 
         const timeSinceLastSuccess = Date.now() - lastSuccessTime;
-        if (timeSinceLastSuccess > maxIdleMs) {
+        if (maxIdleMs > 0 && timeSinceLastSuccess > maxIdleMs) {
           consoleLogger.info(
             `Aborting crawl: no successful scan in ${Math.round(timeSinceLastSuccess / 1000)}s. Generating partial report with ${urlsCrawled.scanned.length} pages.`,
           );
@@ -1019,7 +1022,7 @@ const crawlDomain = async ({
   lastSuccessTime = Date.now();
   const idleCheckInterval = setInterval(() => {
     const timeSinceLastSuccess = Date.now() - lastSuccessTime;
-    if (timeSinceLastSuccess > maxIdleMs) {
+    if (maxIdleMs > 0 && timeSinceLastSuccess > maxIdleMs) {
       consoleLogger.info(
         `Aborting crawl: no successful scan in ${Math.round(timeSinceLastSuccess / 1000)}s. Generating partial report with ${urlsCrawled.scanned.length} pages.`,
       );
@@ -1103,7 +1106,7 @@ const crawlDomain = async ({
       lastSuccessTime = Date.now();
       const clickPassIdleCheck = setInterval(() => {
         const timeSinceLastSuccess = Date.now() - lastSuccessTime;
-        if (timeSinceLastSuccess > maxIdleMs) {
+        if (maxIdleMs > 0 && timeSinceLastSuccess > maxIdleMs) {
           consoleLogger.info(
             `Aborting crawl: no successful scan in ${Math.round(timeSinceLastSuccess / 1000)}s. Generating partial report with ${urlsCrawled.scanned.length} pages.`,
           );

--- a/src/crawlers/crawlRateController.ts
+++ b/src/crawlers/crawlRateController.ts
@@ -19,8 +19,11 @@ export class CrawlRateController {
 
   constructor(maxRequestsPerCrawl: number, maxConcurrency: number) {
     this.maxPages = maxRequestsPerCrawl;
-    this.maxConsecutiveFailures = Number(process.env.OOBEE_CONSECUTIVE_MAX_RETRIES) || 100;
-    this.maxRatchetCycles = Number(process.env.OOBEE_MAX_RATCHET_CYCLES) || 5;
+    // Default 0 = disabled. Any positive value enables the corresponding abort
+    // trigger. This lets long-running scans survive extended bursts of 403s
+    // (e.g. from transient WAF rate-limiting) without being aborted early.
+    this.maxConsecutiveFailures = Number(process.env.OOBEE_CONSECUTIVE_MAX_RETRIES) || 0;
+    this.maxRatchetCycles = Number(process.env.OOBEE_MAX_RATCHET_CYCLES) || 0;
     this.originalMaxConcurrency = maxConcurrency;
   }
 
@@ -102,8 +105,10 @@ export class CrawlRateController {
     }
 
     // First abort trigger: too many failures in a row with no successes in
-    // between. Catches sites that never respond OK.
-    if (this.consecutiveFailures >= this.maxConsecutiveFailures) {
+    // between. Catches sites that never respond OK. maxConsecutiveFailures
+    // <= 0 means this trigger is disabled (OOBEE_CONSECUTIVE_MAX_RETRIES=0 is
+    // the default, so long scans don't abort just from a burst of 403s).
+    if (this.maxConsecutiveFailures > 0 && this.consecutiveFailures >= this.maxConsecutiveFailures) {
       return true;
     }
 
@@ -111,7 +116,8 @@ export class CrawlRateController {
     // times without a full recovery. Catches sites that let just enough
     // requests through to keep the crawler alive but never enough to reach
     // original concurrency. This is the case that was hanging 12h scans.
-    if (this.ratchetCycles >= this.maxRatchetCycles) {
+    // maxRatchetCycles <= 0 means this trigger is disabled (default).
+    if (this.maxRatchetCycles > 0 && this.ratchetCycles >= this.maxRatchetCycles) {
       consoleLogger.info(
         `Concurrency has been reduced ${this.ratchetCycles} times without recovering to ${this.originalMaxConcurrency} — treating site as permanently hostile.`,
       );

--- a/src/crawlers/crawlSitemap.ts
+++ b/src/crawlers/crawlSitemap.ts
@@ -94,7 +94,10 @@ const crawlSitemap = async ({
   let durationExceeded = false;
   let isAbortingScan = false;
   let lastSuccessTime = Date.now();
-  const maxIdleMs = (Number(process.env.OOBEE_MAX_IDLE_MINUTES) || 5) * 60 * 1000;
+  // Default 0 = disabled (no idle-timeout abort). Any positive value enables
+  // aborting after that many minutes without a successful scan.
+  const maxIdleMinutes = Number(process.env.OOBEE_MAX_IDLE_MINUTES) || 0;
+  const maxIdleMs = maxIdleMinutes > 0 ? maxIdleMinutes * 60 * 1000 : 0;
   const remainingBudget = fromCrawlIntelligentSitemap
     ? Math.max(0, maxRequestsPerCrawl - urlsCrawledFromIntelligent.scanned.length)
     : maxRequestsPerCrawl;
@@ -676,7 +679,7 @@ const crawlSitemap = async ({
         }
 
         const timeSinceLastSuccess = Date.now() - lastSuccessTime;
-        if (timeSinceLastSuccess > maxIdleMs) {
+        if (maxIdleMs > 0 && timeSinceLastSuccess > maxIdleMs) {
           consoleLogger.info(
             `Aborting crawl: no successful scan in ${Math.round(timeSinceLastSuccess / 1000)}s. Generating partial report with ${urlsCrawled.scanned.length} pages.`,
           );
@@ -754,7 +757,7 @@ const crawlSitemap = async ({
   lastSuccessTime = Date.now();
   const idleCheckInterval = setInterval(() => {
     const timeSinceLastSuccess = Date.now() - lastSuccessTime;
-    if (timeSinceLastSuccess > maxIdleMs) {
+    if (maxIdleMs > 0 && timeSinceLastSuccess > maxIdleMs) {
       consoleLogger.info(
         `Aborting crawl: no successful scan in ${Math.round(timeSinceLastSuccess / 1000)}s. Generating partial report with ${urlsCrawled.scanned.length} pages.`,
       );


### PR DESCRIPTION
## Summary

Follow-up to #841. Currently `OOBEE_CONSECUTIVE_MAX_RETRIES`, `OOBEE_MAX_RATCHET_CYCLES`, and `OOBEE_MAX_IDLE_MINUTES` default to non-zero values (`100`, `5`, `5` minutes respectively), which means long-running scans can get aborted early just because a site returned a burst of 403s/5xxs for an hour or so (e.g. transient WAF rate-limiting), even though the crawl would otherwise recover.

This PR changes the default for all three to `0`, meaning **disabled by default**. Callers who want the original protective behavior back (e.g. to bail out early on a permanently hostile/dead site) can still opt in by setting a positive value for any of these env vars.

| Variable | Old default | New default | Purpose |
|---|---|---|---|
| `OOBEE_CONSECUTIVE_MAX_RETRIES` | `100` | `0` (disabled) | Abort after this many consecutive HTTP 4xx/5xx failures |
| `OOBEE_MAX_RATCHET_CYCLES` | `5` | `0` (disabled) | Abort after this many concurrency halvings without a full recovery |
| `OOBEE_MAX_IDLE_MINUTES` | `5` | `0` (disabled) | Abort if no page scan succeeds within this window |

`OOBEE_MAX_SCAN_MINUTES` (wall-clock cap) was already unset/no-cap by default and is unaffected by this PR.

## Changes

- `src/crawlers/crawlRateController.ts`
  - `maxConsecutiveFailures` and `maxRatchetCycles` now default to `0` instead of `100`/`5`.
  - Both abort checks in `onFailure()` are now gated with an explicit `> 0` guard, so `0` truly disables the trigger (previously `count >= 0` would always be true once any failure occurred).
- `src/crawlers/crawlDomain.ts` / `src/crawlers/crawlSitemap.ts`
  - `maxIdleMs` now defaults to `0` (disabled) instead of 5 minutes.
  - All 5 idle-check sites (request handler catch blocks, periodic `idleCheckInterval`, and the click-discovery second-pass idle check in `crawlDomain.ts`) now skip the abort when `maxIdleMs` is `0`.
- Docs updated: `README.md`, `AGENTS.md`, `CRAWL.md` — reflect the new `0` (disabled) defaults and clarify opt-in behavior.

## Why

Sites that rate-limit aggressively (e.g. Cloudflare/Akamai WAFs) can return 403s for extended periods and then recover. With the old defaults, a scan would give up permanently after 100 consecutive failures, 5 concurrency-halving cycles, or 5 minutes of no successful scans — even if the site would have started responding normally again shortly after. Disabling these by default lets long scans ride out such bursts and keep trying, while still allowing users who want fail-fast behavior to opt back in via env vars.

## Testing

- `npx tsc --noEmit` — passes with no errors.
- Manually traced all abort-trigger call sites in `crawlRateController.ts`, `crawlDomain.ts`, and `crawlSitemap.ts` to confirm the `0` default now fully disables each check (guarded with `> 0`) rather than defaulting to always-true comparisons.

## Backward compatibility

No behavior change for callers who explicitly set any of these env vars to a positive value — only the unset/default case changes.
