### PR TITLE
fix: remove browser fallback for legacy Google Forms telemetry

### DIFF
--- a/src/constants/common.ts
+++ b/src/constants/common.ts
@@ -2090,40 +2090,9 @@ export const getScreenToScan = (
   return 'Desktop';
 };
 
-export const submitFormViaPlaywright = async (
-  browserToRun: string,
-  userDataDirectory: string,
-  finalUrl: string,
-) => {
-  const browserContext = await launchPersistentSafeContext(userDataDirectory, {
-    ...getPlaywrightLaunchOptions(browserToRun),
-  });
-
-  register(browserContext);
-
-  const page = await browserContext.newPage();
-
-  try {
-    await page.goto(finalUrl, {
-      timeout: 30000,
-      waitUntil: 'commit',
-    });
-
-    try {
-      await page.waitForLoadState('networkidle', { timeout: 10000 });
-    } catch {
-      consoleLogger.info('Unable to detect networkidle');
-    }
-  } catch (error) {
-    consoleLogger.error(error);
-  } finally {
-    await browserContext.close();
-  }
-};
-
 export const submitForm = async (
-  browserToRun: string,
-  userDataDirectory: string,
+  _browserToRun: string,
+  _userDataDirectory: string,
   scannedUrl: string,
   entryUrl: string,
   scanType: string,
@@ -2136,34 +2105,38 @@ export const submitForm = async (
   metadata: string,
 ) => {
   // Legacy code start - Google Sheets submission
-  const additionalPageDataJson = JSON.stringify({
-    redirectsScanned: numberOfRedirectsScanned,
-    pagesNotScanned: numberOfPagesNotScanned,
-  });
-
-  let finalUrl =
-    `${formDataFields.formUrl}?` +
-    `${formDataFields.entryUrlField}=${entryUrl}&` +
-    `${formDataFields.scanTypeField}=${scanType}&` +
-    `${formDataFields.emailField}=${email}&` +
-    `${formDataFields.nameField}=${name}&` +
-    `${formDataFields.resultsField}=${encodeURIComponent(scanResultsJson)}&` +
-    `${formDataFields.numberOfPagesScannedField}=${numberOfPagesScanned}&` +
-    `${formDataFields.additionalPageDataField}=${encodeURIComponent(additionalPageDataJson)}&` +
-    `${formDataFields.metadataField}=${encodeURIComponent(metadata)}`;
-
-  if (scannedUrl !== entryUrl) {
-    finalUrl += `&${formDataFields.redirectUrlField}=${scannedUrl}`;
-  }
-
+  // Best-effort telemetry: this must never fail the caller's scan. The entire
+  // body is guarded because building the payload can throw independently of the
+  // network call (e.g. encodeURIComponent raises URIError on lone surrogates,
+  // which can appear in scanned page content).
   try {
+    const additionalPageDataJson = JSON.stringify({
+      redirectsScanned: numberOfRedirectsScanned,
+      pagesNotScanned: numberOfPagesNotScanned,
+    });
+
+    let finalUrl =
+      `${formDataFields.formUrl}?` +
+      `${formDataFields.entryUrlField}=${entryUrl}&` +
+      `${formDataFields.scanTypeField}=${scanType}&` +
+      `${formDataFields.emailField}=${email}&` +
+      `${formDataFields.nameField}=${name}&` +
+      `${formDataFields.resultsField}=${encodeURIComponent(scanResultsJson)}&` +
+      `${formDataFields.numberOfPagesScannedField}=${numberOfPagesScanned}&` +
+      `${formDataFields.additionalPageDataField}=${encodeURIComponent(additionalPageDataJson)}&` +
+      `${formDataFields.metadataField}=${encodeURIComponent(metadata)}`;
+
+    if (scannedUrl !== entryUrl) {
+      finalUrl += `&${formDataFields.redirectUrlField}=${scannedUrl}`;
+    }
+
     await axios.get(finalUrl, { timeout: 2000 });
   } catch (error) {
-    if (error.code === 'ECONNABORTED') {
-      if (browserToRun || constants.launcher === webkit) {
-        await submitFormViaPlaywright(browserToRun, userDataDirectory, finalUrl);
-      }
-    }
+    // Never rethrow. Previously a timeout here would launch a second browser to
+    // retry the request, which could throw "Executable doesn't exist" on
+    // machines without the Playwright-managed browser and abort an
+    // already-successful scan.
+    consoleLogger.info(`Unable to submit form: ${error}`);
   }
 };
 // Legacy code end - Google Sheets submission


### PR DESCRIPTION
## Problem

`scanPage()` (the npm/library entry point) could fail with an unrecoverable error on machines that do not have the Playwright-managed Chromium revision downloaded, **even though the caller supplied their own already-launched `page`**:

```
browserType.launchPersistentContext: Executable doesn't exist at ...
╔══════════════════════════════════════════════════════════╗
║ Looks like Playwright ... was just installed or updated.  ║
║ Please run the following command to download new browsers ║
╚══════════════════════════════════════════════════════════╝
```

### Root cause

`scanPage()` → `processAndSubmitResults()` → `submitForm(BrowserTypes.CHROMIUM, '', ...)` (`src/npmIndex.ts:754`).

`submitForm` sends legacy Google Sheets telemetry via `axios.get(finalUrl, { timeout: 2000 })`. On `ECONNABORTED` it used to fall back to `submitFormViaPlaywright()`, which launched a **second, entirely separate browser** purely to re-issue that one HTTP request.

The call site hardcodes `BrowserTypes.CHROMIUM`, so `getPlaywrightLaunchOptions('chromium')` yields **no channel** — Playwright resolves its managed build rather than an installed Chrome/Edge. If that revision was never downloaded, the launch throws and the exception propagates out of `scanPage()`, destroying a scan that had already completed successfully.

Because the fallback only triggers when the 2s request times out, the failure was intermittent and purely timing-dependent (in our case 2 of 5 pages).

Note also that the payload — including the full results JSON — is `encodeURIComponent`'d into a **GET query string**, which is what makes the 2s timeout easy to hit in the first place.

## Fix

Remove the browser fallback entirely, and harden `submitForm` so it can never fail the caller's scan.

- Deleted `submitFormViaPlaywright()`.
- **The entire `submitForm` body is now inside a single `try`**, not just the network call. Payload construction can throw independently of the request — most realistically `encodeURIComponent(scanResultsJson)` raising `URIError` on a lone surrogate, which is a live risk because scan results embed arbitrary page text/HTML. `JSON.stringify` on the additional page data is covered too.
- The `catch` logs at info level and **never rethrows**.
- `browserToRun` / `userDataDirectory` params kept (prefixed `_`) to preserve the signature for all existing callers: `scanCustomFlow.ts:262`, `combine.ts:386`, `npmIndex.ts:615`, `npmIndex.ts:754`.

This matters because two callers `await submitForm(...)` bare, with no guard of their own (`combine.ts:386`, `npmIndex.ts:754`) — anything thrown there propagates straight out and aborts an already-completed scan. Only `scanCustomFlow.ts` was already defensive, via `void submitResult.catch(...)` on its fire-and-forget path. Containing the failure inside `submitForm` protects every call site uniformly rather than requiring each one to remember.


Net **+29 / −56** lines (the insertion count is inflated by re-indenting the existing payload-construction block into the `try`).

## Impact

Library consumers that pass their own `page` into `scanPage()` no longer need `npx playwright install`. This matters for embedded integrations (e.g. the VS Code Dev Suite extension) where asking an end user to download browsers is not acceptable — and is redundant, since the caller already has a working browser.

Behaviour on the happy path is unchanged: successful telemetry submissions still go through axios exactly as before. When the request does fail, telemetry is now silently skipped rather than escalating to a browser launch.

## Notes for reviewers

- **`submitFormViaPlaywright` was an exported symbol.** Nothing in-repo references it anymore, but it was technically part of this module's public surface. As internal legacy plumbing, removal seems correct — flagging in case any out-of-tree consumer imports it.
- **The underlying GET-size issue is not addressed here.** The full results JSON is still `encodeURIComponent`'d into a query string, so the 2s axios timeout can still fire on large scans; those submissions now no-op instead of retrying via browser. Making them actually succeed would mean switching to a form-encoded POST, which is left as a follow-up since the shape can't be validated without submitting live data to the production form.

## Validation

- `npx tsc --noEmit -p tsconfig.json` → exit 0.
- `grep -rn 'submitFormViaPlaywright' src/` → no matches remaining.
- No orphaned imports: `webkit` is still used by the Chrome→webkit CLI fallback (lines 1464/1466/1497/1501), and `launchPersistentSafeContext` / `register` remain in use elsewhere in the file (lines 407, 953, 1175, 2162).
- Reproduced originally against `0.11.15`, where 2/5 scanned pages aborted after their scan had already succeeded.


