### PR TITLE
security: address rescan findings from 2026-09-08 review

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -45,7 +45,13 @@ jobs:
             ./oobee-portable-windows.zip.sha256
 
       - name: Release Windows artifact
-        uses: softprops/action-gh-release@v1
+        # Pin third-party actions to a commit SHA — a mutable tag can be
+        # repointed by the action owner (or anyone who compromises the
+        # upstream repo) to a version that exfiltrates OIDC tokens or the
+        # GITHUB_TOKEN scoped to this workflow. The trailing comment names
+        # the tag the SHA corresponds to so Dependabot can keep the pin
+        # current without dropping back to a floating tag.
+        uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v1
         if: startsWith(github.ref, 'refs/tags/')
         with:
           files: |
@@ -190,7 +196,8 @@ jobs:
             ./oobee-portable-mac.zip.sha256
 
       - name: Release Mac artifact
-        uses: softprops/action-gh-release@v1
+        # See Windows job above for rationale on the SHA pin + tag comment.
+        uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v1
         if: startsWith(github.ref, 'refs/tags/')
         with:
           files: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,10 +30,37 @@ jobs:
   publish:
     if: ${{ inputs.action == 'publish' }}
     runs-on: ubuntu-latest
+    # Gate npm publish behind a protected GitHub Environment. The
+    # environment must be configured (Settings → Environments) with a
+    # required reviewer list so only designated maintainers can approve
+    # the release run — repo write access is not sufficient. This closes
+    # the "any actor with write access can ship arbitrary code as
+    # @govtechsg/oobee" path, since workflow_dispatch on its own does not
+    # gate on maintainer status.
+    environment: npm-publish
     steps:
+      - name: Validate release_tag input
+        env:
+          RELEASE_TAG: ${{ inputs.release_tag }}
+        # The publish job checks out ``inputs.release_tag`` and runs
+        # arbitrary build scripts from that ref before ``npm publish``.
+        # If the ref were free-form (branch name / SHA / attacker-owned
+        # tag), a repo-writer could publish arbitrary code as the
+        # official npm package. Constrain it here to the semver tag
+        # pattern the release automation produces, and reject anything
+        # else before touching the workspace.
+        run: |
+          if [ -z "${RELEASE_TAG}" ]; then
+            echo "::error::release_tag input is required for publish"
+            exit 1
+          fi
+          if ! printf '%s' "${RELEASE_TAG}" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$'; then
+            echo "::error::release_tag must be a semver tag (e.g. 0.11.16); got '${RELEASE_TAG}'"
+            exit 1
+          fi
       - uses: actions/checkout@v5
         with:
-          ref: ${{ inputs.release_tag }}
+          ref: refs/tags/${{ inputs.release_tag }}
       - uses: actions/setup-node@v5
         with:
           node-version: '22.x'

--- a/scripts/install_oobee_dependencies.command
+++ b/scripts/install_oobee_dependencies.command
@@ -1,6 +1,70 @@
 #!/bin/bash
 
+set -e
+
 NODE_VERSION="22.19.0"
+
+# --- Security: SHA-256 verification for every downloaded artifact ---
+#
+# The prior version of this script downloaded Node.js, Corretto, and the
+# veraPDF installer over TLS with no post-download integrity check. A
+# compromised mirror, a cache-poisoning attacker on a shared network, or
+# an accidental partial download would all silently ship whatever bytes
+# arrived. Every fetch below is now paired with an SHA-256 check that
+# aborts the script if the digest does not match.
+#
+# Pinned digests below cover:
+#   * Node.js: taken from the official
+#       https://nodejs.org/dist/v${NODE_VERSION}/SHASUMS256.txt
+#     which upstream publishes and GPG-signs for exactly this purpose.
+#   * veraPDF: the "cache" release tag on GovTechSG/oobee is a fixed,
+#     immutable asset — a static SHA-256 is embedded here and any drift
+#     means the release was re-uploaded (which should be a review event).
+#   * Corretto: the URL is intentionally "latest", so the digest is
+#     fetched from Amazon's ``latest_sha256`` sidecar at the same time as
+#     the archive. This defends against in-transit tampering and mirror
+#     corruption; sidecar and archive are fetched over TLS from the same
+#     origin, so this is TLS-level integrity, not signature verification.
+
+NODE_SHA256_DARWIN_ARM64="c59006db713c770d6ec63ae16cb3edc11f49ee093b5c415d667bb4f436c6526d"
+NODE_SHA256_DARWIN_X64="3cfed4795cd97277559763c5f56e711852d2cc2420bda1cea30c8aa9ac77ce0c"
+VERAPDF_SHA256="b6c50ab65d574bff0cbc0449ffacf587e325a3a53f8a6ecc0d578966abc800ec"
+
+# Verify a file's SHA-256 against an expected digest. Aborts (exit 1) on
+# mismatch or missing tools — never falls back to skipping the check,
+# because the whole point is to fail closed on tampered downloads.
+verify_sha256() {
+  local file="$1"
+  local expected="$2"
+  local label="$3"
+
+  if [ ! -f "$file" ]; then
+    echo "ERROR: $label: expected file '$file' was not downloaded" >&2
+    exit 1
+  fi
+
+  local actual
+  if command -v shasum >/dev/null 2>&1; then
+    actual="$(shasum -a 256 "$file" | awk '{print $1}')"
+  elif command -v sha256sum >/dev/null 2>&1; then
+    actual="$(sha256sum "$file" | awk '{print $1}')"
+  else
+    echo "ERROR: $label: neither shasum nor sha256sum is available; refusing to install unverified download" >&2
+    rm -f "$file"
+    exit 1
+  fi
+
+  if [ "$actual" != "$expected" ]; then
+    echo "ERROR: $label: SHA-256 mismatch" >&2
+    echo "  file:     $file" >&2
+    echo "  expected: $expected" >&2
+    echo "  actual:   $actual" >&2
+    rm -f "$file"
+    exit 1
+  fi
+
+  echo "OK: $label: SHA-256 verified ($expected)"
+}
 
 # Get current shell command
 SHELL_COMMAND=$(ps -o comm= -p $$)
@@ -17,32 +81,46 @@ fi
 
 if ! [ -f nodejs-mac-arm64/bin/node ]; then
   echo "Downloading NodeJS LTS (ARM64)"
-  curl -o ./nodejs-mac-arm64.tar.gz --create-dirs https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-darwin-arm64.tar.gz  
+  curl -fSL -o ./nodejs-mac-arm64.tar.gz --create-dirs "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-darwin-arm64.tar.gz"
+  verify_sha256 ./nodejs-mac-arm64.tar.gz "$NODE_SHA256_DARWIN_ARM64" "NodeJS ${NODE_VERSION} darwin-arm64"
   mkdir nodejs-mac-arm64
   tar -xzf nodejs-mac-arm64.tar.gz -C nodejs-mac-arm64 --strip-components=1 && rm ./nodejs-mac-arm64.tar.gz
-  rm nodejs-mac-arm64.tar.gz
+  rm -f nodejs-mac-arm64.tar.gz
 fi
 
 if ! [ -f nodejs-mac-x64/bin/node ]; then
   echo "Downloading NodeJS LTS (x64)"
-  curl -o ./nodejs-mac-x64.tar.gz --create-dirs https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-darwin-x64.tar.gz     
+  curl -fSL -o ./nodejs-mac-x64.tar.gz --create-dirs "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-darwin-x64.tar.gz"
+  verify_sha256 ./nodejs-mac-x64.tar.gz "$NODE_SHA256_DARWIN_X64" "NodeJS ${NODE_VERSION} darwin-x64"
   mkdir nodejs-mac-x64
   tar -xzf nodejs-mac-x64.tar.gz -C nodejs-mac-x64 --strip-components=1 && rm ./nodejs-mac-x64.tar.gz
-  rm node-*-darwin-x64.tar.gz
+  rm -f node-*-darwin-x64.tar.gz
 fi
 
 export CORRETTO_BASEDIR="$HOME/Library/Application Support/Oobee"
-mkdir -p "$CORRETTO_BASEDIR" 
+mkdir -p "$CORRETTO_BASEDIR"
 
 echo "INFO: Set path to Corretto-11 JDK"
 export JAVA_HOME="$CORRETTO_BASEDIR/amazon-corretto-11.jdk.x64/Contents/Home"
 export PATH="$JAVA_HOME/bin:$PATH"
 
 if ! [ -f jre/bin/java ]; then
-  cd "$CORRETTO_BASEDIR" 
+  cd "$CORRETTO_BASEDIR"
   if ! [ -f amazon-corretto-11.jdk.x64/Contents/Home/bin/java ]; then
       echo "Downloading Corretto (x64)"
-      curl -L -o ./corretto-11.tar.gz "https://corretto.aws/downloads/latest/amazon-corretto-11-x64-macos-jdk.tar.gz"
+      curl -fSL -o ./corretto-11.tar.gz "https://corretto.aws/downloads/latest/amazon-corretto-11-x64-macos-jdk.tar.gz"
+      # Corretto's "latest" URL rotates; pair the download with the
+      # matching digest fetched at the same time from the same origin.
+      # This is TLS-integrity — no upstream signature verification — but
+      # is strictly better than the previous "trust whatever bytes arrive"
+      # behavior and matches Amazon's documented integrity workflow.
+      CORRETTO_EXPECTED="$(curl -fsSL 'https://corretto.aws/downloads/latest_sha256/amazon-corretto-11-x64-macos-jdk.tar.gz' | tr -d '[:space:]')"
+      if [ -z "$CORRETTO_EXPECTED" ]; then
+        echo "ERROR: Corretto: could not fetch expected SHA-256 sidecar" >&2
+        rm -f ./corretto-11.tar.gz
+        exit 1
+      fi
+      verify_sha256 ./corretto-11.tar.gz "$CORRETTO_EXPECTED" "Corretto 11 macOS x64"
       tar -zxf ./corretto-11.tar.gz
       rm -f ./corretto-11.tar.gz
       mv amazon-corretto-11.jdk amazon-corretto-11.jdk.x64
@@ -60,12 +138,13 @@ if ! [ -f verapdf/verapdf ]; then
   echo "Downloading VeraPDF"
   if [ -d "./verapdf" ]; then rm -Rf ./verapdf; fi
   if [ -d "./verapdf-installer" ]; then rm -Rf ./verapdf-installer; fi
-  curl -L -o ./verapdf-installer.zip https://github.com/GovTechSG/oobee/releases/download/cache/verapdf-installer.zip
+  curl -fSL -o ./verapdf-installer.zip https://github.com/GovTechSG/oobee/releases/download/cache/verapdf-installer.zip
+  verify_sha256 ./verapdf-installer.zip "$VERAPDF_SHA256" "veraPDF installer"
   unzip -j ./verapdf-installer.zip -d ./verapdf-installer
   ./verapdf-installer/verapdf-install "${__dir}/verapdf-auto-install-macos.xml"
   cp -r /tmp/verapdf .
   rm -rf ./verapdf-installer.zip ./verapdf-installer /tmp/verapdf
-  
+
 fi
 
 if [ -d "/Applications/Cloudflare WARP.app" ]; then
@@ -81,7 +160,7 @@ fi
 
 if [ -d "node_modules" ]; then
   echo "Deleting node_modules before installation"
-  rm -rf node_modules 
+  rm -rf node_modules
 fi
 
 echo "Installing Node dependencies to $PWD"

--- a/scripts/install_oobee_dependencies.command
+++ b/scripts/install_oobee_dependencies.command
@@ -27,7 +27,7 @@ NODE_VERSION="22.19.0"
 #     origin, so this is TLS-level integrity, not signature verification.
 
 NODE_SHA256_DARWIN_ARM64="c59006db713c770d6ec63ae16cb3edc11f49ee093b5c415d667bb4f436c6526d"
-NODE_SHA256_DARWIN_X64="3cfed4795cd97277559763c5f56e711852d2cc2420bda1cea30c8aa9ac77ce0c"
+NODE_SHA256_DARWIN_X64="3cfed4795cd97277559763c5f56e711852d2cc2420bda1cea30c8aa9ac77ce0c" # guardrails-disable-line
 VERAPDF_SHA256="b6c50ab65d574bff0cbc0449ffacf587e325a3a53f8a6ecc0d578966abc800ec"
 
 # Verify a file's SHA-256 against an expected digest. Aborts (exit 1) on

--- a/scripts/install_oobee_dependencies.ps1
+++ b/scripts/install_oobee_dependencies.ps1
@@ -6,14 +6,47 @@ if ((Split-Path -Path $pwd -Leaf) -eq "scripts") {
 $ProgressPreferences = 'SilentlyContinue'
 $ErrorActionPreference = 'Stop'
 
+# --- Security: SHA-256 verification for every downloaded artifact ---
+#
+# See the sibling install_oobee_dependencies.command for the rationale.
+# In short: this script previously fetched Node.js, Corretto, and the
+# veraPDF installer over TLS and immediately unpacked whatever bytes
+# arrived. Every download below is now paired with an SHA-256 check
+# that terminates the script on mismatch.
+
+$NodeVersion = "22.19.0"
+$NodeSha256WinX64 = "ea3fad0e67a991d8477d8c01344b56e69c676ccb733f065b22436994b1253f86"
+$VeraPdfSha256   = "b6c50ab65d574bff0cbc0449ffacf587e325a3a53f8a6ecc0d578966abc800ec"
+
+function Assert-Sha256 {
+    param(
+        [Parameter(Mandatory=$true)][string]$Path,
+        [Parameter(Mandatory=$true)][string]$Expected,
+        [Parameter(Mandatory=$true)][string]$Label
+    )
+    if (-not (Test-Path $Path)) {
+        Write-Error "$Label`: expected file '$Path' was not downloaded"
+        exit 1
+    }
+    $actual = (Get-FileHash -Algorithm SHA256 -Path $Path).Hash.ToLowerInvariant()
+    $exp = $Expected.ToLowerInvariant()
+    if ($actual -ne $exp) {
+        Write-Error "$Label`: SHA-256 mismatch (expected $exp, actual $actual)"
+        Remove-Item -Force -ErrorAction SilentlyContinue $Path
+        exit 1
+    }
+    Write-Output "OK: $Label`: SHA-256 verified ($exp)"
+}
+
 # Install NodeJS binaries
 if (-Not (Test-Path nodejs-win\node.exe)) {
     Write-Output "Downloading Node"
-    Invoke-WebRequest -o ./nodejs-win.zip "https://nodejs.org/dist/v22.19.0/node-v22.19.0-win-x64.zip"     
-    
+    Invoke-WebRequest -o ./nodejs-win.zip "https://nodejs.org/dist/v$NodeVersion/node-v$NodeVersion-win-x64.zip"
+    Assert-Sha256 -Path ./nodejs-win.zip -Expected $NodeSha256WinX64 -Label "NodeJS $NodeVersion win-x64"
+
     Write-Output "Unzip Node"
     Expand-Archive .\nodejs-win.zip -DestinationPath .
-    Rename-Item node-v22.19.0-win-x64 -NewName nodejs-win
+    Rename-Item "node-v$NodeVersion-win-x64" -NewName nodejs-win
     Remove-Item -Force .\nodejs-win.zip
 }
 
@@ -21,8 +54,19 @@ if (-Not (Test-Path nodejs-win\node.exe)) {
 if (-Not (Test-Path jre\bin\java.exe)) {
     if (-Not (Test-Path jdk\bin\java.exe)) {
         Write-Output "Downloading Corretto-11"
-        Invoke-WebRequest -o ./corretto-11.zip "https://corretto.aws/downloads/latest/amazon-corretto-11-x64-windows-jdk.zip"     
-        
+        Invoke-WebRequest -o ./corretto-11.zip "https://corretto.aws/downloads/latest/amazon-corretto-11-x64-windows-jdk.zip"
+
+        # Corretto's "latest" URL rotates. Fetch the matching digest from
+        # Amazon's ``latest_sha256`` sidecar over the same TLS origin.
+        $correttoSha = (Invoke-WebRequest -UseBasicParsing `
+            -Uri 'https://corretto.aws/downloads/latest_sha256/amazon-corretto-11-x64-windows-jdk.zip').Content.Trim()
+        if ([string]::IsNullOrWhiteSpace($correttoSha)) {
+            Write-Error "Corretto: could not fetch expected SHA-256 sidecar"
+            Remove-Item -Force -ErrorAction SilentlyContinue ./corretto-11.zip
+            exit 1
+        }
+        Assert-Sha256 -Path ./corretto-11.zip -Expected $correttoSha -Label "Corretto 11 win-x64"
+
         Write-Output "Unzip Corretto-11"
         Expand-Archive .\corretto-11.zip -DestinationPath .
         Get-ChildItem ./jdk* -Directory | Rename-Item -NewName jdk
@@ -41,6 +85,8 @@ if (-Not (Test-Path jre\bin\java.exe)) {
 if (-Not (Test-Path verapdf\verapdf.bat)) {
     Write-Output "INFO: Downloading VeraPDF"
     Invoke-WebRequest -o .\verapdf-installer.zip "https://github.com/GovTechSG/oobee/releases/download/cache/verapdf-installer.zip"
+    Assert-Sha256 -Path .\verapdf-installer.zip -Expected $VeraPdfSha256 -Label "veraPDF installer"
+
     Expand-Archive .\verapdf-installer.zip -DestinationPath .
     Get-ChildItem ./verapdf-greenfield-* -Directory | Rename-Item -NewName verapdf-installer
 
@@ -51,7 +97,7 @@ if (-Not (Test-Path verapdf\verapdf.bat)) {
     Write-Output "INFO: Installing VeraPDF"
     .\verapdf-installer\verapdf-install "$PWD\verapdf-auto-install-windows.xml"
     Move-Item -Path C:\Windows\Temp\verapdf -Destination verapdf
-    Remove-Item -Force -Path .\verapdf-installer.zip 
+    Remove-Item -Force -Path .\verapdf-installer.zip
     Remove-Item -Force -Path .\verapdf-installer -recurse
 }
 
@@ -69,14 +115,14 @@ if (Test-Path oobee) {
     # Omit installing Playwright browsers as it is not reuqired
     # Write-Output "Install Playwright browsers"
     # & ".\oobee_shell_ps.ps1" "npx playwright install chromium"
-    
+
     try {
-	Write-Output "Building Typescript" 
-	& ".\oobee_shell_ps.ps1" "cd oobee;npm run build" 
+	Write-Output "Building Typescript"
+	& ".\oobee_shell_ps.ps1" "cd oobee;npm run build"
     } catch {
-	Write-Output "Build with some errors but continuing. $_.Exception.Message" 
-    } 
-    
+	Write-Output "Build with some errors but continuing. $_.Exception.Message"
+    }
+
     if (Test-Path oobee\.git) {
         Write-Output "Unhide .git folder"
         attrib -s -h oobee\.git
@@ -87,7 +133,7 @@ if (Test-Path oobee) {
 
     if (Test-Path package.json) {
         Write-Output "Installing node dependencies"
-        & ".\oobee_shell_ps.ps1" "npm install --force --omit=dev" 
+        & ".\oobee_shell_ps.ps1" "npm install --force --omit=dev"
 
         Write-Output "Install Playwright browsers"
         & "npx playwright install chromium"
@@ -96,13 +142,13 @@ if (Test-Path oobee) {
             Write-Output "Unhide .git folder"
             attrib -s -h .git
         }
-	
+
 	try {
-		Write-Output "Building Typescript" 
+		Write-Output "Building Typescript"
 		npm run build
  	} catch {
- 		Write-Output "Build with some errors but continuing" 
-	} 
+ 		Write-Output "Build with some errors but continuing"
+	}
 
     } else {
         Write-Output "Could not find oobee"

--- a/scripts/install_oobee_dependencies.ps1
+++ b/scripts/install_oobee_dependencies.ps1
@@ -15,8 +15,8 @@ $ErrorActionPreference = 'Stop'
 # that terminates the script on mismatch.
 
 $NodeVersion = "22.19.0"
-$NodeSha256WinX64 = "ea3fad0e67a991d8477d8c01344b56e69c676ccb733f065b22436994b1253f86"
-$VeraPdfSha256   = "b6c50ab65d574bff0cbc0449ffacf587e325a3a53f8a6ecc0d578966abc800ec"
+$NodeSha256WinX64 = "ea3fad0e67a991d8477d8c01344b56e69c676ccb733f065b22436994b1253f86" # guardrails-disable-line
+$VeraPdfSha256   = "b6c50ab65d574bff0cbc0449ffacf587e325a3a53f8a6ecc0d578966abc800ec" # guardrails-disable-line
 
 function Assert-Sha256 {
     param(

--- a/src/cfProxyWorker.ts
+++ b/src/cfProxyWorker.ts
@@ -331,9 +331,37 @@ async function resolveHostname(
 ): Promise<{ ip: string; bypass: boolean; blocked: boolean } | null> {
   // The SOCKS5 client may have already resolved DNS locally and passed an IP
   // literal (atyp 0x01/0x04). Skip DNS in that case and check the list directly.
+  //
+  // Setting ``blocked: isInternalIp(hostname)`` here (instead of a hard-coded
+  // ``false``) plugs the SSRF gap in the caller: a scanned page that hands the
+  // proxy ``169.254.169.254`` or ``127.0.0.1`` via SOCKS would otherwise be
+  // direct-forwarded on the bypass and INCLUDE_PROXY branches, letting the
+  // driven browser reach cloud-metadata / loopback services. handleSocks5
+  // already treats ``blocked`` as a refusal (0x02) so both branches inherit
+  // the guard the sibling handleSocks5FamilyLocal already applies.
   if (isIpLiteral(hostname)) {
-    return { ip: hostname, bypass: ipInRanges(hostname, bypassRanges), blocked: false };
+    return {
+      ip: hostname,
+      bypass: ipInRanges(hostname, bypassRanges),
+      blocked: isInternalIp(hostname),
+    };
   }
+
+  // Wraps a DNS-resolved address in the same block-if-internal contract as
+  // the IP-literal path. Handles the DNS-rebinding case where a hostile
+  // hostname resolves into internal / metadata address space.
+  const wrapResolved = (
+    ip: string,
+    bypass: boolean,
+  ): { ip: string; bypass: boolean; blocked: boolean } => {
+    if (isInternalIp(ip)) {
+      consoleLogger.info(
+        `[cfProxyWorker] Refusing ${hostname}: resolved to internal ${ip}`,
+      );
+      return { ip, bypass: false, blocked: true };
+    }
+    return { ip, bypass, blocked: false };
+  };
 
   if (isFamilyDnsEnabled()) {
     const ip = await resolveViaFamilyDoH(hostname);
@@ -347,9 +375,9 @@ async function resolveHostname(
     }
     if (ipInRanges(ip, bypassRanges)) {
       consoleLogger.info(`[cfProxyWorker] Bypass IP matched ${ip} for ${hostname}`);
-      return { ip, bypass: true, blocked: false };
+      return wrapResolved(ip, true);
     }
-    return { ip, bypass: false, blocked: false };
+    return wrapResolved(ip, false);
   }
 
   try {
@@ -357,11 +385,11 @@ async function resolveHostname(
     for (const addr of addresses) {
       if (ipInRanges(addr, bypassRanges)) {
         consoleLogger.info(`[cfProxyWorker] Bypass IP matched ${addr} for ${hostname}`);
-        return { ip: addr, bypass: true, blocked: false };
+        return wrapResolved(addr, true);
       }
     }
     if (addresses.length > 0) {
-      return { ip: addresses[0], bypass: false, blocked: false };
+      return wrapResolved(addresses[0], false);
     }
   } catch (e) {
     // IPv4 failed, try IPv6
@@ -370,11 +398,11 @@ async function resolveHostname(
       for (const addr of addresses) {
         if (ipInRanges(addr, bypassRanges)) {
           consoleLogger.info(`[cfProxyWorker] Bypass IPv6 matched ${addr} for ${hostname}`);
-          return { ip: addr, bypass: true, blocked: false };
+          return wrapResolved(addr, true);
         }
       }
       if (addresses.length > 0) {
-        return { ip: addresses[0], bypass: false, blocked: false };
+        return wrapResolved(addresses[0], false);
       }
     } catch (err) {
       consoleLogger.warn(`[cfProxyWorker] DNS resolution failed for ${hostname}: ${(err as Error).message}`);

--- a/src/constants/common.ts
+++ b/src/constants/common.ts
@@ -1048,6 +1048,85 @@ export const isDisallowedInRobotsTxt = (url: string): boolean => {
   return false;
 };
 
+// Reject hostnames pointing at private, loopback, or link-local address
+// space. Used to guard the recursive sitemap fetch against a hostile
+// server listing ``http://169.254.169.254/latest/meta-data/...`` (cloud
+// metadata) or ``http://127.0.0.1/...`` (loopback) as a child sitemap.
+// Both IP literals and DNS names are handled: for names we resolve via
+// the OS resolver and check every returned address. Failure to resolve
+// is not fatal — the subsequent page.goto() will handle DNS errors —
+// but if any resolved address falls in a blocked range we refuse.
+const INTERNAL_ADDR_RANGES: string[] = [
+  '127.0.0.0/8',
+  '10.0.0.0/8',
+  '172.16.0.0/12',
+  '192.168.0.0/16',
+  '169.254.0.0/16',
+  '100.64.0.0/10',
+  '0.0.0.0/8',
+];
+const isIpv4Literal = (s: string): boolean =>
+  /^(\d{1,3}\.){3}\d{1,3}$/.test(s) && s.split('.').every(o => Number(o) >= 0 && Number(o) <= 255);
+const ipv4ToInt = (ip: string): number =>
+  ip.split('.').reduce((acc, o) => (acc << 8) + Number(o), 0) >>> 0;
+const ipv4InRange = (ip: string, cidr: string): boolean => {
+  const [range, bitsStr] = cidr.split('/');
+  const bits = Number(bitsStr);
+  const mask = bits === 0 ? 0 : (~0 << (32 - bits)) >>> 0;
+  return (ipv4ToInt(ip) & mask) === (ipv4ToInt(range) & mask);
+};
+const isInternalIpv4 = (ip: string): boolean =>
+  INTERNAL_ADDR_RANGES.some(r => ipv4InRange(ip, r));
+async function isInternalOrLoopbackUrl(candidate: string): Promise<boolean> {
+  let host: string;
+  try {
+    host = new URL(candidate).hostname;
+  } catch {
+    return false;
+  }
+  if (!host) return false;
+  const lower = host.toLowerCase();
+  // Loopback / IPv6 loopback / RFC 6761 special names — cover before DNS.
+  if (lower === 'localhost' || lower.endsWith('.localhost') || lower === '[::1]' || lower === '::1') {
+    return true;
+  }
+  // Strip IPv6 brackets so ``[::1]`` / ``[fe80::…]`` are recognised.
+  const bare = lower.replace(/^\[|\]$/g, '');
+  if (isIpv4Literal(bare)) {
+    return isInternalIpv4(bare);
+  }
+  if (bare.includes(':')) {
+    // IPv6 literal — treat any ULA (fc00::/7) / link-local (fe80::/10) /
+    // loopback (::1) as internal. We match on prefix rather than parse.
+    if (bare === '::1' || bare.startsWith('fe8') || bare.startsWith('fe9') ||
+        bare.startsWith('fea') || bare.startsWith('feb') ||
+        bare.startsWith('fc') || bare.startsWith('fd')) {
+      return true;
+    }
+  }
+  try {
+    const { lookup } = await import('dns/promises');
+    const records = await lookup(bare, { all: true });
+    for (const r of records) {
+      if (r.family === 4 && isInternalIpv4(r.address)) return true;
+      if (r.family === 6) {
+        const a = r.address.toLowerCase();
+        if (a === '::1' || a.startsWith('fe8') || a.startsWith('fe9') ||
+            a.startsWith('fea') || a.startsWith('feb') ||
+            a.startsWith('fc') || a.startsWith('fd') ||
+            a.startsWith('::ffff:127.') || a.startsWith('::ffff:10.') ||
+            a.startsWith('::ffff:169.254.') || a.startsWith('::ffff:192.168.')) {
+          return true;
+        }
+      }
+    }
+  } catch {
+    // DNS failure — let page.goto() surface the network error naturally.
+    return false;
+  }
+  return false;
+}
+
 export const getLinksFromSitemap = async (
   sitemapUrl: string,
   _maxLinksCount: number,
@@ -1340,6 +1419,28 @@ export const getLinksFromSitemap = async (
           if (childSitemapPath.endsWith('.xml') || childSitemapPath.endsWith('.txt')) {
             if (isImageSitemapUrl(childSitemapUrlText)) {
               consoleLogger.info(`Skipping image sitemap: ${childSitemapUrlText}`);
+              continue;
+            }
+            // A sitemap index is scanned-content — a hostile server can list
+            // arbitrary child URLs. addToUrlList() below already enforces
+            // the operator's crawl strategy (same-domain/host/etc.) via
+            // isFollowStrategy, but the recursive descent used to fetch
+            // ``.xml``/``.txt`` children with a real browser (page.goto())
+            // with no scope check, letting the child sitemap URL point at
+            // internal HTTP endpoints (169.254.169.254, 127.0.0.1) or an
+            // off-scope host. Apply the same strategy gate here, and refuse
+            // hosts that resolve into private/link-local/loopback ranges
+            // before invoking page.goto().
+            if (userUrl && !isFollowStrategy(childSitemapUrlText, userUrl, strategy)) {
+              consoleLogger.info(
+                `Skipping off-strategy child sitemap: ${childSitemapUrlText}`,
+              );
+              continue;
+            }
+            if (await isInternalOrLoopbackUrl(childSitemapUrlText)) {
+              consoleLogger.warn(
+                `Refusing to fetch child sitemap targeting internal address: ${childSitemapUrlText}`,
+              );
               continue;
             }
             await fetchUrls(childSitemapUrlText, extraHTTPHeaders); // Recursive call for nested sitemaps
@@ -2133,6 +2234,13 @@ export const submitForm = async (
   // body is guarded because building the payload can throw independently of the
   // network call (e.g. encodeURIComponent raises URIError on lone surrogates,
   // which can appear in scanned page content).
+  // Opt-out: OOBEE_DISABLE_TELEMETRY=1 skips this submission entirely so
+  // PII (email, name, entry URL) is never sent off-device.
+  const telemetryOptOut = /^(1|true|yes)$/i.test(process.env.OOBEE_DISABLE_TELEMETRY ?? '');
+  if (telemetryOptOut) {
+    consoleLogger.info('Skipping telemetry submission: OOBEE_DISABLE_TELEMETRY is set');
+    return;
+  }
   try {
     const additionalPageDataJson = JSON.stringify({
       redirectsScanned: numberOfRedirectsScanned,

--- a/src/crawlers/commonCrawlerFunc.ts
+++ b/src/crawlers/commonCrawlerFunc.ts
@@ -1523,11 +1523,58 @@ export const createCrawleeSubFolders = async (
   return { dataset, requestQueue };
 };
 
-export const preNavigationHooks = (extraHTTPHeaders: Record<string, string>) => {
+export const preNavigationHooks = (
+  extraHTTPHeaders: Record<string, string>,
+  entryUrl?: string,
+) => {
+  // Resolve the entry origin once. splitAuthHeaders binds Basic credentials
+  // to this origin via Playwright's httpCredentials.origin so the browser
+  // refuses to auto-attach them after a cross-origin redirect. The
+  // Authorization header carries no such binding — if we attach it to
+  // ``request.headers`` unconditionally the crawler will send it to every
+  // navigation, including cross-origin redirects and off-scope subdomains,
+  // leaking the operator's bearer/basic token to attacker-controlled hosts.
+  // Compute the entry origin here so the per-request hook can drop the
+  // Authorization header whenever it would cross that boundary.
+  const entryOrigin = (() => {
+    if (!entryUrl) return undefined;
+    try {
+      return new URL(entryUrl).origin;
+    } catch {
+      return undefined;
+    }
+  })();
+
   return [
     async (crawlingContext: CrawlingContext, gotoOptions: PlaywrightGotoOptions) => {
       if (extraHTTPHeaders && Object.keys(extraHTTPHeaders).length > 0) {
-        crawlingContext.request.headers = extraHTTPHeaders;
+        let headersForRequest = extraHTTPHeaders;
+        // Same-origin Authorization only. If the entry origin was unknown
+        // (older callers), fall through to defense-in-depth: drop
+        // Authorization entirely rather than leak it — the credential must
+        // instead flow via httpCredentials + addAuthRouteHandler which
+        // enforce their own same-origin bounds.
+        const hasAuthHeader = Object.keys(extraHTTPHeaders).some(
+          k => k.toLowerCase() === 'authorization',
+        );
+        if (hasAuthHeader) {
+          let sameOrigin = false;
+          if (entryOrigin) {
+            try {
+              sameOrigin = new URL(crawlingContext.request.url).origin === entryOrigin;
+            } catch {
+              sameOrigin = false;
+            }
+          }
+          if (!sameOrigin) {
+            const filtered: Record<string, string> = {};
+            for (const [k, v] of Object.entries(extraHTTPHeaders)) {
+              if (k.toLowerCase() !== 'authorization') filtered[k] = v;
+            }
+            headersForRequest = filtered;
+          }
+        }
+        crawlingContext.request.headers = headersForRequest;
       }
       // Use domcontentloaded — fires as soon as the DOM is parsed, before
       // images/stylesheets/network requests settle. This avoids indefinite

--- a/src/crawlers/crawlDomain.ts
+++ b/src/crawlers/crawlDomain.ts
@@ -161,6 +161,17 @@ const crawlDomain = async ({
     }
   };
 
+  const isExcludedFromEnqueue = (candidateUrl: string): boolean => {
+    if (scannedUrlSet.has(normUrl(candidateUrl))) return true;
+    if (isBlacklisted(candidateUrl, blacklistedPatterns)) return true;
+    if (!isFollowStrategy(candidateUrl, url, strategy)) return true;
+    if (disallowedListOfPatterns.some(pattern => candidateUrl.toLowerCase().startsWith(pattern))) {
+      return true;
+    }
+    if (isDisallowedInRobotsTxt(candidateUrl)) return true;
+    return false;
+  };
+
   await enqueueUniqueRequest({
     url,
     skipNavigation: isUrlPdf(url),
@@ -438,7 +449,7 @@ const crawlDomain = async ({
       requestQueue,
       maxRequestRetries: 3,
       preNavigationHooks: [
-        ...preNavigationHooks(extraHTTPHeaders),
+        ...preNavigationHooks(extraHTTPHeaders, url),
         // Attach URL-scheme guards to each new BrowserContext the first time
         // Crawlee routes a request through it. Complements the up-front URL
         // filter below by catching in-page navigations (window.open,
@@ -893,11 +904,13 @@ const crawlDomain = async ({
                   const interceptedRequestUrl = interceptedRequest
                     .url()
                     .replace(/(?<=&|\?)utm_.*?(&|$)/gim, '');
-                  await enqueueUniqueRequest({
-                    url: interceptedRequestUrl,
-                    skipNavigation: isUrlPdf(interceptedRequest.url()),
-                    label: interceptedRequestUrl,
-                  });
+                  if (!isExcludedFromEnqueue(interceptedRequestUrl)) {
+                    await enqueueUniqueRequest({
+                      url: interceptedRequestUrl,
+                      skipNavigation: isUrlPdf(interceptedRequest.url()),
+                      label: interceptedRequestUrl,
+                    });
+                  }
                 }
               });
             }

--- a/src/crawlers/crawlSitemap.ts
+++ b/src/crawlers/crawlSitemap.ts
@@ -259,7 +259,7 @@ const crawlSitemap = async ({
         },
       ],
       preNavigationHooks: [
-        ...preNavigationHooks(extraHTTPHeaders),
+        ...preNavigationHooks(extraHTTPHeaders, userUrl || sitemapUrl),
         async ({ request, page }, gotoOptions) => {
           const url = request.url.toLowerCase();
 

--- a/src/crawlers/custom/flagUnlabelledClickableElements.ts
+++ b/src/crawlers/custom/flagUnlabelledClickableElements.ts
@@ -1082,8 +1082,9 @@ function hasPointerCursor(node: Node): boolean {
 
   function flagElements() {
     const currentFlaggedElementsByDocument: Record<string, HTMLElement[]> = {}; // Temporary object to hold current flagged elements
+    const MAX_TRAVERSAL_ELEMENTS = 50000;
 
-    /* 
+    /*
         Collects all the elements and places then into an array
         Then places the array in the correct frame
     */
@@ -1092,7 +1093,7 @@ function hasPointerCursor(node: Node): boolean {
     const allElements = Array.from(document.querySelectorAll<HTMLElement>('*'));
     let indexofAllElements: number = 0;
 
-    while (indexofAllElements < allElements.length) {
+    while (indexofAllElements < allElements.length && indexofAllElements < MAX_TRAVERSAL_ELEMENTS) {
       const element = allElements[indexofAllElements] as HTMLElement;
       // if it selects a frameset
       if (
@@ -1104,12 +1105,15 @@ function hasPointerCursor(node: Node): boolean {
       }
 
       // If the element has a shadowRoot, add its children
-      if (element.shadowRoot) {
+      if (element.shadowRoot && allElements.length < MAX_TRAVERSAL_ELEMENTS) {
         allElements.push(
           ...(Array.from(element.shadowRoot.querySelectorAll('*')) as HTMLElement[]),
         );
       }
       indexofAllElements++;
+    }
+    if (indexofAllElements >= MAX_TRAVERSAL_ELEMENTS) {
+      customConsoleWarn(`Reached MAX_TRAVERSAL_ELEMENTS (${MAX_TRAVERSAL_ELEMENTS}) on main document; halting further traversal.`);
     }
     currentFlaggedElementsByDocument[''] = currentFlaggedElements; // Key "" represents the main document
 
@@ -1123,7 +1127,7 @@ function hasPointerCursor(node: Node): boolean {
           const iframeFlaggedElements: HTMLElement[] = [];
           const iframeElements = Array.from(iframeDocument.querySelectorAll<HTMLElement>('*'));
           let indexOfIframeElements: number = 0;
-          while (indexOfIframeElements < iframeElements.length) {
+          while (indexOfIframeElements < iframeElements.length && indexOfIframeElements < MAX_TRAVERSAL_ELEMENTS) {
             const element = iframeElements[indexOfIframeElements] as HTMLElement;
             if (
               shouldFlagElement(element, allowNonClickableFlagging) ||
@@ -1133,12 +1137,15 @@ function hasPointerCursor(node: Node): boolean {
               iframeFlaggedElements.push(element);
             }
             // If the element has a shadowRoot, add its children
-            if (element.shadowRoot) {
+            if (element.shadowRoot && iframeElements.length < MAX_TRAVERSAL_ELEMENTS) {
               iframeElements.push(
                 ...(Array.from(element.shadowRoot.querySelectorAll('*')) as HTMLElement[]),
               );
             }
             indexOfIframeElements++;
+          }
+          if (indexOfIframeElements >= MAX_TRAVERSAL_ELEMENTS) {
+            customConsoleWarn(`Reached MAX_TRAVERSAL_ELEMENTS (${MAX_TRAVERSAL_ELEMENTS}) on iframe ${index}; halting further traversal.`);
           }
           const iframeXPath = getXPath(iframe);
           currentFlaggedElementsByDocument[iframeXPath] = iframeFlaggedElements;
@@ -1158,7 +1165,7 @@ function hasPointerCursor(node: Node): boolean {
           const iframeFlaggedElements: HTMLElement[] = [];
           const iframeElements = Array.from(iframeDocument.querySelectorAll<HTMLElement>('*'));
           let indexOfIframeElements: number = 0;
-          while (indexOfIframeElements < iframeElements.length) {
+          while (indexOfIframeElements < iframeElements.length && indexOfIframeElements < MAX_TRAVERSAL_ELEMENTS) {
             const element = iframeElements[indexOfIframeElements] as HTMLElement;
             if (
               shouldFlagElement(element, allowNonClickableFlagging) ||
@@ -1168,12 +1175,15 @@ function hasPointerCursor(node: Node): boolean {
               iframeFlaggedElements.push(element);
             }
             // If the element has a shadowRoot, add its children
-            if (element.shadowRoot) {
+            if (element.shadowRoot && iframeElements.length < MAX_TRAVERSAL_ELEMENTS) {
               iframeElements.push(
                 ...(Array.from(element.shadowRoot.querySelectorAll('*')) as HTMLElement[]),
               );
             }
             indexOfIframeElements++;
+          }
+          if (indexOfIframeElements >= MAX_TRAVERSAL_ELEMENTS) {
+            customConsoleWarn(`Reached MAX_TRAVERSAL_ELEMENTS (${MAX_TRAVERSAL_ELEMENTS}) on frame ${index}; halting further traversal.`);
           }
           const iframeXPath = getXPath(frame);
           currentFlaggedElementsByDocument[iframeXPath] = iframeFlaggedElements;

--- a/src/crawlers/runCustom.ts
+++ b/src/crawlers/runCustom.ts
@@ -8,7 +8,7 @@ import constants, {
   UrlsCrawled,
 } from '../constants/constants.js';
 import { DEBUG, initNewPage, log } from './custom/utils.js';
-import { guiInfoLog } from '../logs.js';
+import { consoleLogger, guiInfoLog } from '../logs.js';
 import { ViewportSettingsClass } from '../combine.js';
 import { addUrlGuardScript } from './guards/urlGuard.js';
 import {
@@ -146,11 +146,25 @@ const runCustom = async (
 
     const { authHeader, nonAuthHeaders, httpCredentials } = splitAuthHeaders(extraHTTPHeaders, url);
 
+    // Never send caller-supplied credentials to a server whose certificate
+    // couldn't be validated. Leaving ignoreHTTPSErrors:true when Basic /
+    // Authorization headers are attached lets an on-path attacker present
+    // any certificate, complete the TLS handshake, and capture the
+    // configured secret. Preserve the "scan sites with broken certs"
+    // ergonomics for credential-less scans, but hold TLS validation ON
+    // whenever the context carries credentials.
+    const hasCredentials = !!authHeader || !!httpCredentials;
+    if (hasCredentials) {
+      consoleLogger.info(
+        '[runCustom] Credentials detected — enforcing TLS certificate validation for this scan',
+      );
+    }
+
     const context = await launchPersistentSafeContext(userDataDirectory, {
       ...baseLaunchOptions,
       args: mergedArgs,
       headless: false,
-      ignoreHTTPSErrors: true,
+      ignoreHTTPSErrors: !hasCredentials,
       serviceWorkers: 'block' as const,
       viewport: null,
       ...(hasCustomViewport ? contextDeviceOptions : {}),

--- a/src/safeBrowsingProfile.ts
+++ b/src/safeBrowsingProfile.ts
@@ -167,7 +167,16 @@ async function spawnChromeForWarmup(): Promise<void> {
     '--profile-directory=Default',
     '--no-first-run',
     '--no-default-browser-check',
-    '--ignore-certificate-errors',
+    // Do NOT pass --ignore-certificate-errors here. The security-relevant
+    // traffic in this warmup is the Safe Browsing hash-prefix database
+    // download; disabling TLS validation for that connection lets an
+    // on-path attacker substitute a stale/empty/tampered DB that then
+    // propagates into every scanning profile (injectSafeBrowsingDb),
+    // silently defeating the "we protect the analyst against malicious
+    // URLs" property. The generate_204 probe below only needs standard
+    // TLS to succeed — Google's cert chains anchor to public roots. If a
+    // corporate proxy MITMs egress, add the proxy CA to the system
+    // trust store rather than globally disabling certificate checks.
     // Warmup only visits google.com/generate_204 to trigger a DB download into
     // a throwaway profile — no untrusted content. --no-sandbox is safe here and
     // is required inside BuildKit / restricted containers where Chrome's

--- a/src/screenshotFunc/pdfScreenshotFunc.ts
+++ b/src/screenshotFunc/pdfScreenshotFunc.ts
@@ -130,6 +130,22 @@ export async function getPdfScreenshots(
       // Render the page on a Node canvas with 200% scale.
       const viewport = page.getViewport({ scale: 2.0 });
 
+      // PDF page geometry (MediaBox) is attacker-controlled — during a
+      // crawl we download PDFs linked from arbitrary scanned sites. A
+      // crafted PDF declaring an enormous page size would force
+      // canvasFactory.create to allocate a W*H*4 byte buffer and OOM the
+      // scan worker. Clamp against the same MAX_CROP_DIMENSION used for
+      // the crop canvas below (200% of a typical A0 page is well under
+      // this bound; anything above is treated as malformed).
+      if (!isFinitePositive(viewport.width) || !isFinitePositive(viewport.height) ||
+          viewport.width > MAX_CROP_DIMENSION || viewport.height > MAX_CROP_DIMENSION) {
+        consoleLogger.warn(
+          `Skipping PDF page ${pageNum}: viewport dimensions out of bounds (${viewport.width}x${viewport.height})`,
+        );
+        page.cleanup();
+        continue;
+      }
+
       const canvasAndContext =
         pageCanvasCache[pageNum] ?? canvasFactory.create(viewport.width, viewport.height);
       if (!pageCanvasCache[pageNum]) {

--- a/src/static/ejs/partials/scripts/ruleModal/itemCardRenderer.ejs
+++ b/src/static/ejs/partials/scripts/ruleModal/itemCardRenderer.ejs
@@ -404,7 +404,12 @@
     if (!copyButtonElem || !xpath) return;
 
     const copyTooltipItem = new bootstrap.Tooltip(copyButtonElem);
-    const textToCopy = createElementFromString(`<textarea>${xpath}</textarea>`);
+    // xpath is scanned-page content — createElementFromString parses via
+    // innerHTML, so interpolating it as raw markup is a DOM XSS sink. Build
+    // the textarea with textContent so any '<script>' / '</textarea><img>'
+    // payload is treated as literal text.
+    const textToCopy = document.createElement('textarea');
+    textToCopy.textContent = xpath;
 
     copyButtonElem.onclick = event => {
       textToCopy.select();

--- a/src/static/ejs/partials/scripts/topTen.ejs
+++ b/src/static/ejs/partials/scripts/topTen.ejs
@@ -27,7 +27,11 @@
         listItem.className = 'd-flex justify-content-between';
 
         const link = document.createElement('a');
-        link.href = page.url;
+        // page.url is scanned-page content — a crafted javascript:/data: URL
+        // would otherwise fire in the reviewer's origin the moment they
+        // click the entry. Route through the shared allowlist helper
+        // (http/https/mailto only) exactly like pageAccordionBuilder does.
+        link.href = isSafeReportHref(page.url);
         link.target = '_blank';
         link.rel = 'noopener';
         link.className = 'page-links';


### PR DESCRIPTION
## Summary
Follow-up to #854 addressing the rescan findings from the 2026-09-08 GovTech GitHub review.

**Highs**
- Verify SHA-256 for Node / Corretto (via `latest_sha256` sidecar) / veraPDF in `install_oobee_dependencies.{command,ps1}` before use.
- Pin `softprops/action-gh-release` to a commit SHA in `image.yml`.
- Gate `publish.yml` behind an `npm-publish` GitHub Environment (maintainer approval), validate `release_tag` as semver, and checkout by tag ref.

**Mediums**
- Route `link.href` in `topTen.ejs` through the `isSafeReportHref` allowlist (http/https/mailto) to close the DOM-XSS gap.
- Use `textContent` in the XPath copy buffer (`itemCardRenderer.ejs`) instead of `innerHTML` interpolation.
- Drop `--ignore-certificate-errors` from Chromium `baseArgs` in `safeBrowsingProfile.ts` so TLS is validated when Safe Browsing is enabled.
- In `cfProxyWorker.ts`, route both DoH and OS DNS resolutions through `wrapResolved` so internal IPs are rejected in every path.
- In `runCustom.ts`, refuse TLS bypass when credentials/auth headers are attached (`ignoreHTTPSErrors = \!hasCredentials`).
- In `commonCrawlerFunc.ts`, strip `Authorization` on cross-origin navigations inside `preNavigationHooks`.
- Clamp PDF viewport dimensions against `MAX_CROP_DIMENSION` in `pdfScreenshotFunc.ts` to bound canvas allocation.
- Block child-sitemap fetches that resolve to internal/loopback addresses via `isInternalOrLoopbackUrl` in `constants/common.ts` (SSRF guard).

**Lows / Infos**
- `crawlDomain.ts`: apply `isExcludedFromEnqueue` gate in the recovery `route('**/*')` handler so the exclusion policy (blacklist/robots/strategy) also applies to recovery-enqueued URLs.
- `flagUnlabelledClickableElements.ts`: cap DOM traversal at `MAX_TRAVERSAL_ELEMENTS` across main document, iframes, and frames to bound shadow-root expansion.
- `constants/common.ts::submitForm`: honour `OOBEE_DISABLE_TELEMETRY=1` so operators can opt out of the legacy Google Forms PII submission.

## Test plan
- [ ] `npx tsc --noEmit` clean
- [ ] Manual smoke: `--dir domain` scan of an http URL still crawls and generates a report
- [ ] Manual smoke: `--dir sitemap` scan skips a child sitemap pointing to `http://127.0.0.1/`
- [ ] Manual smoke: custom flow with basic auth still runs; TLS-mismatch site is refused
- [ ] Manual smoke: report opens, top-ten links click through, XPath copy works
- [ ] `OOBEE_DISABLE_TELEMETRY=1` scan: `submitForm` is skipped (log line present)

🤖 Generated with [Claude Code](https://claude.com/claude-code)