### PR TITLE
security: address asgard 2026-09-09 rescan findings

### DIFF
--- a/src/cfProxyWorker.ts
+++ b/src/cfProxyWorker.ts
@@ -129,17 +129,37 @@ function cidrMatch(ip: string, cidr: string): boolean {
 }
 
 function ipToBytes(ip: string): number[] | null {
-  if (ip.includes('.')) {
+  // Pure IPv4 dotted-quad (no colons anywhere).
+  if (ip.includes('.') && !ip.includes(':')) {
     const parts = ip.split('.').map(Number);
     if (parts.length !== 4 || parts.some((n) => !Number.isInteger(n) || n < 0 || n > 255)) return null;
     return parts;
   }
   if (ip.includes(':')) {
-    // Minimal IPv6 parse (supports :: compression).
-    const [head, tail] = ip.split('::');
+    // IPv4-mapped / IPv4-compatible form: the last hextet may be written as
+    // a dotted-quad, e.g. `::ffff:127.0.0.1` or `::ffff:192.168.0.0`. Peel
+    // that trailing quad off before the hextet parse so the four octets
+    // become the last four bytes (matching the wire format). Without this
+    // the whole INTERNAL_IP_RANGES table (and any user-provided IPv4-mapped
+    // literal in that form) fails to parse and the SSRF guard silently
+    // permits internal targets — the exact bug asgard flagged.
+    let trailingV4Bytes: number[] | null = null;
+    let ipNoV4 = ip;
+    const lastColon = ip.lastIndexOf(':');
+    const afterLastColon = ip.slice(lastColon + 1);
+    if (afterLastColon.includes('.')) {
+      const parts = afterLastColon.split('.').map(Number);
+      if (parts.length !== 4 || parts.some((n) => !Number.isInteger(n) || n < 0 || n > 255)) return null;
+      trailingV4Bytes = parts;
+      ipNoV4 = ip.slice(0, lastColon);
+    }
+    // Minimal IPv6 parse (supports :: compression). Two synthetic hextets
+    // stand in for the dotted-quad tail so `missing` accounts for it.
+    const trailingGroups = trailingV4Bytes ? 2 : 0;
+    const [head, tail] = ipNoV4.split('::');
     const headParts = head ? head.split(':') : [];
     const tailParts = tail ? tail.split(':') : [];
-    const missing = 8 - headParts.length - tailParts.length;
+    const missing = 8 - headParts.length - tailParts.length - trailingGroups;
     if (missing < 0) return null;
     const groups = [...headParts, ...Array(missing).fill('0'), ...tailParts];
     const bytes = [];
@@ -148,6 +168,8 @@ function ipToBytes(ip: string): number[] | null {
       if (Number.isNaN(n) || n < 0 || n > 0xffff) return null;
       bytes.push(n >> 8, n & 0xff);
     }
+    if (trailingV4Bytes) bytes.push(...trailingV4Bytes);
+    if (bytes.length !== 16) return null;
     return bytes;
   }
   return null;

--- a/src/constants/common.ts
+++ b/src/constants/common.ts
@@ -392,11 +392,17 @@ export const checkUrlConnectivityWithBrowser = async (
     }
   }
 
+  // Never forward Basic credentials over a session that ignores TLS validation:
+  // a MITM presenting any cert would receive the decoded username/password.
+  // When creds are attached we verify TLS; scans without creds keep the
+  // legacy permissive default so self-signed / staging hosts still work.
+  const ignoreHTTPSErrors = !httpCredentials;
+
   const contextOptions: Record<string, unknown> = {
     ...restDevice,
     ...(Object.keys(nonAuthHeaders).length > 0 && { extraHTTPHeaders: nonAuthHeaders }),
     ...(httpCredentials && { httpCredentials }),
-    ignoreHTTPSErrors: true,
+    ignoreHTTPSErrors,
     ...(process.env.OOBEE_DISABLE_BROWSER_DOWNLOAD && { acceptDownloads: false }),
   };
 
@@ -1307,6 +1313,40 @@ export const getLinksFromSitemap = async (
         // to fetch and apply the stylesheet, which may load additional resources
         // (fonts, CSS, images) that prevent 'networkidle' from ever being reached.
         const response = await page.goto(url, { waitUntil: 'domcontentloaded', timeout: 60000 });
+
+        // DNS rebinding defence: the isInternalOrLoopbackUrl() pre-check runs
+        // its own resolver, but a hostile authoritative DNS can return a public
+        // IP to us and a private IP to the browser milliseconds later. Verify
+        // the remote address the browser actually connected to falls outside
+        // link-local / loopback / RFC1918 ranges before trusting the body.
+        if (response) {
+          try {
+            const serverAddr = await response.serverAddr();
+            const remoteIp = serverAddr?.ipAddress;
+            if (remoteIp) {
+              const bare = remoteIp.replace(/^\[|\]$/g, '').toLowerCase();
+              const isInternal =
+                (isIpv4Literal(bare) && isInternalIpv4(bare)) ||
+                bare === '::1' ||
+                bare.startsWith('fe8') || bare.startsWith('fe9') ||
+                bare.startsWith('fea') || bare.startsWith('feb') ||
+                bare.startsWith('fc') || bare.startsWith('fd') ||
+                bare.startsWith('::ffff:127.') || bare.startsWith('::ffff:10.') ||
+                bare.startsWith('::ffff:169.254.') || bare.startsWith('::ffff:192.168.');
+              if (isInternal) {
+                consoleLogger.warn(
+                  `Refusing sitemap body from internal address ${remoteIp} (host ${url})`,
+                );
+                data = '';
+                return;
+              }
+            }
+          } catch {
+            // serverAddr() is best-effort — Chromium may not report it for
+            // service-worker/cached responses. Fall through so the operator
+            // still sees ordinary sitemap discovery for those cases.
+          }
+        }
 
         // Prefer the raw response body — this gives us the original XML before
         // the browser applies any XSL transformation (which would turn the XML

--- a/src/crawlers/custom/extractAndGradeText.ts
+++ b/src/crawlers/custom/extractAndGradeText.ts
@@ -1,39 +1,57 @@
 import { Page } from 'playwright';
 import textReadability from 'text-readability';
 
+// Caps on how much page text we pull back into Node. Reading-ease grading
+// does not need the full document — 200k characters is >> any realistic
+// article-length page, and the per-<p> cap prevents a single attacker-
+// controlled paragraph from dominating memory. Both budgets are enforced
+// inside page.evaluate so we never materialise the oversized text in Node.
+const MAX_PARAGRAPHS = 2000;
+const MAX_TEXT_CHARS = 200_000;
+
 export async function extractAndGradeText(page: Page): Promise<string> {
   try {
     // Extract text content from all specified elements (e.g., paragraphs)
-    const sentences: string[] = await page.evaluate(() => {
-      const elements = document.querySelectorAll('p'); // Adjust selector as needed
-      const extractedSentences: string[] = [];
+    const sentences: string[] = await page.evaluate(
+      ({ maxParagraphs, maxChars }) => {
+        const elements = document.querySelectorAll('p'); // Adjust selector as needed
+        const extractedSentences: string[] = [];
+        let totalChars = 0;
+        const limit = Math.min(elements.length, maxParagraphs);
 
-      elements.forEach(element => {
-        const text = element.innerText.trim();
-        // Split the text into individual sentences
-        const sentencePattern = /[^.!?]*[.!?]+/g; // Match sentences ending with ., !, or ?
-        const matches = text.match(sentencePattern);
-        if (matches) {
-          // Add only sentences that end with punctuation
-          matches.forEach(sentence => {
-            const trimmedSentence = sentence.trim(); // Trim whitespace from each sentence
-            if (trimmedSentence.length > 0) {
-              extractedSentences.push(trimmedSentence);
+        for (let i = 0; i < limit; i += 1) {
+          const element = elements[i] as HTMLElement;
+          const text = element.innerText.trim();
+          const sentencePattern = /[^.!?]*[.!?]+/g; // Match sentences ending with ., !, or ?
+          const matches = text.match(sentencePattern);
+          if (!matches) continue;
+          let stop = false;
+          for (const sentence of matches) {
+            const trimmedSentence = sentence.trim();
+            if (trimmedSentence.length === 0) continue;
+            if (totalChars + trimmedSentence.length > maxChars) {
+              stop = true;
+              break;
             }
-          });
+            extractedSentences.push(trimmedSentence);
+            totalChars += trimmedSentence.length + 1; // +1 for the join separator
+          }
+          if (stop) break;
         }
-      });
 
-      return extractedSentences;
-    });
+        return extractedSentences;
+      },
+      { maxParagraphs: MAX_PARAGRAPHS, maxChars: MAX_TEXT_CHARS },
+    );
 
     // Check if any valid sentences were extracted
     if (sentences.length === 0) {
       return ''; // Return an empty string if no valid sentences are found
     }
 
-    // Join the valid sentences into a single string
-    const filteredText = sentences.join(' ').trim();
+    // Join the valid sentences into a single string. slice() is a defence-in-
+    // depth guard in case a future page.evaluate change removes the in-page cap.
+    const filteredText = sentences.join(' ').trim().slice(0, MAX_TEXT_CHARS);
 
     // Count the total number of words in the filtered text
     const wordCount = filteredText.split(/\s+/).length;

--- a/src/crawlers/runCustom.ts
+++ b/src/crawlers/runCustom.ts
@@ -152,8 +152,15 @@ const runCustom = async (
     // any certificate, complete the TLS handshake, and capture the
     // configured secret. Preserve the "scan sites with broken certs"
     // ergonomics for credential-less scans, but hold TLS validation ON
-    // whenever the context carries credentials.
+    // whenever the context carries credentials AND require the operator
+    // to explicitly opt into insecure TLS via OOBEE_ALLOW_INSECURE_TLS
+    // — silent disable of TLS validation is what the scanner flagged.
     const hasCredentials = !!authHeader || !!httpCredentials;
+    const allowInsecureTls =
+      !hasCredentials &&
+      ['1', 'true', 'yes'].includes(
+        String(process.env.OOBEE_ALLOW_INSECURE_TLS || '').toLowerCase(),
+      );
     if (hasCredentials) {
       consoleLogger.info(
         '[runCustom] Credentials detected — enforcing TLS certificate validation for this scan',
@@ -164,7 +171,7 @@ const runCustom = async (
       ...baseLaunchOptions,
       args: mergedArgs,
       headless: false,
-      ignoreHTTPSErrors: !hasCredentials,
+      ignoreHTTPSErrors: allowInsecureTls,
       serviceWorkers: 'block' as const,
       viewport: null,
       ...(hasCustomViewport ? contextDeviceOptions : {}),

--- a/src/screenshotFunc/pdfScreenshotFunc.ts
+++ b/src/screenshotFunc/pdfScreenshotFunc.ts
@@ -93,6 +93,15 @@ NodeCanvasFactory.prototype = {
 
 const canvasFactory = new NodeCanvasFactory();
 
+// Cumulative memory budget for cached page canvases across the whole PDF.
+// The per-page dimension clamp (MAX_CROP_DIMENSION) bounds a single canvas
+// to ~256MB (8192*8192*4B), but a crafted PDF can declare many pages each
+// near that bound and each carrying a violation, so the number of retained
+// canvases must also be bounded. 512MB gives ample room for typical A4/A3
+// documents (each page ~4-24MB at scale 2.0) while stopping a many-page
+// PDF from OOM-killing the scan worker.
+const PAGE_CANVAS_BUDGET_BYTES = 512 * 1024 * 1024;
+
 export async function getPdfScreenshots(
   pdfFilePath: string,
   items: TransformedRuleObject['items'],
@@ -110,7 +119,9 @@ export async function getPdfScreenshots(
   const structureTree = await pdf._pdfInfo.structureTree;
 
   // save some resources by caching page canvases to be reused by diff violations
-  const pageCanvasCache = {};
+  const pageCanvasCache: Record<string, { canvas: Canvas; context: SKRSContext2D }> = {};
+  let pageCanvasCacheBytes = 0;
+  let budgetExceededLogged = false;
 
   // iterate through each violation
   for (let i = 0; i < newItems.length; i++) {
@@ -146,10 +157,30 @@ export async function getPdfScreenshots(
         continue;
       }
 
+      const pageBytes = viewport.width * viewport.height * 4;
+      const alreadyCached = !!pageCanvasCache[pageNum];
+
+      // Cumulative-bytes guard: a single page passes MAX_CROP_DIMENSION but
+      // 50+ near-max pages together would still OOM. Refuse to render (and
+      // to cache) once the running total for this PDF exceeds the budget.
+      // Already-cached pages are free to reuse (they're already counted).
+      if (!alreadyCached && pageCanvasCacheBytes + pageBytes > PAGE_CANVAS_BUDGET_BYTES) {
+        if (!budgetExceededLogged) {
+          consoleLogger.warn(
+            `PDF page-canvas budget (${PAGE_CANVAS_BUDGET_BYTES} bytes) reached; skipping ` +
+            `screenshots for remaining pages of this PDF to avoid memory exhaustion.`,
+          );
+          budgetExceededLogged = true;
+        }
+        page.cleanup();
+        continue;
+      }
+
       const canvasAndContext =
         pageCanvasCache[pageNum] ?? canvasFactory.create(viewport.width, viewport.height);
-      if (!pageCanvasCache[pageNum]) {
+      if (!alreadyCached) {
         pageCanvasCache[pageNum] = canvasAndContext;
+        pageCanvasCacheBytes += pageBytes;
       }
       const { canvas: origCanvas, context: origCtx } = canvasAndContext;
 
@@ -175,6 +206,15 @@ export async function getPdfScreenshots(
       page.cleanup();
     }
   }
+
+  // Release all cached page canvases before returning. Without this the
+  // ~256MB-per-page buffers would sit in memory until GC eventually caught
+  // up, on top of the next PDF's cache — amplifying pressure on the worker.
+  for (const key of Object.keys(pageCanvasCache)) {
+    canvasFactory.destroy(pageCanvasCache[key]);
+    delete pageCanvasCache[key];
+  }
+
   return newItems;
 }
 

--- a/src/static/ejs/partials/scripts/header/aboutScanModal/ScanDetails.ejs
+++ b/src/static/ejs/partials/scripts/header/aboutScanModal/ScanDetails.ejs
@@ -39,7 +39,23 @@
   const urlA = document.getElementById('urlScanned');
   const urlSpan = document.getElementById('urlScannedText');
   urlSpan.textContent = scanData.urlScanned;
-  urlA.href = scanData.urlScanned;
+  // scanData.urlScanned is the user-supplied CLI target; refuse
+  // javascript:/data:/vbscript: schemes so an attacker who managed to
+  // seed a crafted URL into a shared report can't run script when the
+  // reviewer clicks the link.
+  const SAFE_HREF_SCHEMES = /^(https?:|mailto:|file:)/i;
+  const isSafeScannedHref = (url) => {
+    if (typeof url !== 'string') return false;
+    const trimmed = url.trim();
+    if (trimmed === '') return false;
+    if (/^[./]/.test(trimmed)) return true;
+    return SAFE_HREF_SCHEMES.test(trimmed);
+  };
+  if (isSafeScannedHref(scanData.urlScanned)) {
+    urlA.href = scanData.urlScanned;
+  } else {
+    urlA.removeAttribute('href');
+  }
 
   document.getElementById('aboutStartTime').innerHTML = formattedViewerLocalStartTime;
 

--- a/src/static/ejs/partials/scripts/prioritiseIssues/PrioritiseIssues.ejs
+++ b/src/static/ejs/partials/scripts/prioritiseIssues/PrioritiseIssues.ejs
@@ -1,5 +1,16 @@
 <script>
   (function populatePrioritiseIssues() {
+    // Escape untrusted strings before splicing them into an innerHTML template
+    // literal. axe-core rule descriptions can contain characters that would
+    // otherwise be parsed as HTML markup, and disability labels are indirected
+    // through user-supplied scanData.
+    const escHtml = (value) =>
+      String(value == null ? '' : value)
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#039;');
     const a11yRuleShortDescriptionMap = scanData?.a11yRuleShortDescriptionMap || {};
     const disabilityBadgesMap = scanData?.disabilityBadgesMap || {};
     const wcagLinks = scanData?.wcagLinks || {};
@@ -78,16 +89,16 @@
               disabilities.length > 0
                 ? `
               <div class="priority-issue-badges">
-                ${disabilities.map(disability => `<span class="disability-badge">${disability} Disability</span>`).join('')}
+                ${disabilities.map(disability => `<span class="disability-badge">${escHtml(disability)} Disability</span>`).join('')}
               </div>
             `
                 : '';
 
             return `
-              <li class="priority-issue-item" data-rule-id="${issue.ruleId}">
+              <li class="priority-issue-item" data-rule-id="${escHtml(issue.ruleId)}">
                 <button type="button" class="priority-issue-action d-flex g-one" aria-pressed="false">
                   <div class="d-flex justify-content-between align-items-center w-90">
-                      <div class="priority-issue-title">${issue.description}</div>
+                      <div class="priority-issue-title">${escHtml(issue.description)}</div>
                       ${disabilityBadges}
                   </div>
                 </button>
@@ -107,7 +118,7 @@
                 aria-expanded="false"
                 aria-controls="collapse${index}"
               >
-                <span class="h4 mb-0">WCAG ${wcagScore} -&nbsp;</span>
+                <span class="h4 mb-0">WCAG ${escHtml(wcagScore)} -&nbsp;</span>
                 <span class="h4 fw-normal mb-0">${criteria.issues.length} ${issueWord}</span>
                 <span class="wcag-score-badge">-1 WCAG Score</span>
                 <svg class="accordion-icon-collapsed" width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">

--- a/src/static/ejs/partials/scripts/utils.ejs
+++ b/src/static/ejs/partials/scripts/utils.ejs
@@ -419,7 +419,22 @@
   }
 
   function escapeHtmlStringForArg(string) {
-    return htmlEscapeString(string)
+    // The output of this function is inlined verbatim into a single-quoted
+    // JavaScript string literal that lives inside an HTML onClick attribute
+    // built by string concatenation and then set via innerHTML. We must
+    // therefore make the payload safe in BOTH contexts.
+    //
+    // htmlEscapeString already handles the HTML side (&, <, >, ", ') but
+    // NEVER touches literal backslashes. Left un-escaped, a payload like
+    // `\'` would combine with the `\'` this function injects (see below)
+    // to produce `\\'` in the emitted JS — which the JS parser reads as
+    // ONE escaped backslash followed by a string-terminating quote,
+    // letting the following attacker-controlled bytes execute as JS.
+    // Escape backslashes FIRST so any subsequent `\` we introduce (for
+    // quotes / newlines) is a fresh, unambiguous escape.
+    if (string == null) return '';
+    const backslashEscaped = String(string).replace(/\\/g, '\\\\');
+    return htmlEscapeString(backslashEscaped)
       .replaceAll('&#039;', "\\'")
       .replace(/\r?\n/g, '\\n')
       .replace(/&gt;\s+(.*?)\s+&lt;\//g, '&gt;$1&lt;/');


### PR DESCRIPTION
## Summary
- Fixes 9 security findings from the govtech asgard rescan of master @daf9379 (`~/oobee-v2-cybersecurity-report`, 2026-09-09).
- Priorities cleared: 2 high (asgard-0001, asgard-0002), 5 medium (asgard-0003, 0004, 0005, 0007, 0008), 2 low (asgard-0010, 0012).
- Design-decision findings remain open for discussion: asgard-0006/0009 (Google Forms telemetry sink), asgard-0011 (Sentry telemetry) — NOT changed here.

## Findings addressed

| ID | Sev | Where | What changed |
|---|---|---|---|
| asgard-0001 | high 7.5 | `pdfScreenshotFunc.ts` | Cumulative 512MB byte budget across cached page canvases per PDF + explicit `canvasFactory.destroy` cleanup at return. Bounds memory for many-page crafted PDFs. |
| asgard-0002 | high 7.1 | `utils.ejs` `escapeHtmlStringForArg` | Escape backslashes FIRST before delegating to `htmlEscapeString`, closing the `\\'` string-break that let scanned content inject JS into onClick. |
| asgard-0003 | medium 6.5 | `cfProxyWorker.ts` `ipToBytes` | Peel trailing dotted-quad off IPv4-mapped IPv6 (`::ffff:x.x.x.x`) so INTERNAL_IP_RANGES CIDRs and bracketed literals produce 16 bytes and the SSRF `cidrMatch` guard actually holds. |
| asgard-0004 | medium 5.9 | `checkUrlConnectivityWithBrowser` (`common.ts`) | Refuse `ignoreHTTPSErrors:true` when Basic creds are being forwarded — a MITM cert would otherwise capture the decoded username/password. Credential-less scans keep the legacy permissive default. |
| asgard-0005 | medium 5.9 | `PrioritiseIssues.ejs` | HTML-escape `issue.description`, `disability`, `issue.ruleId`, `wcagScore` before splicing into the innerHTML template. |
| asgard-0007 | medium 4.3 | `extractAndGradeText.ts` | Enforce 2000-paragraph and 200k-char caps inside `page.evaluate` so a hostile page can't return unbounded text. Redundant `.slice(0, MAX_TEXT_CHARS)` in Node for defence-in-depth. |
| asgard-0008 | medium 4.2 | `ScanDetails.ejs` | Validate `scanData.urlScanned` against a scheme allowlist (`https?`, `mailto`, `file`, relative) before assigning to `<a href>` — prevents `javascript:`/`data:` URLs in shared reports from executing on click. |
| asgard-0010 | low 3.3 | `getLinksFromSitemap` (`common.ts`) | Post-fetch check on `response.serverAddr()` — if the browser resolved the sitemap host to a private / loopback / IPv4-mapped private address, discard the body. Closes the TOCTOU gap between the resolver-side `isInternalOrLoopbackUrl` pre-check and the browser's own DNS. |
| asgard-0012 | low 3.1 | `runCustom.ts` | `ignoreHTTPSErrors` now requires `OOBEE_ALLOW_INSECURE_TLS` env opt-in even for credential-less scans; credential scans always validate TLS. |

## Deferred (design decisions — flagging for discussion)
- **asgard-0006 / asgard-0009 (medium/low)**: `submitForm` in `common.ts` sends scan metadata to Google Forms telemetry. Fix requires product-level decision on opt-out UX.
- **asgard-0011 (low)**: PII forwarded to Sentry in `sentryTelemetry.ts`. Same class of decision.

## Compatibility notes
- No URL handling changes affect Windows/mac/Linux absolute vs. relative paths on http/https.
- All new HTML/JS escapes go through `String()` coercion so UTF-8 payloads (i18n strings) pass through unchanged.
- New `OOBEE_ALLOW_INSECURE_TLS` env var is opt-in; scans against valid-TLS sites or credentialed scans see no behavioural difference.
- Playwright `response.serverAddr()` is best-effort — service-worker/cached responses without a remote address fall through to existing behaviour rather than being blocked.

## Test plan
- [ ] `npm run build` / `tsc` — verify no new TS errors
- [ ] Scan a public HTTPS site end-to-end — confirm sitemap discovery + reports render normally
- [ ] Scan against a self-signed TLS host WITHOUT credentials — expect scan to fail until `OOBEE_ALLOW_INSECURE_TLS=1` is set (runCustom flow)
- [ ] Scan against a self-signed TLS host WITH `--http-credentials` — expect scan to always fail regardless of env var (creds must not leak)
- [ ] Scan a PDF-heavy site with many large pages — confirm no OOM; budget warning logged once when hit
- [ ] Open a report where a scanned page contains `<img onerror>` / `javascript:` links — confirm no script executes when clicking through the report
- [ ] Sitemap discovery against a domain that resolves to 127.0.0.1 — expect refusal in both pre-check log and post-fetch guard

🤖 Generated with [Claude Code](https://claude.com/claude-code)